### PR TITLE
fix(docs): correct network port labels and testnet data dir

### DIFF
--- a/contrib/linearize/example-linearize.cfg
+++ b/contrib/linearize/example-linearize.cfg
@@ -29,7 +29,7 @@ input=/home/example/.btq/blocks
 # testnet
 #netmagic=0b110907
 #genesis=000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943
-#input=/home/example/.btq/testnet3/blocks
+#input=/home/example/.btq/test/blocks
 
 # regtest
 #netmagic=fabfb5da

--- a/doc-btq/README.md
+++ b/doc-btq/README.md
@@ -57,10 +57,16 @@ make -j$(nproc)
 
 ### Network Information
 
-- **Mainnet**: Port 8332 (RPC), 8334 (P2P)
-- **Testnet**: Port 18332 (RPC), 18334 (P2P)
-- **Signet**: Port 38332 (RPC), 38334 (P2P)
-- **Regtest**: Port 18443 (RPC), 18445 (P2P)
+| Network  | P2P   | RPC   | Onion  |
+|----------|-------|-------|--------|
+| Mainnet  | 9333  | 8332  | 8334   |
+| Testnet  | 19333 | 18332 | 18334  |
+| Signet   | 38333 | 38332 | 38334  |
+| Regtest  | 19444 | 18443 | 18445  |
+
+- **P2P**: Port for peer-to-peer node communication
+- **RPC**: Port for JSON-RPC API access (btq-cli, applications)
+- **Onion**: Target port for incoming Tor connections
 
 ## Contributing
 

--- a/share/examples/btq.conf
+++ b/share/examples/btq.conf
@@ -279,7 +279,7 @@
 #peerbloomfilters=1
 
 # Listen for connections on <port>. Nodes not using the default ports
-# (default: 8333, testnet: 18333, signet: 38333, regtest: 18444)
+# (default: 9333, testnet: 19333, signet: 38333, regtest: 19444)
 # are unlikely to get incoming connections. Not relevant for I2P
 # (see doc/i2p.md).
 #port=<port>


### PR DESCRIPTION
## Summary
- **README**: The network info section labeled onion service target ports (8334, 18334, 38334, 18445) as "P2P" ports. Replaced with a table showing all three port types — P2P, RPC, and Onion — with descriptions clarifying what each is for.
- **linearize config**: Fixed testnet data dir path from `~/.btq/testnet3/` to `~/.btq/test/` to match `chainparamsbase.cpp`.

### Port source of truth
| Network  | P2P (`nDefaultPort`) | RPC (`RPCPort`) | Onion (`OnionServiceTargetPort`) |
|----------|----------------------|-----------------|----------------------------------|
| Mainnet  | 9333                 | 8332            | 8334                             |
| Testnet  | 19333                | 18332           | 18334                            |
| Signet   | 38333                | 38332           | 38334                            |
| Regtest  | 19444                | 18443           | 18445                            |

Sources: `src/kernel/chainparams.cpp` (P2P), `src/chainparamsbase.cpp` (RPC + Onion)

## Test plan
- [ ] Verify port table renders correctly in GitHub markdown
- [ ] Confirm values match `kernel/chainparams.cpp` and `chainparamsbase.cpp`
