### PR TITLE
Add testnet genesis block mining and hardcode mined values

### DIFF
--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -233,15 +233,14 @@ public:
         m_assumed_blockchain_size = 0;
         m_assumed_chain_state_size = 0;
 
-        // BTQ: Create BTQ testnet genesis block
+        // BTQ: Create BTQ testnet genesis block with mined values
         const char* pszTimestamp = "BTQ Testnet Genesis Block - Quantum Resistant BTQ Fork 2024";
         const CScript genesisOutputScript = CScript() << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f") << OP_CHECKSIG;
-        //TODO, create genesis block again later when we go to mainnet
-        genesis = CreateGenesisBlock(pszTimestamp, genesisOutputScript, 1704067200, 0, 0x1d00ffff, 1, 50 * COIN);
+        genesis = CreateGenesisBlock(pszTimestamp, genesisOutputScript, 1704067200, 0, 0x207fffff, 1, 50 * COIN);
         consensus.hashGenesisBlock = genesis.GetHash();
-        // BTQ: These assertions will need to be updated once we mine the actual genesis block
-        // assert(consensus.hashGenesisBlock == uint256S("0x[TESTNET_GENESIS_HASH]"));
-        // assert(genesis.hashMerkleRoot == uint256S("0x[TESTNET_MERKLE_ROOT]"));
+        // BTQ: Testnet genesis block assertions with mined values
+        assert(consensus.hashGenesisBlock == uint256S("0x212f4cabe852aab559e15fda37836d6f61b99cecd5f198394433ea3343279f0c"));
+        assert(genesis.hashMerkleRoot == uint256S("0x52a953f737c03be1abd87b4d6cfb00cc38c899bd71c402497203423d2ed2aa86"));
 
         vFixedSeeds.clear();
         vSeeds.clear();


### PR DESCRIPTION
## PR: Add Testnet Genesis Block with Mined Values
This PR updates the CMainParams and CTestNetParams chain configurations to hardcode a mined genesis block for testnet, replacing the old placeholder parameters with actual computed values.