### PR TITLE
gui: default btq-qt to testnet when chain is unspecified

### DIFF
--- a/src/common/args.cpp
+++ b/src/common/args.cpp
@@ -548,6 +548,12 @@ void ArgsManager::ForceSetArg(const std::string& strArg, const std::string& strV
     m_settings.forced_settings[SettingName(strArg)] = strValue;
 }
 
+void ArgsManager::SetFallbackChainType(ChainType chain)
+{
+    LOCK(cs_args);
+    m_fallback_chain_type = chain;
+}
+
 void ArgsManager::AddCommand(const std::string& cmd, const std::string& help)
 {
     Assert(cmd.find('=') == std::string::npos);
@@ -761,7 +767,8 @@ std::variant<ChainType, std::string> ArgsManager::GetChainArg() const
     if (fBtqRegTest) return ChainType::BTQREGTEST;
     if (fBtqSigNet) return ChainType::BTQSIGNET;
     if (fBtqTest) return ChainType::BTQTEST;
-    return ChainType::BTQMAIN;
+    LOCK(cs_args);
+    return m_fallback_chain_type;
 }
 
 bool ArgsManager::UseDefaultSection(const std::string& arg) const

--- a/src/common/args.h
+++ b/src/common/args.h
@@ -141,6 +141,7 @@ protected:
     mutable fs::path m_cached_blocks_path GUARDED_BY(cs_args);
     mutable fs::path m_cached_datadir_path GUARDED_BY(cs_args);
     mutable fs::path m_cached_network_datadir_path GUARDED_BY(cs_args);
+    ChainType m_fallback_chain_type GUARDED_BY(cs_args){ChainType::BTQMAIN};
 
     [[nodiscard]] bool ReadConfigStream(std::istream& stream, const std::string& filepath, std::string& error, bool ignore_invalid_keys = false);
 
@@ -326,17 +327,22 @@ protected:
 
     /**
      * Returns the appropriate chain type from the program arguments.
-     * @return ChainType::BTQMAIN by default; raises runtime error if an invalid
-     * combination, or unknown chain is given.
+     * If no explicit chain (-chain/-testnet/-signet/-regtest) appears in merged
+     * settings, the configured fallback applies (normally mainnet; btq-qt sets test).
+     * @raises std::runtime_error on invalid combinations or unknown -chain=value.
      */
     ChainType GetChainType() const;
 
     /**
      * Returns the appropriate chain type string from the program arguments.
-     * @return ChainType::BTQMAIN string by default; raises runtime error if an
-     * invalid combination is given.
      */
     std::string GetChainTypeString() const;
+
+    /**
+     * Chain when no -chain/-testnet/-signet/-regtest is set anywhere in merged settings.
+     * Command line and config override this (unlike SoftSetArg/ForceSetArg).
+     */
+    void SetFallbackChainType(ChainType chain);
 
     /**
      * Add argument

--- a/src/qt/btq.cpp
+++ b/src/qt/btq.cpp
@@ -33,6 +33,7 @@
 #include <qt/utilitydialog.h>
 #include <qt/winshutdownmonitor.h>
 #include <uint256.h>
+#include <util/chaintype.h>
 #include <util/exception.h>
 #include <util/string.h>
 #include <util/threadnames.h>
@@ -546,6 +547,9 @@ int GuiMain(int argc, char* argv[])
             QString::fromStdString("Error parsing command line arguments: %1.").arg(QString::fromStdString(error)));
         return EXIT_FAILURE;
     }
+
+    // GUI defaults to testnet when neither the command line nor config sets a chain.
+    gArgs.SetFallbackChainType(ChainType::BTQTEST);
 
     // Now that the QApplication is setup and we have parsed our parameters, we can set the platform style
     app.setupPlatformStyle();


### PR DESCRIPTION
## Summary
- Introduce `ArgsManager::SetFallbackChainType` and a configurable fallback used when no `-chain`/`-testnet`/`-signet`/`-regtest` appears in merged settings.
- Have `GuiMain` set the fallback to testnet after parsing the command line so `btq-qt` starts on testnet by default.
- `btqd`, `btq-cli`, and other binaries keep mainnet as fallback unless they call `SetFallbackChainType`; explicit CLI and `btq.conf`/`settings.json` values still override the fallback (no forced-setting semantics).

## Test plan
- [x] `make common/libbtq_common_a-args.o qt/libbtqqt_a-btq.o`
- [x] `./src/test/test_btq --run_test=argsman_tests`
- [ ] Launch `btq-qt` with no chain arguments and confirm testnet UI / datadir behaviour
- [ ] Launch `btq-qt -chain=main` and confirm mainnet