### PR TITLE
doc: fix boost dependencies for Ubuntu 22.04

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -48,7 +48,7 @@ Build requirements:
 
 Now, you can either build from self-compiled [depends](#dependencies) or install the required dependencies:
 
-    sudo apt-get install libevent-dev libboost-dev
+    sudo apt-get install libevent-dev libboost-dev libboost-system-dev libboost-filesystem-dev libboost-thread-dev
 
 SQLite is required for the descriptor wallet:
 


### PR DESCRIPTION
## Summary
- Add explicit libboost-system-dev, libboost-filesystem-dev, and libboost-thread-dev to build dependencies for Ubuntu 22.04