### PR TITLE
fix(rpc): correct getnewdilithiumaddress help text default from bech32 to legacy

### DIFF
--- a/src/wallet/rpc/dilithium.cpp
+++ b/src/wallet/rpc/dilithium.cpp
@@ -192,7 +192,7 @@ RPCHelpMan getnewdilithiumaddress()
         "You may need to call keypoolrefill first.\n",
         {
             {"label", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "The label name for the address to be linked to. It can also be set to the empty string \"\" to represent the default label. The label does not need to exist, it will be created if there is no label by the given name."},
-            {"address_type", RPCArg::Type::STR, RPCArg::Default{"bech32"}, "The address type to use. Options are \"legacy\", \"p2sh-segwit\", and \"bech32\"."},
+            {"address_type", RPCArg::Type::STR, RPCArg::Default{"legacy"}, "The address type to use. Options are \"legacy\", \"p2sh-segwit\", and \"bech32\"."},
         },
         RPCResult{
             RPCResult::Type::STR, "address", "The new dilithium address"


### PR DESCRIPTION
## Summary

- `RPCArg::Default{"bech32"}` in the `getnewdilithiumaddress` help declaration was wrong
- The implementation sets `OutputType output_type = OutputType::LEGACY` (line 220) and only updates it when `address_type` is explicitly passed; omitting the arg always produces a legacy address
- The existing comment explains the intent: *"Default to LEGACY for Dilithium to avoid witness v0 ambiguity (witness v0 scripts look identical for Dilithium and ECDSA)"*
- Fix: change `RPCArg::Default{"bech32"}` → `RPCArg::Default{"legacy"}` so `btq-cli help getnewdilithiumaddress` shows the correct default

## Impact

No behaviour change — only the help text is updated to reflect what the code already does.

## Test plan

- [ ] `btq-cli help getnewdilithiumaddress` shows `address_type` default as `"legacy"`
- [ ] `btq-cli getnewdilithiumaddress` (no args) produces a Base58 address starting with `D` (mainnet) or `d` (testnet)
- [ ] `btq-cli getnewdilithiumaddress "" "bech32"` still produces a `qbtc1q...` / `tbtq1q...` address

## Related

Companion docs fix: btq-ag/BTQ-Core-Docs#13
