### PR TITLE
Integrate PR #57 audit hardening onto master (Dilithium/P2MR/constants) + close audit items

### DIFF
--- a/src/addresstype.cpp
+++ b/src/addresstype.cpp
@@ -245,8 +245,8 @@ public:
     bool operator()(const DilithiumPubKeyDestination& dest) const { return false; }
     bool operator()(const DilithiumPKHash& dest) const { return true; }
     bool operator()(const DilithiumScriptHash& dest) const { return true; }
-    bool operator()(const DilithiumWitnessV0KeyHash& dest) const { return true; }
-    bool operator()(const DilithiumWitnessV0ScriptHash& dest) const { return true; }
+    bool operator()(const DilithiumWitnessV0KeyHash& dest) const { return false; }
+    bool operator()(const DilithiumWitnessV0ScriptHash& dest) const { return false; }
 };
 } // namespace
 

--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -9,6 +9,7 @@
 #include <consensus/consensus.h>
 #include <consensus/validation.h>
 #include <key_io.h>
+#include <policy/policy.h>
 #include <script/descriptor.h>
 #include <script/script.h>
 #include <script/solver.h>
@@ -178,7 +179,7 @@ void TxToUniv(const CTransaction& tx, const uint256& block_hash, UniValue& entry
     // so cast to unsigned before giving it to the user.
     entry.pushKV("version", static_cast<int64_t>(static_cast<uint32_t>(tx.nVersion)));
     entry.pushKV("size", (int)::GetSerializeSize(tx, PROTOCOL_VERSION));
-    entry.pushKV("vsize", GetTransactionWeight(tx));
+    entry.pushKV("vsize", GetVirtualTransactionSize(tx));
     entry.pushKV("weight", GetTransactionWeight(tx));
     entry.pushKV("locktime", (int64_t)tx.nLockTime);
 

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -87,7 +87,7 @@ public:
         // BTQ: Enable SegWit at height 1 for Dilithium witness transactions
         consensus.SegwitHeight = 1;
         consensus.MinBIP9WarningHeight = 0;
-        consensus.powLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+        consensus.powLimit = uint256S("00000377ae000000000000000000000000000000000000000000000000000000");
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks (legacy, pre-LWMA)
         consensus.nPowTargetSpacing = 1 * 60;
         consensus.nLWMAHeight = 300000;
@@ -107,10 +107,10 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].min_activation_height = 0;
 
-        // Pre-launch floor: cumulative work through the remined genesis block.
+        // Pre-launch floor: tied to the remined genesis block (see assert below).
         // Rotate both values at each tagged release (see doc/release-process.md).
         consensus.nMinimumChainWork = uint256S("0000000000000000000000000000000000000000000000000000000000010002");
-        consensus.defaultAssumeValid = uint256S("0000ca45ea08433961609b50cd0c3f76d14589f8f61973ebbc344c3a160f7cdd");
+        consensus.defaultAssumeValid = uint256S("0x000003194a90d8d8eff8b39a7ad4e2490729b97a6772b7f4c4cb8887dffd1ae4");
 
         pchMessageStart[0] = 0xf1;
         pchMessageStart[1] = 0xb2;
@@ -121,9 +121,9 @@ public:
         m_assumed_blockchain_size = 0;
         m_assumed_chain_state_size = 0;
 
-        genesis = CreateGenesisBlock(1771804800, 184980, 0x1f00ffff, 1, 5 * COIN); 
+        genesis = CreateGenesisBlock(1771804800, 12582602, 0x1e0377ae, 1, 5 * COIN);
         consensus.hashGenesisBlock = genesis.GetHash();
-        assert(consensus.hashGenesisBlock == uint256S("0x0000ca45ea08433961609b50cd0c3f76d14589f8f61973ebbc344c3a160f7cdd"));
+        assert(consensus.hashGenesisBlock == uint256S("0x000003194a90d8d8eff8b39a7ad4e2490729b97a6772b7f4c4cb8887dffd1ae4"));
         assert(genesis.hashMerkleRoot == uint256S("0xec88310bd306cf5f9554cc257db16b81147e4bd0efda75f11b38467a5d918db1"));
 
         vSeeds.emplace_back("seed1.btq.com");
@@ -182,7 +182,7 @@ public:
         
         consensus.SegwitHeight = 1;
         consensus.MinBIP9WarningHeight = 0;
-        consensus.powLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+        consensus.powLimit = uint256S("00000377ae000000000000000000000000000000000000000000000000000000");
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks (legacy, pre-LWMA)
         consensus.nPowTargetSpacing = 1 * 60;
         consensus.nLWMAHeight = 300000;
@@ -216,9 +216,9 @@ public:
 
         const char* pszTimestamp = "BTQ testnet genesis block 20260526";
         const CScript genesisOutputScript = CScript() << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f") << OP_CHECKSIG;
-        genesis = CreateGenesisBlock(pszTimestamp, genesisOutputScript, 1771977600, 3, 0x207fffff, 1, 5 * COIN);
+        genesis = CreateGenesisBlock(pszTimestamp, genesisOutputScript, 1771977600, 2443007, 0x1e0377ae, 1, 5 * COIN);
         consensus.hashGenesisBlock = genesis.GetHash();
-        assert(consensus.hashGenesisBlock == uint256S("0xb82c2238f94b4c89c1d29af05ca1004ab8eaf35e313790b634aa663cb734b7f0"));
+        assert(consensus.hashGenesisBlock == uint256S("0x000000ffba1eed17608850f753ca60e74456dd3fe7af86b72aadba7d6052f7dd"));
         assert(genesis.hashMerkleRoot == uint256S("0xcd6a53f536b1f8f9442397d1d4f3db492d88bc4280f4c172eb5b1d9e1b6152e5"));
 
         vFixedSeeds.clear();
@@ -326,7 +326,7 @@ public:
         consensus.nRuleChangeActivationThreshold = 18144; // 90% of 20160
         consensus.nMinerConfirmationWindow = 20160;
         consensus.MinBIP9WarningHeight = 0;
-        consensus.powLimit = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+        consensus.powLimit = uint256S("00000377ae000000000000000000000000000000000000000000000000000000");
         consensus.nDilithiumHeight = 1;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = Consensus::BIP9Deployment::NEVER_ACTIVE;

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -110,14 +110,10 @@ bool IsStandardTx(const CTransaction& tx, const std::optional<unsigned>& max_dat
 
     for (const CTxIn& txin : tx.vin)
     {
-        // Biggest 'standard' txin involving only keys is a 15-of-15 P2SH
-        // multisig with compressed keys (remember the 520 byte limit on
-        // redeemScript size). That works out to a (15*(33+1))+3=513 byte
-        // redeemScript, 513+1+15*(73+1)+3=1627 bytes of scriptSig, which
-        // we round off to 1650(MAX_STANDARD_SCRIPTSIG_SIZE) bytes for
-        // some minor future-proofing. That's also enough to spend a
-        // 20-of-20 CHECKMULTISIG scriptPubKey, though such a scriptPubKey
-        // is not considered standard.
+        // BTQ raises MAX_SCRIPT_ELEMENT_SIZE so Dilithium signatures and pubkeys
+        // can be relayed. Keep the total scriptSig standardness cap aligned with
+        // that per-element cap to avoid accepting oversized non-witness pushes
+        // up to the transaction weight limit.
         if (txin.scriptSig.size() > MAX_STANDARD_SCRIPTSIG_SIZE) {
             reason = "scriptsig-size";
             return false;

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -8,6 +8,7 @@
 
 #include <consensus/amount.h>
 #include <consensus/consensus.h>
+#include <consensus/consensus.h>
 #include <primitives/transaction.h>
 #include <script/interpreter.h>
 #include <script/solver.h>
@@ -43,13 +44,16 @@ static constexpr bool DEFAULT_PERMIT_BAREMULTISIG{true};
 /** The maximum number of witness stack items in a standard P2WSH script */
 static constexpr unsigned int MAX_STANDARD_P2WSH_STACK_ITEMS{100};
 /** The maximum size in bytes of each witness stack item in a standard P2WSH script */
-static constexpr unsigned int MAX_STANDARD_P2WSH_STACK_ITEM_SIZE{65536};
+static constexpr unsigned int MAX_STANDARD_P2WSH_STACK_ITEM_SIZE{MAX_SCRIPT_ELEMENT_SIZE};
 /** The maximum size in bytes of each witness stack item in a standard BIP 342 script (Taproot, leaf version 0xc0) */
-static constexpr unsigned int MAX_STANDARD_TAPSCRIPT_STACK_ITEM_SIZE{65536};
+static constexpr unsigned int MAX_STANDARD_TAPSCRIPT_STACK_ITEM_SIZE{MAX_SCRIPT_ELEMENT_SIZE};
 /** The maximum size in bytes of a standard witnessScript */
 static constexpr unsigned int MAX_STANDARD_P2WSH_SCRIPT_SIZE{65536};
 /** The maximum size of a standard ScriptSig */
-static constexpr unsigned int MAX_STANDARD_SCRIPTSIG_SIZE{65536};
+static constexpr unsigned int MAX_STANDARD_SCRIPTSIG_SIZE{MAX_SCRIPT_ELEMENT_SIZE};
+static_assert(MAX_STANDARD_P2WSH_STACK_ITEM_SIZE <= MAX_SCRIPT_ELEMENT_SIZE);
+static_assert(MAX_STANDARD_TAPSCRIPT_STACK_ITEM_SIZE <= MAX_SCRIPT_ELEMENT_SIZE);
+static_assert(MAX_STANDARD_SCRIPTSIG_SIZE * WITNESS_SCALE_FACTOR < MAX_STANDARD_TX_WEIGHT);
 /** Min feerate for defining dust.
  * Changing the dust limit changes which transactions are
  * standard and should be done with care and ideally rarely. It makes sense to

--- a/src/qt/p2mrvaultdialog.cpp
+++ b/src/qt/p2mrvaultdialog.cpp
@@ -127,7 +127,6 @@ void P2MRVaultDialog::refresh()
     }
 
     auto rows = m_controller->listVaults(/*min_depth=*/1);
-    CAmount total{0};
     for (const auto& r : rows) {
         const int row = m_table->rowCount();
         m_table->insertRow(row);
@@ -153,10 +152,9 @@ void P2MRVaultDialog::refresh()
         m_table->setItem(row, COL_STATE, state_item);
         m_table->setItem(row, COL_CREATED, created_item);
         m_table->setItem(row, COL_ID, id_item);
-
-        total += r.balance;
     }
 
+    const CAmount total{m_controller->totalBalance(/*min_depth=*/1)};
     QString total_str = m_wallet_model && m_wallet_model->getOptionsModel()
         ? BTQUnits::formatWithUnit(m_wallet_model->getOptionsModel()->getDisplayUnit(), total)
         : QString::number(total);

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -558,6 +558,7 @@ static RPCHelpMan decodescript()
         case TxoutType::SCRIPTHASH:
         case TxoutType::WITNESS_UNKNOWN:
         case TxoutType::WITNESS_V1_TAPROOT:
+        case TxoutType::WITNESS_V2_P2MR:
         case TxoutType::DILITHIUM_PUBKEY:
         case TxoutType::DILITHIUM_PUBKEYHASH:
         case TxoutType::DILITHIUM_SCRIPTHASH:
@@ -606,6 +607,7 @@ static RPCHelpMan decodescript()
             case TxoutType::WITNESS_V0_KEYHASH:
             case TxoutType::WITNESS_V0_SCRIPTHASH:
             case TxoutType::WITNESS_V1_TAPROOT:
+            case TxoutType::WITNESS_V2_P2MR:
             case TxoutType::DILITHIUM_PUBKEY:
             case TxoutType::DILITHIUM_PUBKEYHASH:
             case TxoutType::DILITHIUM_SCRIPTHASH:

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -28,9 +28,27 @@ const std::string EXAMPLE_ADDRESS[2] = {"bc1q09vm5lfy0j5reeulh4x5752q25uqqvz34hu
 std::string GetAllOutputTypes()
 {
     std::vector<std::string> ret;
-    using U = std::underlying_type<TxoutType>::type;
-    for (U i = (U)TxoutType::NONSTANDARD; i <= (U)TxoutType::WITNESS_UNKNOWN; ++i) {
-        ret.emplace_back(GetTxnOutputType(static_cast<TxoutType>(i)));
+    const std::vector<TxoutType> output_types{
+        TxoutType::NONSTANDARD,
+        TxoutType::PUBKEY,
+        TxoutType::PUBKEYHASH,
+        TxoutType::SCRIPTHASH,
+        TxoutType::MULTISIG,
+        TxoutType::NULL_DATA,
+        TxoutType::WITNESS_V0_SCRIPTHASH,
+        TxoutType::WITNESS_V0_KEYHASH,
+        TxoutType::WITNESS_V1_TAPROOT,
+        TxoutType::WITNESS_V2_P2MR,
+        TxoutType::WITNESS_UNKNOWN,
+        TxoutType::DILITHIUM_PUBKEY,
+        TxoutType::DILITHIUM_PUBKEYHASH,
+        TxoutType::DILITHIUM_SCRIPTHASH,
+        TxoutType::DILITHIUM_MULTISIG,
+        TxoutType::DILITHIUM_WITNESS_V0_KEYHASH,
+        TxoutType::DILITHIUM_WITNESS_V0_SCRIPTHASH,
+    };
+    for (const auto output_type : output_types) {
+        ret.emplace_back(GetTxnOutputType(output_type));
     }
     return Join(ret, ", ");
 }

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -344,6 +344,11 @@ public:
         return m_checker.CheckSchnorrSignature(sig, pubkey, sigversion, execdata, serror);
     }
 
+    bool CheckDilithiumSignature(const std::vector<unsigned char>& scriptSig, const std::vector<unsigned char>& vchPubKey, const CScript& scriptCode, SigVersion sigversion) const override
+    {
+        return m_checker.CheckDilithiumSignature(scriptSig, vchPubKey, scriptCode, sigversion);
+    }
+
     bool CheckLockTime(const CScriptNum& nLockTime) const override
     {
         return m_checker.CheckLockTime(nLockTime);

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -702,7 +702,7 @@ bool ProduceSignature(const SigningProvider& provider, const BaseSignatureCreato
         sigdata.scriptWitness.stack = result;
         sigdata.witness = true;
         result.clear();
-    } else if (whichType == TxoutType::WITNESS_V1_TAPROOT && !P2SH) {
+    } else if ((whichType == TxoutType::WITNESS_V1_TAPROOT || whichType == TxoutType::WITNESS_V2_P2MR) && !P2SH) {
         sigdata.witness = true;
         if (solved) {
             sigdata.scriptWitness.stack = std::move(result);
@@ -718,8 +718,10 @@ bool ProduceSignature(const SigningProvider& provider, const BaseSignatureCreato
     }
     sigdata.scriptSig = PushAll(result);
 
-    // Test solution
-    sigdata.complete = solved && VerifyScript(sigdata.scriptSig, fromPubKey, &sigdata.scriptWitness, STANDARD_SCRIPT_VERIFY_FLAGS, creator.Checker());
+    // Test solution. BTQ activates Dilithium from height 1 (buried DEPLOYMENT_DILITHIUM),
+    // so the wallet's solution check must enable SCRIPT_VERIFY_DILITHIUM to validate
+    // OP_CHECKSIGDILITHIUM satisfactions (it is not part of STANDARD_SCRIPT_VERIFY_FLAGS).
+    sigdata.complete = solved && VerifyScript(sigdata.scriptSig, fromPubKey, &sigdata.scriptWitness, STANDARD_SCRIPT_VERIFY_FLAGS | SCRIPT_VERIFY_DILITHIUM, creator.Checker());
     return sigdata.complete;
 }
 
@@ -737,6 +739,16 @@ public:
         if (m_checker.CheckECDSASignature(scriptSig, vchPubKey, scriptCode, sigversion)) {
             CPubKey pubkey(vchPubKey);
             sigdata.signatures.emplace(pubkey.GetID(), SigPair(pubkey, scriptSig));
+            return true;
+        }
+        return false;
+    }
+
+    bool CheckDilithiumSignature(const std::vector<unsigned char>& scriptSig, const std::vector<unsigned char>& vchPubKey, const CScript& scriptCode, SigVersion sigversion) const override
+    {
+        if (m_checker.CheckDilithiumSignature(scriptSig, vchPubKey, scriptCode, sigversion)) {
+            CDilithiumPubKey pubkey(vchPubKey);
+            sigdata.dilithium_signatures.emplace(pubkey.GetID(), std::make_pair(pubkey, scriptSig));
             return true;
         }
         return false;

--- a/src/test/dilithium_address_script_tests.cpp
+++ b/src/test/dilithium_address_script_tests.cpp
@@ -199,7 +199,8 @@ BOOST_AUTO_TEST_CASE(dilithium_script_solving)
     BOOST_CHECK(solutions[0].size() == 20);
     BOOST_CHECK(std::equal(solutions[0].begin(), solutions[0].end(), pk_hash.begin()));
     
-    // Test Dilithium P2SH script solving
+    // P2SH scriptPubKeys do not commit to the signature algorithm; the redeem
+    // script carries the Dilithium opcode, but the outer script solves as P2SH.
     CScript redeem_script = CScript() << ToByteVector(pubkey) << OP_CHECKSIGDILITHIUM;
     DilithiumScriptHash script_hash(redeem_script);
     CScript p2sh_script = CScript() << OP_HASH160 << ToByteVector(script_hash) << OP_EQUAL;
@@ -267,16 +268,18 @@ BOOST_AUTO_TEST_CASE(dilithium_destination_extraction)
     BOOST_CHECK(std::holds_alternative<DilithiumPKHash>(dest));
     BOOST_CHECK(std::get<DilithiumPKHash>(dest) == pk_hash);
     
-    // Test Dilithium P2SH destination extraction
+    // The outer P2SH destination is algorithm-agnostic; the redeem script is
+    // still a Dilithium script, but ExtractDestination returns ScriptHash.
     CScript redeem_script = CScript() << ToByteVector(pubkey) << OP_CHECKSIGDILITHIUM;
     DilithiumScriptHash script_hash(redeem_script);
+    ScriptHash ordinary_script_hash(redeem_script);
     CScript p2sh_script = CScript() << OP_HASH160 << ToByteVector(script_hash) << OP_EQUAL;
     dest = CTxDestination{};
     has_address = ExtractDestination(p2sh_script, dest);
     BOOST_CHECK(has_address);
     // P2SH outputs are indistinguishable from standard P2SH at scriptPubKey level.
     BOOST_CHECK(std::holds_alternative<ScriptHash>(dest));
-    BOOST_CHECK(std::get<ScriptHash>(dest) == ScriptHash(script_hash));
+    BOOST_CHECK(std::get<ScriptHash>(dest) == ordinary_script_hash);
 }
 
 BOOST_AUTO_TEST_CASE(dilithium_output_types)
@@ -321,10 +324,10 @@ BOOST_AUTO_TEST_CASE(dilithium_valid_destination)
     BOOST_CHECK(IsValidDestination(script_hash));
     
     DilithiumWitnessV0KeyHash witness_key_hash(pubkey);
-    BOOST_CHECK(IsValidDestination(witness_key_hash));
-    
+    BOOST_CHECK(!IsValidDestination(witness_key_hash));
+
     DilithiumWitnessV0ScriptHash witness_script_hash(script);
-    BOOST_CHECK(IsValidDestination(witness_script_hash));
+    BOOST_CHECK(!IsValidDestination(witness_script_hash));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/dilithium_basic_tests.cpp
+++ b/src/test/dilithium_basic_tests.cpp
@@ -4,8 +4,11 @@
 
 #include <test/util/setup_common.h>
 #include <crypto/dilithium_key.h>
+#include <key.h>
+#include <primitives/transaction.h>
 #include <script/script.h>
 #include <script/interpreter.h>
+#include <script/sign.h>
 #include <policy/policy.h>
 
 #include <boost/test/unit_test.hpp>
@@ -78,6 +81,133 @@ BOOST_AUTO_TEST_CASE(dilithium_script_limits)
     std::vector<unsigned char> signature;
     BOOST_CHECK(dilithium_key.Sign(test_hash, signature));
     BOOST_CHECK_LE(signature.size(), MAX_SCRIPT_ELEMENT_SIZE);
+}
+
+BOOST_AUTO_TEST_CASE(dilithium_script_signature_with_sighash_byte)
+{
+    CDilithiumKey dilithium_key;
+    dilithium_key.MakeNewKey();
+    const CDilithiumPubKey dilithium_pubkey = dilithium_key.GetPubKey();
+    const DilithiumPKHash key_id{dilithium_pubkey};
+
+    FlatSigningProvider provider;
+    provider.dilithium_pubkeys.emplace(key_id, dilithium_pubkey);
+    provider.dilithium_keys.emplace(key_id, dilithium_key);
+
+    CMutableTransaction spending_tx;
+    spending_tx.nVersion = 1;
+    spending_tx.vin.resize(1);
+    spending_tx.vin[0].prevout = COutPoint{uint256::ONE, 0};
+    spending_tx.vout.emplace_back(1, CScript() << OP_TRUE);
+
+    const CAmount amount{1};
+
+    const auto check_spend = [&](const CScript& script_pubkey, const CScript& script_sig, const ScriptError expected) {
+        CMutableTransaction tx{spending_tx};
+        tx.vin[0].scriptSig = script_sig;
+        const CTransaction ctx{tx};
+
+        ScriptError error{SCRIPT_ERR_OK};
+        // BTQ gates Dilithium opcodes behind SCRIPT_VERIFY_DILITHIUM (buried
+        // DEPLOYMENT_DILITHIUM, active from height 1); apply it as consensus/policy do.
+        const bool verified = VerifyScript(
+            ctx.vin[0].scriptSig,
+            script_pubkey,
+            nullptr,
+            STANDARD_SCRIPT_VERIFY_FLAGS | SCRIPT_VERIFY_DILITHIUM,
+            TransactionSignatureChecker(&ctx, 0, amount, MissingDataBehavior::ASSERT_FAIL),
+            &error);
+
+        BOOST_CHECK_EQUAL(verified, expected == SCRIPT_ERR_OK);
+        BOOST_CHECK_EQUAL(error, expected);
+    };
+
+    const auto sign_for_script = [&](const CScript& script_pubkey) {
+        std::vector<unsigned char> signature;
+        const uint256 sighash = SignatureHash(script_pubkey, spending_tx, 0, SIGHASH_ALL, amount, SigVersion::BASE);
+        BOOST_REQUIRE(dilithium_key.Sign(sighash, signature));
+        BOOST_REQUIRE_EQUAL(signature.size(), BTQ_DILITHIUM_SIGNATURE_SIZE);
+        return signature;
+    };
+
+    const auto pushed_values = [](const CScript& script) {
+        std::vector<std::vector<unsigned char>> pushes;
+        CScript::const_iterator pc = script.begin();
+        while (pc != script.end()) {
+            opcodetype opcode;
+            std::vector<unsigned char> data;
+            BOOST_REQUIRE(script.GetOp(pc, opcode, data));
+            BOOST_REQUIRE_LE(opcode, OP_PUSHDATA4);
+            pushes.push_back(std::move(data));
+        }
+        return pushes;
+    };
+
+    const auto check_produced_signature = [&](const CScript& script_pubkey, const size_t expected_pushes) {
+        MutableTransactionSignatureCreator creator{spending_tx, 0, amount, SIGHASH_ALL};
+        SignatureData sigdata;
+        BOOST_REQUIRE(ProduceSignature(provider, creator, script_pubkey, sigdata));
+        BOOST_CHECK(sigdata.complete);
+        BOOST_CHECK(!sigdata.witness);
+        BOOST_REQUIRE_EQUAL(sigdata.dilithium_signatures.size(), 1);
+
+        const std::vector<unsigned char>& signature = sigdata.dilithium_signatures.begin()->second.second;
+        BOOST_REQUIRE_EQUAL(signature.size(), BTQ_DILITHIUM_SIGNATURE_SIZE + 1);
+        BOOST_CHECK_EQUAL(signature.back(), SIGHASH_ALL);
+
+        const auto pushes = pushed_values(sigdata.scriptSig);
+        BOOST_REQUIRE_EQUAL(pushes.size(), expected_pushes);
+        BOOST_REQUIRE_EQUAL(pushes.front().size(), BTQ_DILITHIUM_SIGNATURE_SIZE + 1);
+        BOOST_CHECK_EQUAL(pushes.front().back(), SIGHASH_ALL);
+        check_spend(script_pubkey, sigdata.scriptSig, SCRIPT_ERR_OK);
+    };
+
+    const CScript p2pk_script = CScript() << ToByteVector(dilithium_pubkey) << OP_CHECKSIGDILITHIUM;
+    std::vector<unsigned char> p2pk_signature = sign_for_script(p2pk_script);
+
+    CScript raw_signature_script_sig = CScript() << p2pk_signature;
+    check_spend(p2pk_script, raw_signature_script_sig, SCRIPT_ERR_SIG_DER);
+
+    p2pk_signature.push_back(SIGHASH_ALL);
+    CScript p2pk_script_sig = CScript() << p2pk_signature;
+    check_spend(p2pk_script, p2pk_script_sig, SCRIPT_ERR_OK);
+    check_produced_signature(p2pk_script, 1);
+
+    const CScript p2pkh_script = CScript() << OP_DUP << OP_HASH160 << ToByteVector(dilithium_pubkey.GetID()) << OP_EQUALVERIFY << OP_CHECKSIGDILITHIUM;
+    std::vector<unsigned char> p2pkh_signature = sign_for_script(p2pkh_script);
+    p2pkh_signature.push_back(SIGHASH_ALL);
+    CScript p2pkh_script_sig = CScript() << p2pkh_signature << ToByteVector(dilithium_pubkey);
+    check_spend(p2pkh_script, p2pkh_script_sig, SCRIPT_ERR_OK);
+    check_produced_signature(p2pkh_script, 2);
+}
+
+BOOST_AUTO_TEST_CASE(ecdsa_oversized_signature_rejected_under_standard_flags)
+{
+    CKey key;
+    key.MakeNewKey(true);
+
+    CMutableTransaction spending_tx;
+    spending_tx.nVersion = 1;
+    spending_tx.vin.resize(1);
+    spending_tx.vin[0].prevout = COutPoint{uint256::ONE, 0};
+    spending_tx.vout.emplace_back(1, CScript() << OP_TRUE);
+
+    const CAmount amount{1};
+    const CScript script_pubkey = CScript() << ToByteVector(key.GetPubKey()) << OP_CHECKSIG;
+    spending_tx.vin[0].scriptSig = CScript() << std::vector<unsigned char>(600, 0);
+    const CTransaction ctx{spending_tx};
+
+    ScriptError error{SCRIPT_ERR_OK};
+    const bool verified = VerifyScript(
+        ctx.vin[0].scriptSig,
+        script_pubkey,
+        nullptr,
+        STANDARD_SCRIPT_VERIFY_FLAGS,
+        TransactionSignatureChecker(&ctx, 0, amount, MissingDataBehavior::ASSERT_FAIL),
+        &error);
+
+    BOOST_CHECK(!verified);
+    BOOST_CHECK_EQUAL(error, SCRIPT_ERR_SIG_DER);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/dilithium_wallet_tests.cpp
+++ b/src/test/dilithium_wallet_tests.cpp
@@ -11,6 +11,7 @@
 #include <uint256.h>
 #include <util/strencodings.h>
 
+#include <algorithm>
 #include <array>
 #include <cstring>
 #include <vector>
@@ -22,6 +23,7 @@ extern "C" {
 }
 
 using wallet::CKeyingMaterial;
+using wallet::DeriveDilithiumKeyIV;
 using wallet::EncryptDilithiumSecret;
 using wallet::DecryptDilithiumSecret;
 using wallet::DecryptDilithiumKey;
@@ -100,9 +102,9 @@ BOOST_AUTO_TEST_CASE(dilithium_key_encryption)
         master_key[i] = i;
     }
 
-    // Production path encrypts with KeyIDToIV(keyID) as IV; decrypt must match.
+    // Production path derives a 32-byte IV from the 20-byte key id; decrypt must match.
     const CKeyID key_id = CKeyID(key.GetPubKey().GetID());
-    const uint256 iv = KeyIDToIV(key_id);
+    const uint256 iv{DeriveDilithiumKeyIV(key_id)};
 
     std::vector<unsigned char> encrypted_secret;
     CKeyingMaterial secret(key.begin(), key.end());
@@ -118,6 +120,30 @@ BOOST_AUTO_TEST_CASE(dilithium_key_encryption)
     CDilithiumKey decrypted_key;
     BOOST_CHECK(DecryptDilithiumKey(master_key, encrypted_secret, key_id, decrypted_key));
     BOOST_CHECK(decrypted_key.IsValid());
+    BOOST_CHECK(decrypted_key == key);
+}
+
+BOOST_AUTO_TEST_CASE(dilithium_key_decryption_accepts_legacy_keyid_iv)
+{
+    CDilithiumKey key;
+    key.MakeNewKey();
+    BOOST_REQUIRE(key.IsValid());
+
+    CKeyingMaterial master_key(32, 0);
+    for (int i = 0; i < 32; i++) {
+        master_key[i] = 0xff - i;
+    }
+
+    const CKeyID key_id = CKeyID(key.GetPubKey().GetID());
+    uint256 legacy_iv;
+    std::copy(key_id.begin(), key_id.end(), legacy_iv.begin());
+
+    std::vector<unsigned char> encrypted_secret;
+    CKeyingMaterial secret(key.begin(), key.end());
+    BOOST_REQUIRE(EncryptDilithiumSecret(master_key, secret, legacy_iv, encrypted_secret));
+
+    CDilithiumKey decrypted_key;
+    BOOST_CHECK(DecryptDilithiumKey(master_key, encrypted_secret, key_id, decrypted_key));
     BOOST_CHECK(decrypted_key == key);
 }
 

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -17,9 +17,10 @@ BOOST_FIXTURE_TEST_SUITE(pow_tests, BasicTestingSetup)
 BOOST_AUTO_TEST_CASE(get_next_work)
 {
     const auto chainParams = CreateChainParams(*m_node.args, ChainType::BTQMAIN);
+    const auto& consensus = chainParams->GetConsensus();
     int64_t nLastRetargetTime = 1261130161; // Block #30240
     CBlockIndex pindexLast;
-    pindexLast.nHeight = 32255;
+    pindexLast.nHeight = consensus.DifficultyAdjustmentInterval() - 1;
     pindexLast.nTime = 1262152739;  // Block #32255
     pindexLast.nBits = 0x1d00ffff;
 
@@ -28,56 +29,59 @@ BOOST_AUTO_TEST_CASE(get_next_work)
     // reimplementing the same code that is written in pow.cpp. Rather than
     // copy that code, we just hardcode the expected result.
     unsigned int expected_nbits = 0x1d00d86aU;
-    BOOST_CHECK_EQUAL(CalculateNextWorkRequired(&pindexLast, nLastRetargetTime, chainParams->GetConsensus()), expected_nbits);
-    BOOST_CHECK(PermittedDifficultyTransition(chainParams->GetConsensus(), pindexLast.nHeight+1, pindexLast.nBits, expected_nbits));
+    BOOST_CHECK_EQUAL(CalculateNextWorkRequired(&pindexLast, nLastRetargetTime, consensus), expected_nbits);
+    BOOST_CHECK(PermittedDifficultyTransition(consensus, pindexLast.nHeight+1, pindexLast.nBits, expected_nbits));
 }
 
 /* Test the constraint on the upper bound for next work */
 BOOST_AUTO_TEST_CASE(get_next_work_pow_limit)
 {
     const auto chainParams = CreateChainParams(*m_node.args, ChainType::BTQMAIN);
+    const auto& consensus = chainParams->GetConsensus();
     int64_t nLastRetargetTime = 1231006505; // Block #0
     CBlockIndex pindexLast;
-    pindexLast.nHeight = 2015;
+    pindexLast.nHeight = consensus.DifficultyAdjustmentInterval() - 1;
     pindexLast.nTime = 1233061996;  // Block #2015
-    pindexLast.nBits = 0x1d00ffff;
-    unsigned int expected_nbits = 0x1d00ffffU;
-    BOOST_CHECK_EQUAL(CalculateNextWorkRequired(&pindexLast, nLastRetargetTime, chainParams->GetConsensus()), expected_nbits);
-    BOOST_CHECK(PermittedDifficultyTransition(chainParams->GetConsensus(), pindexLast.nHeight+1, pindexLast.nBits, expected_nbits));
+    pindexLast.nBits = UintToArith256(consensus.powLimit).GetCompact();
+    unsigned int expected_nbits = UintToArith256(consensus.powLimit).GetCompact();
+    BOOST_CHECK_EQUAL(CalculateNextWorkRequired(&pindexLast, nLastRetargetTime, consensus), expected_nbits);
+    BOOST_CHECK(PermittedDifficultyTransition(consensus, pindexLast.nHeight+1, pindexLast.nBits, expected_nbits));
 }
 
 /* Test the constraint on the lower bound for actual time taken */
 BOOST_AUTO_TEST_CASE(get_next_work_lower_limit_actual)
 {
     const auto chainParams = CreateChainParams(*m_node.args, ChainType::BTQMAIN);
+    const auto& consensus = chainParams->GetConsensus();
     int64_t nLastRetargetTime = 1279008237; // Block #66528
     CBlockIndex pindexLast;
-    pindexLast.nHeight = 68543;
+    pindexLast.nHeight = consensus.DifficultyAdjustmentInterval() - 1;
     pindexLast.nTime = 1279297671;  // Block #68543
     pindexLast.nBits = 0x1c05a3f4;
     unsigned int expected_nbits = 0x1c0168fdU;
-    BOOST_CHECK_EQUAL(CalculateNextWorkRequired(&pindexLast, nLastRetargetTime, chainParams->GetConsensus()), expected_nbits);
-    BOOST_CHECK(PermittedDifficultyTransition(chainParams->GetConsensus(), pindexLast.nHeight+1, pindexLast.nBits, expected_nbits));
+    BOOST_CHECK_EQUAL(CalculateNextWorkRequired(&pindexLast, nLastRetargetTime, consensus), expected_nbits);
+    BOOST_CHECK(PermittedDifficultyTransition(consensus, pindexLast.nHeight+1, pindexLast.nBits, expected_nbits));
     // Test that reducing nbits further would not be a PermittedDifficultyTransition.
     unsigned int invalid_nbits = expected_nbits-1;
-    BOOST_CHECK(!PermittedDifficultyTransition(chainParams->GetConsensus(), pindexLast.nHeight+1, pindexLast.nBits, invalid_nbits));
+    BOOST_CHECK(!PermittedDifficultyTransition(consensus, pindexLast.nHeight+1, pindexLast.nBits, invalid_nbits));
 }
 
 /* Test the constraint on the upper bound for actual time taken */
 BOOST_AUTO_TEST_CASE(get_next_work_upper_limit_actual)
 {
     const auto chainParams = CreateChainParams(*m_node.args, ChainType::BTQMAIN);
+    const auto& consensus = chainParams->GetConsensus();
     int64_t nLastRetargetTime = 1263163443; // NOTE: Not an actual block time
     CBlockIndex pindexLast;
-    pindexLast.nHeight = 46367;
+    pindexLast.nHeight = consensus.DifficultyAdjustmentInterval() - 1;
     pindexLast.nTime = 1269211443;  // Block #46367
     pindexLast.nBits = 0x1c387f6f;
     unsigned int expected_nbits = 0x1d00e1fdU;
-    BOOST_CHECK_EQUAL(CalculateNextWorkRequired(&pindexLast, nLastRetargetTime, chainParams->GetConsensus()), expected_nbits);
-    BOOST_CHECK(PermittedDifficultyTransition(chainParams->GetConsensus(), pindexLast.nHeight+1, pindexLast.nBits, expected_nbits));
+    BOOST_CHECK_EQUAL(CalculateNextWorkRequired(&pindexLast, nLastRetargetTime, consensus), expected_nbits);
+    BOOST_CHECK(PermittedDifficultyTransition(consensus, pindexLast.nHeight+1, pindexLast.nBits, expected_nbits));
     // Test that increasing nbits further would not be a PermittedDifficultyTransition.
     unsigned int invalid_nbits = expected_nbits+1;
-    BOOST_CHECK(!PermittedDifficultyTransition(chainParams->GetConsensus(), pindexLast.nHeight+1, pindexLast.nBits, invalid_nbits));
+    BOOST_CHECK(!PermittedDifficultyTransition(consensus, pindexLast.nHeight+1, pindexLast.nBits, invalid_nbits));
 }
 
 BOOST_AUTO_TEST_CASE(CheckProofOfWork_test_negative_target)
@@ -142,7 +146,7 @@ BOOST_AUTO_TEST_CASE(GetBlockProofEquivalentTime_test)
         blocks[i].pprev = i ? &blocks[i - 1] : nullptr;
         blocks[i].nHeight = i;
         blocks[i].nTime = 1269211443 + i * chainParams->GetConsensus().nPowTargetSpacing;
-        blocks[i].nBits = 0x207fffff; /* target 0x7fffff000... */
+        blocks[i].nBits = UintToArith256(chainParams->GetConsensus().powLimit).GetCompact();
         blocks[i].nChainWork = i ? blocks[i - 1].nChainWork + GetBlockProof(blocks[i - 1]) : arith_uint256(0);
     }
 
@@ -174,6 +178,7 @@ void sanity_check_chainparams(const ArgsManager& args, ChainType chain_type)
     BOOST_CHECK(!neg && pow_compact != 0);
     BOOST_CHECK(!over);
     BOOST_CHECK(UintToArith256(consensus.powLimit) >= pow_compact);
+    BOOST_CHECK(CheckProofOfWork(chainParams->GenesisBlock().GetHash(), chainParams->GenesisBlock().nBits, consensus));
 
     // check max target * 4*nPowTargetTimespan doesn't overflow -- see pow.cpp:CalculateNextWorkRequired()
     if (!consensus.fPowNoRetargeting) {

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -82,6 +82,14 @@ UniValue RPCTestingSetup::CallRPC(std::string args)
 
 BOOST_FIXTURE_TEST_SUITE(rpc_tests, RPCTestingSetup)
 
+BOOST_AUTO_TEST_CASE(rpc_all_output_types_includes_btq_types)
+{
+    const std::string types = GetAllOutputTypes();
+    BOOST_CHECK_NE(types.find("witness_v2_p2mr"), std::string::npos);
+    BOOST_CHECK_NE(types.find("dilithium_pubkeyhash"), std::string::npos);
+    BOOST_CHECK_NE(types.find("dilithium_witness_v0_keyhash"), std::string::npos);
+}
+
 BOOST_AUTO_TEST_CASE(rpc_namedparams)
 {
     const std::vector<std::pair<std::string, bool>> arg_names{{"arg1", false}, {"arg2", false}, {"arg3", false}, {"arg4", false}, {"arg5", false}};

--- a/src/test/sigopcount_tests.cpp
+++ b/src/test/sigopcount_tests.cpp
@@ -81,6 +81,15 @@ BOOST_AUTO_TEST_CASE(dilithium_sigop_weighting)
                        << ToByteVector(dilithium_key.GetPubKey()) << OP_2
                        << OP_CHECKMULTISIGDILITHIUM;
     BOOST_CHECK_EQUAL(dilithium_multisig.GetSigOpCount(true), 2U * DILITHIUM_SIGOP_COST);
+
+    // P2SH-wrapped Dilithium: GetSigOpCount(scriptSig) must recurse into the
+    // redeem script and weight the hidden OP_CHECKSIGDILITHIUM accordingly.
+    const CScript& dilithium_redeem = dilithium_p2pk;
+    const CScript p2sh = CScript() << OP_HASH160 << ToByteVector(CScriptID(dilithium_redeem)) << OP_EQUAL;
+    const CScript p2sh_scriptsig = CScript() << Serialize(dilithium_redeem);
+    BOOST_CHECK_EQUAL(p2sh.GetSigOpCount(p2sh_scriptsig), DILITHIUM_SIGOP_COST);
+    // The P2SH scriptPubKey on its own hides the redeem script, so it must report 0.
+    BOOST_CHECK_EQUAL(p2sh.GetSigOpCount(true), 0U);
 }
 
 /**

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -29,6 +29,7 @@
 #include <util/string.h>
 #include <validation.h>
 
+#include <algorithm>
 #include <functional>
 #include <map>
 #include <string>
@@ -557,6 +558,28 @@ BOOST_AUTO_TEST_CASE(test_big_witness_transaction)
     scriptcheckqueue.StopWorkerThreads();
 }
 
+BOOST_AUTO_TEST_CASE(tx_to_univ_reports_virtual_size_not_weight)
+{
+    CMutableTransaction mtx;
+    mtx.nVersion = 2;
+    uint256 prev_hash;
+    prev_hash.SetHex("01");
+    mtx.vin.emplace_back(COutPoint{prev_hash, 0}, CScript{}, 0);
+    mtx.vin[0].scriptWitness.stack.emplace_back(100, 0x42);
+    mtx.vout.emplace_back(1000, CScript{} << OP_TRUE);
+
+    const CTransaction tx{mtx};
+    const int64_t weight = GetTransactionWeight(tx);
+    const int64_t vsize = GetVirtualTransactionSize(tx);
+    BOOST_REQUIRE_NE(weight, vsize);
+
+    UniValue entry{UniValue::VOBJ};
+    TxToUniv(tx, /*block_hash=*/uint256{}, entry, /*include_hex=*/false);
+
+    BOOST_CHECK_EQUAL(entry.find_value("weight").getInt<int64_t>(), weight);
+    BOOST_CHECK_EQUAL(entry.find_value("vsize").getInt<int64_t>(), vsize);
+}
+
 SignatureData CombineSignatures(const CMutableTransaction& input1, const CMutableTransaction& input2, const CTransactionRef tx)
 {
     SignatureData sigdata;
@@ -865,15 +888,16 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     t.vout[1].scriptPubKey = CScript() << OP_RETURN;
     CheckIsNotStandard(t, "multi-op-return");
 
-    // Check large scriptSig (non-standard if size is >1650 bytes)
+    // Check large scriptSig (non-standard if size is > MAX_STANDARD_SCRIPTSIG_SIZE)
     t.vout.resize(1);
     t.vout[0].nValue = MAX_MONEY;
     t.vout[0].scriptPubKey = GetScriptForDestination(PKHash(key.GetPubKey()));
-    // OP_PUSHDATA2 with len (3 bytes) + data (1647 bytes) = 1650 bytes
-    t.vin[0].scriptSig = CScript() << std::vector<unsigned char>(1647, 0); // 1650
+    t.vin[0].scriptSig.clear();
+    t.vin[0].scriptSig.resize(MAX_STANDARD_SCRIPTSIG_SIZE);
+    std::fill(t.vin[0].scriptSig.begin(), t.vin[0].scriptSig.end(), OP_0);
     CheckIsStandard(t);
 
-    t.vin[0].scriptSig = CScript() << std::vector<unsigned char>(1648, 0); // 1651
+    t.vin[0].scriptSig.push_back(OP_0);
     CheckIsNotStandard(t, "scriptsig-size");
 
     // Check scriptSig format (non-standard if there are any other ops than just PUSHs)
@@ -911,19 +935,19 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
 
     // Check tx-size (non-standard if transaction weight is > MAX_STANDARD_TX_WEIGHT)
     t.vin.clear();
-    t.vin.resize(2438); // size per input (empty scriptSig): 41 bytes
-    t.vout[0].scriptPubKey = CScript() << OP_RETURN << std::vector<unsigned char>(19, 0); // output size: 30 bytes
-    // tx header:                12 bytes =>     48 vbytes
-    // 2438 inputs: 2438*41 = 99958 bytes => 399832 vbytes
-    //    1 output:              30 bytes =>    120 vbytes
-    //                      ===============================
-    //                                total: 400000 vbytes
-    BOOST_CHECK_EQUAL(GetTransactionWeight(CTransaction(t)), 400000);
+    t.vin.resize(609); // size per input (empty scriptSig): 41 bytes
+    t.vout[0].scriptPubKey = CScript() << OP_RETURN << std::vector<unsigned char>(8, 0); // scriptPubKey size: 10 bytes
+    // tx header:          20 bytes
+    // 609 inputs: 609*41 = 24969 bytes
+    // 1 output script:    11 bytes
+    //                    =================
+    //                      25000 bytes * WITNESS_SCALE_FACTOR = MAX_STANDARD_TX_WEIGHT
+    BOOST_CHECK_EQUAL(GetTransactionWeight(CTransaction(t)), MAX_STANDARD_TX_WEIGHT);
     CheckIsStandard(t);
 
-    // increase output size by one byte, so we end up with 400004 vbytes
-    t.vout[0].scriptPubKey = CScript() << OP_RETURN << std::vector<unsigned char>(20, 0); // output size: 31 bytes
-    BOOST_CHECK_EQUAL(GetTransactionWeight(CTransaction(t)), 400004);
+    // Increase output size by one byte, so we exceed MAX_STANDARD_TX_WEIGHT.
+    t.vout[0].scriptPubKey = CScript() << OP_RETURN << std::vector<unsigned char>(9, 0); // scriptPubKey size: 11 bytes
+    BOOST_CHECK_EQUAL(GetTransactionWeight(CTransaction(t)), MAX_STANDARD_TX_WEIGHT + WITNESS_SCALE_FACTOR);
     CheckIsNotStandard(t, "tx-size");
 
     // Check bare multisig (standard if policy flag g_bare_multi is set)
@@ -937,64 +961,86 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     CheckIsNotStandard(t, "bare-multisig");
     g_bare_multi = DEFAULT_PERMIT_BAREMULTISIG;
 
+    const auto CheckDustBoundary = [&](const CScript& script_pub_key, const CAmount expected_threshold) {
+        t.vout[0].scriptPubKey = script_pub_key;
+        const CAmount dust_threshold{GetDustThreshold(t.vout[0], g_dust)};
+        BOOST_CHECK_EQUAL(dust_threshold, expected_threshold);
+        t.vout[0].nValue = dust_threshold;
+        CheckIsStandard(t);
+        t.vout[0].nValue = dust_threshold - 1;
+        CheckIsNotStandard(t, "dust");
+    };
+
     // Check compressed P2PK outputs dust threshold (must have leading 02 or 03)
-    t.vout[0].scriptPubKey = CScript() << std::vector<unsigned char>(33, 0x02) << OP_CHECKSIG;
-    t.vout[0].nValue = 576;
-    CheckIsStandard(t);
-    t.vout[0].nValue = 575;
-    CheckIsNotStandard(t, "dust");
+    CheckDustBoundary(CScript() << std::vector<unsigned char>(33, 0x02) << OP_CHECKSIG, 576);
 
     // Check uncompressed P2PK outputs dust threshold (must have leading 04/06/07)
-    t.vout[0].scriptPubKey = CScript() << std::vector<unsigned char>(65, 0x04) << OP_CHECKSIG;
-    t.vout[0].nValue = 672;
-    CheckIsStandard(t);
-    t.vout[0].nValue = 671;
-    CheckIsNotStandard(t, "dust");
+    CheckDustBoundary(CScript() << std::vector<unsigned char>(65, 0x04) << OP_CHECKSIG, 672);
 
     // Check P2PKH outputs dust threshold
-    t.vout[0].scriptPubKey = CScript() << OP_DUP << OP_HASH160 << std::vector<unsigned char>(20, 0) << OP_EQUALVERIFY << OP_CHECKSIG;
-    t.vout[0].nValue = 546;
-    CheckIsStandard(t);
-    t.vout[0].nValue = 545;
-    CheckIsNotStandard(t, "dust");
+    CheckDustBoundary(CScript() << OP_DUP << OP_HASH160 << std::vector<unsigned char>(20, 0) << OP_EQUALVERIFY << OP_CHECKSIG, 546);
 
     // Check P2SH outputs dust threshold
-    t.vout[0].scriptPubKey = CScript() << OP_HASH160 << std::vector<unsigned char>(20, 0) << OP_EQUAL;
-    t.vout[0].nValue = 540;
-    CheckIsStandard(t);
-    t.vout[0].nValue = 539;
-    CheckIsNotStandard(t, "dust");
+    CheckDustBoundary(CScript() << OP_HASH160 << std::vector<unsigned char>(20, 0) << OP_EQUAL, 540);
 
     // Check P2WPKH outputs dust threshold
-    t.vout[0].scriptPubKey = CScript() << OP_0 << std::vector<unsigned char>(20, 0);
-    t.vout[0].nValue = 294;
-    CheckIsStandard(t);
-    t.vout[0].nValue = 293;
-    CheckIsNotStandard(t, "dust");
+    CheckDustBoundary(CScript() << OP_0 << std::vector<unsigned char>(20, 0), 234);
 
     // Check P2WSH outputs dust threshold
-    t.vout[0].scriptPubKey = CScript() << OP_0 << std::vector<unsigned char>(32, 0);
-    t.vout[0].nValue = 330;
-    CheckIsStandard(t);
-    t.vout[0].nValue = 329;
-    CheckIsNotStandard(t, "dust");
+    CheckDustBoundary(CScript() << OP_0 << std::vector<unsigned char>(32, 0), 270);
 
     // Check P2TR outputs dust threshold (Invalid xonly key ok!)
-    t.vout[0].scriptPubKey = CScript() << OP_1 << std::vector<unsigned char>(32, 0);
-    t.vout[0].nValue = 330;
-    CheckIsStandard(t);
-    t.vout[0].nValue = 329;
-    CheckIsNotStandard(t, "dust");
+    CheckDustBoundary(CScript() << OP_1 << std::vector<unsigned char>(32, 0), 270);
 
     // Check future Witness Program versions dust threshold (non-32-byte pushes are undefined for version 1)
     for (int op = OP_1; op <= OP_16; op += 1) {
-        t.vout[0].scriptPubKey = CScript() << (opcodetype)op << std::vector<unsigned char>(2, 0);
-        t.vout[0].nValue = 240;
-        CheckIsStandard(t);
-
-        t.vout[0].nValue = 239;
-        CheckIsNotStandard(t, "dust");
+        CheckDustBoundary(CScript() << (opcodetype)op << std::vector<unsigned char>(2, 0), 180);
     }
+}
+
+BOOST_AUTO_TEST_CASE(test_IsWitnessStandard_stack_item_size_limits)
+{
+    CCoinsView coins_dummy;
+    CCoinsViewCache coins(&coins_dummy);
+    uint32_t prevout_index{0};
+
+    const auto check_witness_standard = [&](const CScript& prev_script, const CScriptWitness& witness) {
+        const COutPoint outpoint{uint256::ONE, prevout_index++};
+        coins.AddCoin(outpoint, Coin{CTxOut{1, prev_script}, 1, /*coinbase=*/false}, /*possible_overwrite=*/false);
+
+        CMutableTransaction tx;
+        tx.vin.emplace_back(outpoint);
+        tx.vin[0].scriptWitness = witness;
+        tx.vout.emplace_back(1, CScript() << OP_TRUE);
+        return IsWitnessStandard(CTransaction{tx}, coins);
+    };
+
+    const auto p2wsh_witness = [](size_t item_size) {
+        CScriptWitness witness;
+        const CScript witness_script{CScript() << OP_TRUE};
+        witness.stack.emplace_back(item_size, 0);
+        witness.stack.emplace_back(witness_script.begin(), witness_script.end());
+        return witness;
+    };
+    const CScript p2wsh_script = GetScriptForDestination(WitnessV0ScriptHash{CScript() << OP_TRUE});
+    BOOST_CHECK(check_witness_standard(p2wsh_script, p2wsh_witness(MAX_STANDARD_P2WSH_STACK_ITEM_SIZE)));
+    BOOST_CHECK(!check_witness_standard(p2wsh_script, p2wsh_witness(MAX_STANDARD_P2WSH_STACK_ITEM_SIZE + 1)));
+
+    const auto tapscript_witness = [](size_t item_size) {
+        CScriptWitness witness;
+        const CScript script{CScript() << OP_TRUE};
+        witness.stack.emplace_back(item_size, 0);
+        witness.stack.emplace_back(script.begin(), script.end());
+        witness.stack.push_back({TAPROOT_LEAF_TAPSCRIPT});
+        return witness;
+    };
+    const CScript taproot_script = CScript() << OP_1 << std::vector<unsigned char>(WITNESS_V1_TAPROOT_SIZE, 0);
+    BOOST_CHECK(check_witness_standard(taproot_script, tapscript_witness(MAX_STANDARD_TAPSCRIPT_STACK_ITEM_SIZE)));
+    BOOST_CHECK(!check_witness_standard(taproot_script, tapscript_witness(MAX_STANDARD_TAPSCRIPT_STACK_ITEM_SIZE + 1)));
+
+    const CScript p2mr_script = CScript() << OP_2 << std::vector<unsigned char>(WITNESS_V2_P2MR_SIZE, 0);
+    BOOST_CHECK(check_witness_standard(p2mr_script, tapscript_witness(MAX_STANDARD_TAPSCRIPT_STACK_ITEM_SIZE)));
+    BOOST_CHECK(!check_witness_standard(p2mr_script, tapscript_witness(MAX_STANDARD_TAPSCRIPT_STACK_ITEM_SIZE + 1)));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -276,7 +276,7 @@ TestChain100Setup::TestChain100Setup(
         const bool block_tree_db_in_memory)
     : TestingSetup{ChainType::BTQREGTEST, extra_args, coins_db_in_memory, block_tree_db_in_memory}
 {
-    SetMockTime(1598887952);
+    SetMockTime(Params().GenesisBlock().GetBlockTime() + Params().GetConsensus().nPowTargetSpacing);
     constexpr std::array<unsigned char, 32> vchKey = {
         {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}};
     coinbaseKey.Set(vchKey.begin(), vchKey.end(), true);
@@ -286,9 +286,13 @@ TestChain100Setup::TestChain100Setup(
 
     {
         LOCK(::cs_main);
-        assert(
-            m_node.chainman->ActiveChain().Tip()->GetBlockHash().ToString() ==
-            "571d80a9967ae599cec0448b0b0ba1cfb606f584d8069bd7166b86854ba7a191");
+        const CChain& active_chain{m_node.chainman->ActiveChain()};
+        const CBlockIndex* tip{active_chain.Tip()};
+        assert(tip);
+        assert(active_chain.Height() == COINBASE_MATURITY);
+        assert(tip->GetBlockTime() - Params().GenesisBlock().GetBlockTime() ==
+               COINBASE_MATURITY * Params().GetConsensus().nPowTargetSpacing);
+        assert(tip->GetBlockTime() <= GetTime());
     }
 }
 
@@ -298,7 +302,7 @@ void TestChain100Setup::mineBlocks(int num_blocks)
     for (int i = 0; i < num_blocks; i++) {
         std::vector<CMutableTransaction> noTxns;
         CBlock b = CreateAndProcessBlock(noTxns, scriptPubKey);
-        SetMockTime(GetTime() + 1);
+        SetMockTime(GetTime() + Params().GetConsensus().nPowTargetSpacing);
         m_coinbase_txns.push_back(b.vtx[0]);
     }
 }

--- a/src/wallet/crypter.cpp
+++ b/src/wallet/crypter.cpp
@@ -7,8 +7,10 @@
 #include <common/system.h>
 #include <crypto/aes.h>
 #include <crypto/sha512.h>
+#include <hash.h>
 // #include <crypto/dilithium_key.h> // Temporarily disabled
 
+#include <algorithm>
 #include <vector>
 
 namespace wallet {
@@ -148,6 +150,38 @@ bool DecryptKey(const CKeyingMaterial& vMasterKey, const std::vector<unsigned ch
 }
 
 // Dilithium key encryption/decryption functions
+uint256 DeriveDilithiumKeyIV(const CKeyID& keyid)
+{
+    return Hash(Span{keyid});
+}
+
+static uint256 DeriveLegacyDilithiumKeyIV(const CKeyID& keyid)
+{
+    uint256 iv;
+    std::copy(keyid.begin(), keyid.end(), iv.begin());
+    return iv;
+}
+
+static bool SetDilithiumKeyFromSecret(const CKeyingMaterial& secret, const CKeyID& keyid, CDilithiumKey& key)
+{
+    if (secret.size() != CDilithiumKey::GetKeySize()) {
+        return false;
+    }
+
+    CDilithiumKey candidate;
+    candidate.Set(secret.begin(), secret.end());
+    if (!candidate.IsValid() || CKeyID(candidate.GetPubKey().GetID()) != keyid) {
+        return false;
+    }
+    std::vector<unsigned char> signature;
+    if (!candidate.Sign(uint256::ONE, signature) || !candidate.GetPubKey().Verify(uint256::ONE, signature)) {
+        return false;
+    }
+
+    key = candidate;
+    return true;
+}
+
 bool EncryptDilithiumSecret(const CKeyingMaterial& vMasterKey, const CKeyingMaterial &vchPlaintext, const uint256& nIV, std::vector<unsigned char> &vchCiphertext)
 {
     CCrypter cKeyCrypter;
@@ -171,17 +205,13 @@ bool DecryptDilithiumSecret(const CKeyingMaterial& vMasterKey, const std::vector
 bool DecryptDilithiumKey(const CKeyingMaterial& vMasterKey, const std::vector<unsigned char>& vchCryptedSecret, const CKeyID& keyid, CDilithiumKey& key)
 {
     CKeyingMaterial vchSecret;
-    if(!DecryptDilithiumSecret(vMasterKey, vchCryptedSecret, KeyIDToIV(keyid), vchSecret))
-        return false;
-
-    // Dilithium keys are much larger than ECDSA keys
-    if (vchSecret.size() != CDilithiumKey::GetKeySize())
-        return false;
-
-    key.Set(vchSecret.begin(), vchSecret.end());
-    if (!key.IsValid()) {
-        return false;
+    if (DecryptDilithiumSecret(vMasterKey, vchCryptedSecret, DeriveDilithiumKeyIV(keyid), vchSecret) &&
+        SetDilithiumKeyFromSecret(vchSecret, keyid, key)) {
+        return true;
     }
-    return CKeyID(key.GetPubKey().GetID()) == keyid;
+
+    vchSecret.clear();
+    return DecryptDilithiumSecret(vMasterKey, vchCryptedSecret, DeriveLegacyDilithiumKeyIV(keyid), vchSecret) &&
+           SetDilithiumKeyFromSecret(vchSecret, keyid, key);
 }
 } // namespace wallet

--- a/src/wallet/crypter.h
+++ b/src/wallet/crypter.h
@@ -113,6 +113,7 @@ bool DecryptKey(const CKeyingMaterial& vMasterKey, const std::vector<unsigned ch
 uint256 KeyIDToIV(const CKeyID& id);
 
 // Dilithium key encryption/decryption functions
+uint256 DeriveDilithiumKeyIV(const CKeyID& keyid);
 bool EncryptDilithiumSecret(const CKeyingMaterial& vMasterKey, const CKeyingMaterial &vchPlaintext, const uint256& nIV, std::vector<unsigned char> &vchCiphertext);
 bool DecryptDilithiumSecret(const CKeyingMaterial& vMasterKey, const std::vector<unsigned char>& vchCiphertext, const uint256& nIV, CKeyingMaterial& vchPlaintext);
 bool DecryptDilithiumKey(const CKeyingMaterial& vMasterKey, const std::vector<unsigned char>& vchCryptedSecret, const CKeyID& keyid, CDilithiumKey& key);

--- a/src/wallet/dilithium_wallet_manager.cpp
+++ b/src/wallet/dilithium_wallet_manager.cpp
@@ -77,9 +77,7 @@ util::Result<CTxDestination> DilithiumWalletManager::GetNewDilithiumAddress(Outp
 {
     // Generate a new Dilithium key
     CDilithiumKey dilithium_key;
-    dilithium_key.MakeNewKey();
-    
-    if (!dilithium_key.IsValid()) {
+    if (!dilithium_key.MakeNewKey() || !dilithium_key.IsValid()) {
         return util::Error{_("Error: Failed to generate Dilithium key")};
     }
     
@@ -95,12 +93,7 @@ util::Result<CTxDestination> DilithiumWalletManager::GetNewDilithiumAddress(Outp
             return util::Error{_("Error: Failed to store Dilithium key")};
         }
     } else if (type == OutputType::DILITHIUM_BECH32) {
-        dest = DilithiumWitnessV0KeyHash(dilithium_pubkey);
-        // Store using legacy key ID for compatibility
-        DilithiumLegacyKeyID legacy_id(dilithium_pubkey);
-        if (!AddDilithiumKeyLegacy(dilithium_key, legacy_id)) {
-            return util::Error{_("Error: Failed to store Dilithium key")};
-        }
+        return util::Error{_("Error: dilithium-bech32 is disabled because witness v0 keyhash programs are indistinguishable from ECDSA P2WPKH and are not spendable with Dilithium keys")};
     } else {
         return util::Error{_("Error: Unsupported Dilithium output type")};
     }

--- a/src/wallet/feebumper.h
+++ b/src/wallet/feebumper.h
@@ -6,8 +6,10 @@
 #define BTQ_WALLET_FEEBUMPER_H
 
 #include <consensus/consensus.h>
-#include <script/interpreter.h>
+#include <crypto/dilithium_key.h>
 #include <primitives/transaction.h>
+#include <pubkey.h>
+#include <script/interpreter.h>
 
 class uint256;
 enum class FeeEstimateMode;
@@ -75,31 +77,31 @@ Result CommitTransaction(CWallet& wallet,
 struct SignatureWeights
 {
 private:
-    int m_sigs_count{0};
+    int64_t m_max_sigs_weight{0};
     int64_t m_sigs_weight{0};
 
 public:
-    void AddSigWeight(const size_t weight, const SigVersion sigversion)
+    void AddSigWeight(const size_t weight, const SigVersion sigversion, const size_t max_weight = CPubKey::SIGNATURE_SIZE)
     {
+        int64_t scale{0};
         switch (sigversion) {
         case SigVersion::BASE:
-            m_sigs_weight += weight * WITNESS_SCALE_FACTOR;
-            m_sigs_count += 1 * WITNESS_SCALE_FACTOR;
+            scale = WITNESS_SCALE_FACTOR;
             break;
         case SigVersion::WITNESS_V0:
-            m_sigs_weight += weight;
-            m_sigs_count++;
-            break;
         case SigVersion::TAPROOT:
         case SigVersion::TAPSCRIPT:
-            assert(false);
+        case SigVersion::P2MR_TAPSCRIPT:
+            scale = 1;
+            break;
         }
+        m_sigs_weight += weight * scale;
+        m_max_sigs_weight += max_weight * scale;
     }
 
     int64_t GetWeightDiffToMax() const
     {
-        // Note: the witness scaling factor is already accounted for because the count is multiplied by it.
-        return (/* max signature size=*/ 72 * m_sigs_count) - m_sigs_weight;
+        return m_max_sigs_weight - m_sigs_weight;
     }
 };
 
@@ -115,6 +117,24 @@ public:
     {
         if (m_checker.CheckECDSASignature(sig, pubkey, script, sigversion)) {
             m_weights.AddSigWeight(sig.size(), sigversion);
+            return true;
+        }
+        return false;
+    }
+
+    bool CheckSchnorrSignature(Span<const unsigned char> sig, Span<const unsigned char> pubkey, SigVersion sigversion, ScriptExecutionData& execdata, ScriptError* serror = nullptr) const override
+    {
+        if (m_checker.CheckSchnorrSignature(sig, pubkey, sigversion, execdata, serror)) {
+            m_weights.AddSigWeight(sig.size(), sigversion, /* max_weight=*/65);
+            return true;
+        }
+        return false;
+    }
+
+    bool CheckDilithiumSignature(const std::vector<unsigned char>& sig, const std::vector<unsigned char>& pubkey, const CScript& script, SigVersion sigversion) const override
+    {
+        if (m_checker.CheckDilithiumSignature(sig, pubkey, script, sigversion)) {
+            m_weights.AddSigWeight(sig.size(), sigversion, DilithiumConstants::SIGNATURE_SIZE + 1);
             return true;
         }
         return false;

--- a/src/wallet/key_types.h
+++ b/src/wallet/key_types.h
@@ -66,19 +66,20 @@ public:
         return std::visit([](const auto& key) { return key.IsValid(); }, m_key);
     }
     
-    // Generate new key
-    void MakeNewKey(KeyType type, bool fCompressed = true) {
+    // Generate new key. Returns false if key generation failed (e.g. RNG failure);
+    // the resulting key is then invalid.
+    bool MakeNewKey(KeyType type, bool fCompressed = true) {
         m_type = type;
         switch (type) {
             case KeyType::ECDSA:
                 m_key = ECDSAKey{};
                 std::get<ECDSAKey>(m_key).MakeNewKey(fCompressed);
-                break;
+                return std::get<ECDSAKey>(m_key).IsValid();
             case KeyType::DILITHIUM:
                 m_key = DilithiumKey{};
-                std::get<DilithiumKey>(m_key).MakeNewKey();
-                break;
+                return std::get<DilithiumKey>(m_key).MakeNewKey();
         }
+        return false;
     }
     
     // Get public key

--- a/src/wallet/p2mr.cpp
+++ b/src/wallet/p2mr.cpp
@@ -7,6 +7,7 @@
 #include <core_io.h>
 #include <interfaces/chain.h>
 #include <key_io.h>
+#include <policy/policy.h>
 #include <rpc/protocol.h>
 #include <rpc/request.h>
 #include <rpc/util.h>
@@ -24,6 +25,7 @@
 #include <wallet/walletdb.h>
 
 #include <algorithm>
+#include <set>
 
 namespace wallet {
 
@@ -67,6 +69,17 @@ UniValue BuildMetadataJSON(const std::string& id,
 bool DecodeMetadata(const std::string& raw, UniValue& out)
 {
     return out.read(raw) && out.isObject();
+}
+
+bool SameP2MRTree(const std::vector<P2MRTreeLeaf>& a, const std::vector<P2MRTreeLeaf>& b)
+{
+    if (a.size() != b.size()) return false;
+    for (size_t i = 0; i < a.size(); ++i) {
+        if (a[i].depth != b[i].depth) return false;
+        if (a[i].leaf_version != b[i].leaf_version) return false;
+        if (a[i].script != b[i].script) return false;
+    }
+    return true;
 }
 
 P2MREntry MetadataToEntry(const CTxDestination& dest, const UniValue& meta, const std::string& fallback_id)
@@ -140,6 +153,7 @@ util::Result<std::vector<P2MRTreeLeaf>> ParseP2MRTreeChecked(const UniValue& tre
         }
         if (depth < 0 || depth > 128) return util::Error{Untranslated("depth out of range")};
         if (leaf_version < 0 || leaf_version > 255) return util::Error{Untranslated("leaf_version out of range")};
+        if ((leaf_version & ~TAPROOT_LEAF_MASK) != 0) return util::Error{Untranslated("leaf_version parity bit must be unset")};
         auto script = TryParseHex<unsigned char>(script_hex);
         if (!script) return util::Error{Untranslated("script must be valid hex")};
 
@@ -166,12 +180,18 @@ util::Result<P2MRBuilder> BuildP2MRTreeChecked(const std::vector<P2MRTreeLeaf>& 
     }
     P2MRBuilder builder;
     for (const auto& leaf : leaves) {
+        if (leaf.depth > P2MR_CONTROL_MAX_NODE_COUNT) {
+            return util::Error{Untranslated("depth out of range")};
+        }
+        if ((leaf.leaf_version & ~TAPROOT_LEAF_MASK) != 0) {
+            return util::Error{Untranslated("leaf_version parity bit must be unset")};
+        }
         builder.Add(leaf.depth, leaf.script, leaf.leaf_version);
     }
-    builder.Finalize();
     if (!builder.IsValid() || !builder.IsComplete()) {
         return util::Error{Untranslated("invalid P2MR tree, verify DFS order and depths")};
     }
+    builder.Finalize();
     return builder;
 }
 
@@ -261,7 +281,9 @@ CAmount GetTrackedP2MRBalance(const CWallet& wallet, int min_depth)
 {
     AssertLockHeld(wallet.cs_wallet);
     CAmount total{0};
+    std::set<CScript> counted_scripts;
     for (const auto& entry : ListP2MR(wallet)) {
+        if (!counted_scripts.insert(entry.script_pub_key).second) continue;
         total += SumUnspentForScript(wallet, entry.script_pub_key, min_depth);
     }
     return total;
@@ -282,10 +304,20 @@ util::Result<P2MRCreated> CreateP2MR(CWallet& wallet,
     out.dest = builder.GetOutput();
     out.script_pub_key = GetScriptForDestination(out.dest);
     out.address = EncodeDestination(out.dest);
-    out.id = NewP2MRId();
     const WitnessV2P2MR& w = std::get<WitnessV2P2MR>(out.dest);
     std::copy(w.begin(), w.end(), out.merkle_root.begin());
 
+    for (const auto& entry : ListP2MR(wallet)) {
+        if (entry.script_pub_key == out.script_pub_key && SameP2MRTree(entry.tree, leaves)) {
+            out.id = entry.id;
+            out.address = entry.address;
+            out.merkle_root = entry.merkle_root;
+            out.dest = entry.dest;
+            return out;
+        }
+    }
+
+    out.id = NewP2MRId();
     const UniValue meta = BuildMetadataJSON(out.id, out.address, out.script_pub_key, out.merkle_root, label, leaves);
 
     WalletBatch batch(wallet.GetDatabase(), /*fFlushOnClose=*/false);
@@ -422,10 +454,8 @@ util::Result<P2MRSpendSigned> SignP2MRTransaction(const CWallet& wallet,
             continue;
         }
 
-        // Fallback: if the builder produced exactly one tapscript leaf with control
-        // block, finalize directly. This mirrors the previous RPC behavior so the
-        // OP_TRUE template (and any single-leaf script) signs cleanly without a
-        // SignatureChecker round-trip.
+        // Fallback for no-argument scripts such as OP_TRUE. Only report completion
+        // after verifying the assembled witness against the actual transaction.
         bool fallback_ok = false;
         if (!solutions.empty() && solutions[0].size() == WitnessV2P2MR::SIZE) {
             const WitnessV2P2MR p2mr_output{solutions[0]};
@@ -438,7 +468,18 @@ util::Result<P2MRSpendSigned> SignP2MRTransaction(const CWallet& wallet,
                     out.tx.vin[i].scriptWitness.stack.clear();
                     out.tx.vin[i].scriptWitness.stack.emplace_back(script.begin(), script.end());
                     out.tx.vin[i].scriptWitness.stack.push_back(*control_blocks.begin());
-                    fallback_ok = true;
+                    std::vector<CTxOut> spent_outputs;
+                    spent_outputs.reserve(out.tx.vin.size());
+                    for (const CTxIn& txin : out.tx.vin) {
+                        const auto coin_it = coins.find(txin.prevout);
+                        spent_outputs.push_back(coin_it != coins.end() && !coin_it->second.IsSpent() ? coin_it->second.out : CTxOut{});
+                    }
+                    PrecomputedTransactionData txdata;
+                    txdata.Init(out.tx, std::move(spent_outputs), /*force=*/true);
+                    const CTransaction tx_const{out.tx};
+                    TransactionSignatureChecker checker(&tx_const, i, it->second.out.nValue, txdata, MissingDataBehavior::FAIL);
+                    fallback_ok = VerifyScript(out.tx.vin[i].scriptSig, it->second.out.scriptPubKey, &out.tx.vin[i].scriptWitness, STANDARD_SCRIPT_VERIFY_FLAGS, checker);
+                    if (!fallback_ok) out.tx.vin[i].scriptWitness.stack.clear();
                 }
             }
         }

--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -82,6 +82,18 @@ static bool GetWalletAddressesForKey(const LegacyScriptPubKeyMan* spk_man, const
     return fLabelFound;
 }
 
+static bool GetWalletAddressForDilithiumKey(const CWallet& wallet, const CKeyID& keyid, std::string& strAddr, std::string& strLabel) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
+{
+    const CTxDestination dest{DilithiumPKHash(keyid)};
+    strAddr = EncodeDestination(dest);
+    const auto* address_book_entry = wallet.FindAddressBookEntry(dest);
+    if (!address_book_entry) {
+        return false;
+    }
+    strLabel = EncodeDumpString(address_book_entry->GetLabel());
+    return true;
+}
+
 static const int64_t TIMESTAMP_MIN = 0;
 
 static void RescanWallet(CWallet& wallet, const WalletRescanReserver& reserver, int64_t time_begin = TIMESTAMP_MIN, bool update = true)
@@ -196,7 +208,7 @@ RPCHelpMan importprivkey()
         if (is_dilithium) {
             CDilithiumPubKey dilithium_pubkey = dilithium_key.GetPubKey();
             pubkey = CPubKey(dilithium_pubkey.begin(), dilithium_pubkey.end());
-            vchAddress = pubkey.GetID();
+            vchAddress = CKeyID(dilithium_pubkey.GetID());
         } else {
             pubkey = key.GetPubKey();
             CHECK_NONFATAL(key.VerifyPubKey(pubkey));
@@ -208,9 +220,16 @@ RPCHelpMan importprivkey()
             // We don't know which corresponding address will be used;
             // label all new addresses, and label existing addresses if a
             // label was passed.
-            for (const auto& dest : GetAllDestinationsForKey(pubkey)) {
+            if (is_dilithium) {
+                const CTxDestination dest{DilithiumPKHash(vchAddress)};
                 if (!request.params[1].isNull() || !pwallet->FindAddressBookEntry(dest)) {
                     pwallet->SetAddressBook(dest, strLabel, AddressPurpose::RECEIVE);
+                }
+            } else {
+                for (const auto& dest : GetAllDestinationsForKey(pubkey)) {
+                    if (!request.params[1].isNull() || !pwallet->FindAddressBookEntry(dest)) {
+                        pwallet->SetAddressBook(dest, strLabel, AddressPurpose::RECEIVE);
+                    }
                 }
             }
 
@@ -227,7 +246,7 @@ RPCHelpMan importprivkey()
             }
 
             // Add the wpkh script for this key if possible
-            if (pubkey.IsCompressed()) {
+            if (!is_dilithium && pubkey.IsCompressed()) {
                 pwallet->ImportScripts({GetScriptForDestination(WitnessV0KeyHash(vchAddress))}, /*timestamp=*/0);
             }
         }
@@ -572,6 +591,7 @@ RPCHelpMan importwallet()
         // we don't want for this progress bar showing the import progress. uiInterface.ShowProgress does not have a cancel button.
         pwallet->chain().showProgress(strprintf("%s " + _("Importing…").translated, pwallet->GetDisplayName()), 0, false); // show progress dialog in GUI
         std::vector<std::tuple<CKey, int64_t, bool, std::string>> keys;
+        std::vector<std::tuple<CDilithiumKey, int64_t, bool, std::string>> dilithium_keys;
         std::vector<std::pair<CScript, int64_t>> scripts;
         while (file.good()) {
             pwallet->chain().showProgress("", std::max(1, std::min(50, (int)(((double)file.tellg() / (double)nFilesize) * 100))), false);
@@ -602,6 +622,24 @@ RPCHelpMan importwallet()
                 }
                 nTimeBegin = std::min(nTimeBegin, nTime);
                 keys.emplace_back(key, nTime, fLabel, strLabel);
+            } else if (CDilithiumKey dilithium_key = DecodeDilithiumSecret(vstr[0]); dilithium_key.IsValid()) {
+                int64_t nTime = ParseISO8601DateTime(vstr[1]);
+                std::string strLabel;
+                bool fLabel = true;
+                for (unsigned int nStr = 2; nStr < vstr.size(); nStr++) {
+                    if (vstr[nStr].front() == '#')
+                        break;
+                    if (vstr[nStr] == "change=1")
+                        fLabel = false;
+                    if (vstr[nStr] == "reserve=1")
+                        fLabel = false;
+                    if (vstr[nStr].substr(0,6) == "label=") {
+                        strLabel = DecodeDumpString(vstr[nStr].substr(6));
+                        fLabel = true;
+                    }
+                }
+                nTimeBegin = std::min(nTimeBegin, nTime);
+                dilithium_keys.emplace_back(dilithium_key, nTime, fLabel, strLabel);
             } else if(IsHex(vstr[0])) {
                 std::vector<unsigned char> vData(ParseHex(vstr[0]));
                 CScript script = CScript(vData.begin(), vData.end());
@@ -613,11 +651,11 @@ RPCHelpMan importwallet()
         file.close();
         EnsureBlockDataFromTime(*pwallet, nTimeBegin);
         // We now know whether we are importing private keys, so we can error if private keys are disabled
-        if (keys.size() > 0 && pwallet->IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS)) {
+        if ((!keys.empty() || !dilithium_keys.empty()) && pwallet->IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS)) {
             pwallet->chain().showProgress("", 100, false); // hide progress dialog in GUI
             throw JSONRPCError(RPC_WALLET_ERROR, "Importing wallets is disabled when private keys are disabled");
         }
-        double total = (double)(keys.size() + scripts.size());
+        double total = (double)(keys.size() + dilithium_keys.size() + scripts.size());
         double progress = 0;
         for (const auto& key_tuple : keys) {
             pwallet->chain().showProgress("", std::max(50, std::min(75, (int)((progress / total) * 100) + 50)), false);
@@ -640,6 +678,34 @@ RPCHelpMan importwallet()
 
             if (has_label)
                 pwallet->SetAddressBook(PKHash(keyid), label, AddressPurpose::RECEIVE);
+            progress++;
+        }
+        LegacyScriptPubKeyMan* spk_man = pwallet->GetLegacyScriptPubKeyMan();
+        for (const auto& key_tuple : dilithium_keys) {
+            pwallet->chain().showProgress("", std::max(50, std::min(75, (int)((progress / total) * 100) + 50)), false);
+            const CDilithiumKey& key = std::get<0>(key_tuple);
+            int64_t time = std::get<1>(key_tuple);
+            bool has_label = std::get<2>(key_tuple);
+            std::string label = std::get<3>(key_tuple);
+
+            const CDilithiumPubKey pubkey = key.GetPubKey();
+            const CKeyID keyid{pubkey.GetID()};
+
+            pwallet->WalletLogPrintf("Importing %s...\n", EncodeDestination(DilithiumPKHash(keyid)));
+
+            {
+                LOCK(spk_man->cs_KeyStore);
+                spk_man->mapKeyMetadata[keyid].nCreateTime = time;
+            }
+            if (!spk_man->AddDilithiumKeyPubKey(key, CPubKey(pubkey.begin(), pubkey.end()))) {
+                pwallet->WalletLogPrintf("Error importing Dilithium key for %s\n", EncodeDestination(DilithiumPKHash(keyid)));
+                fGood = false;
+                continue;
+            }
+
+            if (has_label) {
+                pwallet->SetAddressBook(DilithiumPKHash(keyid), label, AddressPurpose::RECEIVE);
+            }
             progress++;
         }
         for (const auto& script_pair : scripts) {
@@ -846,6 +912,19 @@ RPCHelpMan dumpwallet()
                 file << "change=1";
             }
             file << strprintf(" # addr=%s%s\n", strAddr, (metadata.has_key_origin ? " hdkeypath="+WriteHDKeypath(metadata.key_origin.path, /*apostrophe=*/true) : ""));
+        } else if (CDilithiumKey dilithium_key; spk_man.GetDilithiumKey(keyid, dilithium_key)) {
+            CKeyMetadata metadata;
+            const auto it{spk_man.mapKeyMetadata.find(keyid)};
+            if (it != spk_man.mapKeyMetadata.end()) metadata = it->second;
+            file << strprintf("%s %s ", EncodeDilithiumSecret(dilithium_key), strTime);
+            if (GetWalletAddressForDilithiumKey(wallet, keyid, strAddr, strLabel)) {
+                file << strprintf("label=%s", strLabel);
+            } else if (metadata.hdKeypath == "s") {
+                file << "inactivehdseed=1";
+            } else {
+                file << "change=1";
+            }
+            file << strprintf(" # addr=%s%s\n", strAddr, (metadata.has_key_origin ? " hdkeypath="+WriteHDKeypath(metadata.key_origin.path, /*apostrophe=*/true) : ""));
         }
     }
     file << "\n";
@@ -965,6 +1044,7 @@ static std::string RecurseImportData(const CScript& script, ImportData& import_d
     case TxoutType::NONSTANDARD:
     case TxoutType::WITNESS_UNKNOWN:
     case TxoutType::WITNESS_V1_TAPROOT:
+    case TxoutType::WITNESS_V2_P2MR:
         return "unrecognized script";
     } // no default case, so the compiler can warn about missing cases
     NONFATAL_UNREACHABLE();

--- a/src/wallet/rpc/dilithium.cpp
+++ b/src/wallet/rpc/dilithium.cpp
@@ -228,6 +228,12 @@ RPCHelpMan getnewdilithiumaddress()
                 }
                 output_type = *parsed;
             }
+            if (output_type == OutputType::BECH32 || output_type == OutputType::DILITHIUM_BECH32) {
+                throw JSONRPCError(RPC_WALLET_ERROR, "dilithium-bech32 is disabled because witness v0 keyhash programs are indistinguishable from ECDSA P2WPKH and are not spendable with Dilithium keys");
+            }
+            if (output_type != OutputType::LEGACY && output_type != OutputType::DILITHIUM_LEGACY && output_type != OutputType::P2SH_SEGWIT) {
+                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, strprintf("Unsupported Dilithium address type '%s'", request.params[1].isNull() ? "legacy" : request.params[1].get_str()));
+            }
 
             std::string address;
             if (output_type == OutputType::P2SH_SEGWIT) {
@@ -252,15 +258,11 @@ RPCHelpMan getnewdilithiumaddress()
                     wallet->SetAddressBook(DecodeDestination(address), label, AddressPurpose::RECEIVE);
                 }
             } else {
-                const OutputType dil_type = (output_type == OutputType::BECH32)
-                    ? OutputType::DILITHIUM_BECH32
-                    : OutputType::DILITHIUM_LEGACY;
+                const OutputType dil_type = OutputType::DILITHIUM_LEGACY;
                 util::Result<CTxDestination> dest = util::Error{Untranslated("")};
                 if (wallet->IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS)) {
                     // Descriptor wallets register spk managers under classical output types.
-                    const OutputType spkm_type = (output_type == OutputType::BECH32)
-                        ? OutputType::BECH32
-                        : OutputType::LEGACY;
+                    const OutputType spkm_type = OutputType::LEGACY;
                     ScriptPubKeyMan* spk_man = wallet->GetScriptPubKeyMan(spkm_type, /*internal=*/false);
                     if (!spk_man) {
                         throw JSONRPCError(RPC_WALLET_ERROR, "No active ScriptPubKeyMan for Dilithium address generation");
@@ -655,4 +657,3 @@ RPCHelpMan signtransactionwithdilithium()
 }
 
 } // namespace wallet
-

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -31,7 +31,10 @@ const uint32_t BIP32_HARDENED_KEY_LIMIT = 0x80000000;
 util::Result<CTxDestination> LegacyScriptPubKeyMan::GetNewDestination(const OutputType type)
 {
     if (LEGACY_OUTPUT_TYPES.count(type) == 0) {
-        return util::Error{_("Error: Legacy wallets only support the \"legacy\", \"p2sh-segwit\", \"bech32\", \"dilithium-legacy\", and \"dilithium-bech32\" address types")};
+        if (type == OutputType::DILITHIUM_BECH32) {
+            return util::Error{_("Error: dilithium-bech32 is disabled because witness v0 keyhash programs are indistinguishable from ECDSA P2WPKH and are not spendable with Dilithium keys")};
+        }
+        return util::Error{_("Error: Legacy wallets only support the \"legacy\", \"p2sh-segwit\", \"bech32\", and \"dilithium-legacy\" address types")};
     }
     assert(type != OutputType::BECH32M);
 
@@ -41,7 +44,7 @@ util::Result<CTxDestination> LegacyScriptPubKeyMan::GetNewDestination(const Outp
     LOCK(cs_KeyStore);
 
     // Handle Dilithium output types
-    if (type == OutputType::DILITHIUM_LEGACY || type == OutputType::DILITHIUM_BECH32) {
+    if (type == OutputType::DILITHIUM_LEGACY) {
         if (!CanGenerateKeys()) {
             return util::Error{_("Error: Keypool ran out, please call keypoolrefill first")};
         }
@@ -52,11 +55,7 @@ util::Result<CTxDestination> LegacyScriptPubKeyMan::GetNewDestination(const Outp
         }
 
         CTxDestination dest;
-        if (type == OutputType::DILITHIUM_LEGACY) {
-            dest = DilithiumPKHash(dilithium_pubkey);
-        } else {
-            dest = DilithiumWitnessV0KeyHash(dilithium_pubkey);
-        }
+        dest = DilithiumPKHash(dilithium_pubkey);
         return dest;
     }
 
@@ -295,8 +294,9 @@ bool LegacyScriptPubKeyMan::CheckDecryptionKey(const CKeyingMaterial& master_key
     {
         LOCK(cs_KeyStore);
         assert(mapKeys.empty());
+        assert(mapDilithiumKeys.empty());
 
-        bool keyPass = mapCryptedKeys.empty(); // Always pass when there are no encrypted keys
+        bool keyPass = mapCryptedKeys.empty() && mapCryptedDilithiumKeys.empty(); // Always pass when there are no encrypted keys
         bool keyFail = false;
         CryptedKeyMap::const_iterator mi = mapCryptedKeys.begin();
         WalletBatch batch(m_storage.GetDatabase());
@@ -316,6 +316,22 @@ bool LegacyScriptPubKeyMan::CheckDecryptionKey(const CKeyingMaterial& master_key
             else {
                 // Rewrite these encrypted keys with checksums
                 batch.WriteCryptedKey(vchPubKey, vchCryptedSecret, mapKeyMetadata[vchPubKey.GetID()]);
+            }
+        }
+        for (const auto& entry : mapCryptedDilithiumKeys) {
+            if (fDecryptionThoroughlyChecked && keyPass) {
+                break;
+            }
+            const CKeyID& keyID = entry.first;
+            const std::vector<unsigned char>& vchCryptedSecret = entry.second.second;
+            CDilithiumKey key;
+            if (!DecryptDilithiumKey(master_key, vchCryptedSecret, keyID, key)) {
+                keyFail = true;
+                break;
+            }
+            keyPass = true;
+            if (!fDecryptionThoroughlyChecked) {
+                batch.WriteCryptedDilithiumKeyByID(keyID, vchCryptedSecret, mapKeyMetadata[keyID]);
             }
         }
         if (keyPass && keyFail)
@@ -379,27 +395,24 @@ bool LegacyScriptPubKeyMan::Encrypt(const CKeyingMaterial& master_key, WalletBat
             return false;
         }
     }
-
-    DilithiumKeyMap dilithium_keys_to_encrypt = mapDilithiumKeys;
-    for (const DilithiumKeyMap::value_type& mKey : dilithium_keys_to_encrypt)
-    {
-        const CKeyID& keyID = mKey.first;
-        const CDilithiumKey& dilithium_key = mKey.second;
-        CKeyingMaterial vchSecret(dilithium_key.begin(), dilithium_key.end());
+    DilithiumKeyMap dilithium_keys_to_encrypt;
+    dilithium_keys_to_encrypt.swap(mapDilithiumKeys);
+    for (const auto& entry : dilithium_keys_to_encrypt) {
+        const CKeyID& keyID = entry.first;
+        const CDilithiumKey& key = entry.second;
+        CKeyingMaterial vchSecret(key.begin(), key.end());
         std::vector<unsigned char> vchCryptedSecret;
-        if (!EncryptDilithiumSecret(master_key, vchSecret, KeyIDToIV(keyID), vchCryptedSecret)) {
+        if (!EncryptDilithiumSecret(master_key, vchSecret, DeriveDilithiumKeyIV(keyID), vchCryptedSecret)) {
             encrypted_batch = nullptr;
             return false;
         }
         mapCryptedDilithiumKeys[keyID] = make_pair(CPubKey(), vchCryptedSecret);
         const CKeyMetadata meta = mapKeyMetadata.count(keyID) ? mapKeyMetadata.at(keyID) : CKeyMetadata(GetTime());
-        if (!encrypted_batch->WriteCryptedDilithiumKeyByID(keyID, vchCryptedSecret, meta)) {
+        if (encrypted_batch && !encrypted_batch->WriteCryptedDilithiumKeyByID(keyID, vchCryptedSecret, meta)) {
             encrypted_batch = nullptr;
             return false;
         }
-        mapDilithiumKeys.erase(keyID);
     }
-
     encrypted_batch = nullptr;
     return true;
 }
@@ -1036,7 +1049,7 @@ bool LegacyScriptPubKeyMan::AddDilithiumKeyPubKeyInner(const CDilithiumKey& key,
     std::vector<unsigned char> vchCryptedSecret;
     CKeyingMaterial vchSecret(key.begin(), key.end());
     // Use the Dilithium key ID for encryption salt
-    if (!EncryptDilithiumSecret(m_storage.GetEncryptionKey(), vchSecret, KeyIDToIV(keyID), vchCryptedSecret)) {
+    if (!EncryptDilithiumSecret(m_storage.GetEncryptionKey(), vchSecret, DeriveDilithiumKeyIV(keyID), vchCryptedSecret)) {
         return false;
     }
 
@@ -1116,6 +1129,10 @@ bool LegacyScriptPubKeyMan::GetDilithiumKey(const CKeyID &address, CDilithiumKey
         return false;
     }
 
+    if (m_storage.IsLocked()) {
+        return false;
+    }
+
     CryptedDilithiumKeyMap::const_iterator mi = mapCryptedDilithiumKeys.find(address);
     if (mi != mapCryptedDilithiumKeys.end())
     {
@@ -1135,6 +1152,19 @@ bool LegacyScriptPubKeyMan::HaveDilithiumKey(const CKeyID &address) const
         // For encrypted wallets, check if we have the encrypted Dilithium key
         return mapCryptedDilithiumKeys.count(address) > 0;
     }
+}
+
+std::set<CKeyID> LegacyScriptPubKeyMan::GetDilithiumKeyIDs() const
+{
+    LOCK(cs_KeyStore);
+    std::set<CKeyID> key_ids;
+    for (const auto& entry : mapDilithiumKeys) {
+        key_ids.insert(entry.first);
+    }
+    for (const auto& entry : mapCryptedDilithiumKeys) {
+        key_ids.insert(entry.first);
+    }
+    return key_ids;
 }
 
 CDilithiumPubKey LegacyScriptPubKeyMan::GenerateNewDilithiumKey(WalletBatch &batch, CHDChain& hd_chain, bool internal)
@@ -1879,13 +1909,31 @@ std::vector<CKeyPool> LegacyScriptPubKeyMan::MarkReserveKeysAsUsed(int64_t keypo
 
 std::vector<CKeyID> GetAffectedKeys(const CScript& spk, const SigningProvider& provider)
 {
+    std::vector<CKeyID> ret;
+    std::vector<std::vector<unsigned char>> solutions;
+    const TxoutType which_type = Solver(spk, solutions);
+    if (which_type == TxoutType::DILITHIUM_PUBKEY && !solutions.empty()) {
+        const CDilithiumPubKey pubkey{solutions[0]};
+        if (pubkey.IsValid()) {
+            ret.emplace_back(pubkey.GetID());
+        }
+    } else if ((which_type == TxoutType::DILITHIUM_PUBKEYHASH ||
+                which_type == TxoutType::DILITHIUM_WITNESS_V0_KEYHASH) &&
+               !solutions.empty() && solutions[0].size() == uint160::size()) {
+        ret.emplace_back(uint160{Span<const unsigned char>(solutions[0])});
+    }
+
     std::vector<CScript> dummy;
     FlatSigningProvider out;
-    InferDescriptor(spk, provider)->Expand(0, DUMMY_SIGNING_PROVIDER, dummy, out);
-    std::vector<CKeyID> ret;
-    ret.reserve(out.pubkeys.size());
-    for (const auto& entry : out.pubkeys) {
-        ret.push_back(entry.first);
+    if (auto desc = InferDescriptor(spk, provider)) {
+        desc->Expand(0, DUMMY_SIGNING_PROVIDER, dummy, out);
+        ret.reserve(ret.size() + out.pubkeys.size() + out.dilithium_pubkeys.size());
+        for (const auto& entry : out.pubkeys) {
+            ret.push_back(entry.first);
+        }
+        for (const auto& entry : out.dilithium_pubkeys) {
+            ret.emplace_back(static_cast<uint160>(entry.first));
+        }
     }
     return ret;
 }
@@ -2380,11 +2428,13 @@ util::Result<CTxDestination> DescriptorScriptPubKeyMan::GetNewDestination(const 
         assert(desc_addr_type);
         
         // Handle Dilithium output types specially
-        if (type == OutputType::DILITHIUM_LEGACY || type == OutputType::DILITHIUM_BECH32) {
+        if (type == OutputType::DILITHIUM_BECH32) {
+            return util::Error{_("Error: dilithium-bech32 is disabled because witness v0 keyhash programs are indistinguishable from ECDSA P2WPKH and are not spendable with Dilithium keys")};
+        }
+
+        if (type == OutputType::DILITHIUM_LEGACY) {
             bool is_compatible = false;
             if (type == OutputType::DILITHIUM_LEGACY && *desc_addr_type == OutputType::LEGACY) {
-                is_compatible = true;
-            } else if (type == OutputType::DILITHIUM_BECH32 && *desc_addr_type == OutputType::BECH32) {
                 is_compatible = true;
             }
 
@@ -2392,12 +2442,26 @@ util::Result<CTxDestination> DescriptorScriptPubKeyMan::GetNewDestination(const 
                 return util::Error{_("Error: Descriptor type is not compatible with requested Dilithium address type")};
             }
 
+            if (m_storage.HasEncryptionKeys() && m_storage.IsLocked()) {
+                return util::Error{_("Error: Please enter the wallet passphrase with walletpassphrase first.")};
+            }
+
+            const KeyMap descriptor_private_keys = GetKeys();
+            if (descriptor_private_keys.empty()) {
+                return util::Error{_("Error: Descriptor private key is not available for Dilithium key generation")};
+            }
+
             CDilithiumKey dilithium_key;
             const uint32_t child_index = m_wallet_descriptor.next_index;
 
-            // Deterministic Dilithium key from descriptor identity + index (no timestamp).
-            static const unsigned char desc_ctx[] = {'D','i','l','i','t','h','i','u','m',' ','d','e','s','c'};
+            // Deterministic Dilithium key from private descriptor material + descriptor identity + index.
+            static const unsigned char desc_ctx[] = {'D','i','l','i','t','h','i','u','m',' ','d','e','s','c',' ','s','e','c','r','e','t'};
             CHMAC_SHA512 hmac(desc_ctx, sizeof(desc_ctx));
+            const CKey& descriptor_key = descriptor_private_keys.begin()->second;
+            if (!descriptor_key.IsValid()) {
+                return util::Error{_("Error: Descriptor private key is invalid for Dilithium key generation")};
+            }
+            hmac.Write(descriptor_key.begin(), descriptor_key.size());
             const uint256 desc_id = GetID();
             hmac.Write(desc_id.begin(), desc_id.size());
             const uint32_t idx_be = htobe32(child_index);
@@ -2430,11 +2494,7 @@ util::Result<CTxDestination> DescriptorScriptPubKeyMan::GetNewDestination(const 
             batch.WriteDescriptor(GetID(), m_wallet_descriptor);
 
             CTxDestination dest;
-            if (type == OutputType::DILITHIUM_LEGACY) {
-                dest = DilithiumPKHash(dilithium_pubkey);
-            } else {
-                dest = DilithiumWitnessV0KeyHash(dilithium_pubkey);
-            }
+            dest = DilithiumPKHash(dilithium_pubkey);
             return dest;
         }
         
@@ -2532,11 +2592,11 @@ isminetype DescriptorScriptPubKeyMan::IsMine(const CScript& script) const
 bool DescriptorScriptPubKeyMan::CheckDecryptionKey(const CKeyingMaterial& master_key, bool accept_no_keys)
 {
     LOCK(cs_desc_man);
-    if (!m_map_keys.empty()) {
+    if (!m_map_keys.empty() || !m_map_dilithium_keys.empty()) {
         return false;
     }
 
-    bool keyPass = m_map_crypted_keys.empty(); // Always pass when there are no encrypted keys
+    bool keyPass = m_map_crypted_keys.empty() && m_map_crypted_dilithium_keys.empty(); // Always pass when there are no encrypted keys
     bool keyFail = false;
     for (const auto& mi : m_map_crypted_keys) {
         const CPubKey &pubkey = mi.second.first;
@@ -2549,6 +2609,19 @@ bool DescriptorScriptPubKeyMan::CheckDecryptionKey(const CKeyingMaterial& master
         keyPass = true;
         if (m_decryption_thoroughly_checked)
             break;
+    }
+    for (const auto& entry : m_map_crypted_dilithium_keys) {
+        if (m_decryption_thoroughly_checked && keyPass) {
+            break;
+        }
+        const CKeyID& keyid = entry.first;
+        const std::vector<unsigned char>& crypted_secret = entry.second.second;
+        CDilithiumKey key;
+        if (!DecryptDilithiumKey(master_key, crypted_secret, keyid, key)) {
+            keyFail = true;
+            break;
+        }
+        keyPass = true;
     }
     if (keyPass && keyFail) {
         LogPrintf("The wallet is probably corrupted: Some keys decrypt but not all.\n");
@@ -2582,13 +2655,12 @@ bool DescriptorScriptPubKeyMan::Encrypt(const CKeyingMaterial& master_key, Walle
     }
     m_map_keys.clear();
 
-    for (const auto& key_in : m_map_dilithium_keys)
-    {
+    for (const auto& key_in : m_map_dilithium_keys) {
         const CKeyID& keyid = key_in.first;
-        const CDilithiumKey& dilithium_key = key_in.second;
-        CKeyingMaterial secret(dilithium_key.begin(), dilithium_key.end());
+        const CDilithiumKey& key = key_in.second;
+        CKeyingMaterial secret(key.begin(), key.end());
         std::vector<unsigned char> crypted_secret;
-        if (!EncryptDilithiumSecret(master_key, secret, KeyIDToIV(keyid), crypted_secret)) {
+        if (!EncryptDilithiumSecret(master_key, secret, DeriveDilithiumKeyIV(keyid), crypted_secret)) {
             return false;
         }
         m_map_crypted_dilithium_keys[keyid] = make_pair(CPubKey(), crypted_secret);
@@ -2597,7 +2669,6 @@ bool DescriptorScriptPubKeyMan::Encrypt(const CKeyingMaterial& master_key, Walle
         }
     }
     m_map_dilithium_keys.clear();
-
     return true;
 }
 
@@ -2646,6 +2717,16 @@ std::map<DilithiumPKHash, CDilithiumKey> DescriptorScriptPubKeyMan::GetDilithium
         DilithiumPKHash dilithium_hash;
         std::memcpy(dilithium_hash.begin(), key_pair.first.begin(), 20);
         result[dilithium_hash] = key_pair.second;
+    }
+    if (m_storage.HasEncryptionKeys() && !m_storage.IsLocked()) {
+        for (const auto& key_pair : m_map_crypted_dilithium_keys) {
+            CDilithiumKey key;
+            if (DecryptDilithiumKey(m_storage.GetEncryptionKey(), key_pair.second.second, key_pair.first, key)) {
+                DilithiumPKHash dilithium_hash;
+                std::memcpy(dilithium_hash.begin(), key_pair.first.begin(), 20);
+                result[dilithium_hash] = key;
+            }
+        }
     }
     return result;
 }
@@ -2800,7 +2881,7 @@ bool DescriptorScriptPubKeyMan::AddDilithiumKeyWithDB(WalletBatch& batch, const 
 
         std::vector<unsigned char> crypted_secret;
         CKeyingMaterial secret(key.begin(), key.end());
-        if (!EncryptDilithiumSecret(m_storage.GetEncryptionKey(), secret, KeyIDToIV(keyid), crypted_secret)) {
+        if (!EncryptDilithiumSecret(m_storage.GetEncryptionKey(), secret, DeriveDilithiumKeyIV(keyid), crypted_secret)) {
             return false;
         }
 
@@ -2835,7 +2916,7 @@ bool DescriptorScriptPubKeyMan::GetDilithiumKey(const CKeyID& keyid, CDilithiumK
 
     auto mi = m_map_crypted_dilithium_keys.find(keyid);
     if (mi != m_map_crypted_dilithium_keys.end()) {
-        if (m_storage.HasEncryptionKeys()) {
+        if (m_storage.HasEncryptionKeys() && !m_storage.IsLocked()) {
             const std::vector<unsigned char>& crypted_secret = mi->second.second;
             return DecryptDilithiumKey(m_storage.GetEncryptionKey(), crypted_secret, keyid, key);
         }
@@ -3096,12 +3177,9 @@ std::unique_ptr<FlatSigningProvider> DescriptorScriptPubKeyMan::GetSigningProvid
         m_map_signing_providers[index] = *out_keys;
     }
 
-    // Always add Dilithium pubkeys for fee estimation (even if include_private=false)
-    // Convert Dilithium keys to pubkeys for solving
-    for (const auto& key_pair : m_map_dilithium_keys) {
-        DilithiumPKHash dilithium_hash;
-        std::memcpy(dilithium_hash.begin(), key_pair.first.begin(), 20);
-        out_keys->dilithium_pubkeys[dilithium_hash] = key_pair.second.GetPubKey();
+    const auto dilithium_keys = GetDilithiumKeys();
+    for (const auto& key_pair : dilithium_keys) {
+        out_keys->dilithium_pubkeys[key_pair.first] = key_pair.second.GetPubKey();
     }
     
     if (HavePrivateKeys() && include_private) {
@@ -3110,7 +3188,6 @@ std::unique_ptr<FlatSigningProvider> DescriptorScriptPubKeyMan::GetSigningProvid
 
         m_wallet_descriptor.descriptor->ExpandPrivate(index, master_provider, *out_keys);
 
-        auto dilithium_keys = GetDilithiumKeys();
         out_keys->dilithium_keys.insert(dilithium_keys.begin(), dilithium_keys.end());
     }
 

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -266,7 +266,6 @@ static const std::unordered_set<OutputType> LEGACY_OUTPUT_TYPES {
     OutputType::P2SH_SEGWIT,
     OutputType::BECH32,
     OutputType::DILITHIUM_LEGACY,
-    OutputType::DILITHIUM_BECH32,
 };
 
 class DescriptorScriptPubKeyMan;
@@ -455,6 +454,7 @@ public:
     //! Get a Dilithium key from the store
     bool GetDilithiumKey(const CKeyID &address, CDilithiumKey& keyOut) const;
     bool HaveDilithiumKey(const CKeyID &address) const;
+    std::set<CKeyID> GetDilithiumKeyIDs() const;
     //! Generate a new Dilithium key using HD derivation
     CDilithiumPubKey GenerateNewDilithiumKey(WalletBatch& batch, CHDChain& hd_chain, bool internal = false) EXCLUSIVE_LOCKS_REQUIRED(cs_KeyStore);
     //! Derive a new Dilithium child key using HD derivation

--- a/src/wallet/test/feebumper_tests.cpp
+++ b/src/wallet/test/feebumper_tests.cpp
@@ -17,6 +17,25 @@ namespace wallet {
 namespace feebumper {
 BOOST_FIXTURE_TEST_SUITE(feebumper_tests, WalletTestingSetup)
 
+class AlwaysValidSignatureChecker final : public BaseSignatureChecker
+{
+public:
+    mutable int schnorr_checks{0};
+    mutable int dilithium_checks{0};
+
+    bool CheckSchnorrSignature(Span<const unsigned char> sig, Span<const unsigned char> pubkey, SigVersion sigversion, ScriptExecutionData& execdata, ScriptError* serror = nullptr) const override
+    {
+        schnorr_checks++;
+        return true;
+    }
+
+    bool CheckDilithiumSignature(const std::vector<unsigned char>& sig, const std::vector<unsigned char>& pubkey, const CScript& script, SigVersion sigversion) const override
+    {
+        dilithium_checks++;
+        return true;
+    }
+};
+
 static void CheckMaxWeightComputation(const std::string& script_str, const std::vector<std::string>& witness_str_stack, const std::string& prevout_script_str, int64_t expected_max_weight)
 {
     std::vector script_data(ParseHex(script_str));
@@ -42,13 +61,52 @@ static void CheckMaxWeightComputation(const std::string& script_str, const std::
 BOOST_AUTO_TEST_CASE(external_max_weight_test)
 {
     // P2PKH
-    CheckMaxWeightComputation("453042021f03c8957c5ce12940ee6e3333ecc3f633d9a1ac53a55b3ce0351c617fa96abe021f0dccdcce3ef45a63998be9ec748b561baf077b8e862941d0cd5ec08f5afe68012102fccfeb395f0ecd3a77e7bc31c3bc61dc987418b18e395d441057b42ca043f22c", {}, "76a914f60dcfd3392b28adc7662669603641f578eed72d88ac", 593);
+    CheckMaxWeightComputation("453042021f03c8957c5ce12940ee6e3333ecc3f633d9a1ac53a55b3ce0351c617fa96abe021f0dccdcce3ef45a63998be9ec748b561baf077b8e862941d0cd5ec08f5afe68012102fccfeb395f0ecd3a77e7bc31c3bc61dc987418b18e395d441057b42ca043f22c", {}, "76a914f60dcfd3392b28adc7662669603641f578eed72d88ac", 2369);
     // P2SH-P2WPKH
-    CheckMaxWeightComputation("160014001dca1b22c599b5a56a87c78417ad2ff39552f1", {"3042021f5443c58eaf45f3e5ef46f8516f966b334a7d497cedda4edb2b9fad57c90c3b021f63a77cb56cde848e2e2dd20b487eec2f53101f634193786083f60b4d23a82301", "026cfe86116f161057deb240201d6b82ebd4f161e0200d63dc9aca65a1d6b38bb7"}, "a9147c8ab5ad7708b97ccb6b483d57aba48ee85214df87", 364);
+    CheckMaxWeightComputation("160014001dca1b22c599b5a56a87c78417ad2ff39552f1", {"3042021f5443c58eaf45f3e5ef46f8516f966b334a7d497cedda4edb2b9fad57c90c3b021f63a77cb56cde848e2e2dd20b487eec2f53101f634193786083f60b4d23a82301", "026cfe86116f161057deb240201d6b82ebd4f161e0200d63dc9aca65a1d6b38bb7"}, "a9147c8ab5ad7708b97ccb6b483d57aba48ee85214df87", 1132);
     // P2WPKH
-    CheckMaxWeightComputation("", {"3042021f0f8906f0394979d5b737134773e5b88bf036c7d63542301d600ab677ba5a59021f0e9fe07e62c113045fa1c1532e2914720e8854d189c4f5b8c88f57956b704401", "0359edba11ed1a0568094a6296a16c4d5ee4c8cfe2f5e2e6826871b5ecf8188f79"}, "00149961a78658030cc824af4c54fbf5294bec0cabdd", 272);
+    CheckMaxWeightComputation("", {"3042021f0f8906f0394979d5b737134773e5b88bf036c7d63542301d600ab677ba5a59021f0e9fe07e62c113045fa1c1532e2914720e8854d189c4f5b8c88f57956b704401", "0359edba11ed1a0568094a6296a16c4d5ee4c8cfe2f5e2e6826871b5ecf8188f79"}, "00149961a78658030cc824af4c54fbf5294bec0cabdd", 764);
     // P2WSH HTLC
-    CheckMaxWeightComputation("", {"3042021f5c4c29e6b686aae5b6d0751e90208592ea96d26bc81d78b0d3871a94a21fa8021f74dc2f971e438ccece8699c8fd15704c41df219ab37b63264f2147d15c34d801", "01", "6321024cf55e52ec8af7866617dc4e7ff8433758e98799906d80e066c6f32033f685f967029000b275210214827893e2dcbe4ad6c20bd743288edad21100404eb7f52ccd6062fd0e7808f268ac"}, "002089e84892873c679b1129edea246e484fd914c2601f776d4f2f4a001eb8059703", 318);
+    CheckMaxWeightComputation("", {"3042021f5c4c29e6b686aae5b6d0751e90208592ea96d26bc81d78b0d3871a94a21fa8021f74dc2f971e438ccece8699c8fd15704c41df219ab37b63264f2147d15c34d801", "01", "6321024cf55e52ec8af7866617dc4e7ff8433758e98799906d80e066c6f32033f685f967029000b275210214827893e2dcbe4ad6c20bd743288edad21100404eb7f52ccd6062fd0e7808f268ac"}, "002089e84892873c679b1129edea246e484fd914c2601f776d4f2f4a001eb8059703", 810);
+}
+
+BOOST_AUTO_TEST_CASE(signature_weight_diff_uses_sigversion_scale_and_signature_family_maxima)
+{
+    SignatureWeights base;
+    base.AddSigWeight(/* weight=*/70, SigVersion::BASE, /* max_weight=*/72);
+    BOOST_CHECK_EQUAL(base.GetWeightDiffToMax(), 2 * WITNESS_SCALE_FACTOR);
+
+    SignatureWeights witness;
+    witness.AddSigWeight(/* weight=*/70, SigVersion::WITNESS_V0, /* max_weight=*/72);
+    BOOST_CHECK_EQUAL(witness.GetWeightDiffToMax(), 2);
+
+    SignatureWeights schnorr;
+    schnorr.AddSigWeight(/* weight=*/64, SigVersion::P2MR_TAPSCRIPT, /* max_weight=*/65);
+    BOOST_CHECK_EQUAL(schnorr.GetWeightDiffToMax(), 1);
+
+    SignatureWeights dilithium;
+    dilithium.AddSigWeight(DilithiumConstants::SIGNATURE_SIZE, SigVersion::P2MR_TAPSCRIPT, DilithiumConstants::SIGNATURE_SIZE + 1);
+    BOOST_CHECK_EQUAL(dilithium.GetWeightDiffToMax(), 1);
+}
+
+BOOST_AUTO_TEST_CASE(signature_weight_checker_records_schnorr_and_dilithium)
+{
+    AlwaysValidSignatureChecker valid_checker;
+    SignatureWeights weights;
+    SignatureWeightChecker weight_checker(weights, valid_checker);
+    ScriptExecutionData execdata;
+
+    const std::vector<unsigned char> schnorr_sig(64);
+    const std::vector<unsigned char> schnorr_pubkey(32);
+    BOOST_CHECK(weight_checker.CheckSchnorrSignature(schnorr_sig, schnorr_pubkey, SigVersion::P2MR_TAPSCRIPT, execdata));
+    BOOST_CHECK_EQUAL(valid_checker.schnorr_checks, 1);
+    BOOST_CHECK_EQUAL(weights.GetWeightDiffToMax(), 1);
+
+    const std::vector<unsigned char> dilithium_sig(DilithiumConstants::SIGNATURE_SIZE);
+    const std::vector<unsigned char> dilithium_pubkey(DilithiumConstants::PUBLIC_KEY_SIZE);
+    BOOST_CHECK(weight_checker.CheckDilithiumSignature(dilithium_sig, dilithium_pubkey, CScript{}, SigVersion::P2MR_TAPSCRIPT));
+    BOOST_CHECK_EQUAL(valid_checker.dilithium_checks, 1);
+    BOOST_CHECK_EQUAL(weights.GetWeightDiffToMax(), 2);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/test/ismine_tests.cpp
+++ b/src/wallet/test/ismine_tests.cpp
@@ -583,6 +583,39 @@ BOOST_AUTO_TEST_CASE(ismine_standard)
         BOOST_CHECK(keystore.GetLegacyScriptPubKeyMan()->GetScriptPubKeys().count(scriptPubKey) == 1);
     }
 
+    // P2WSH multisig wrapped in P2SH, imported through the legacy import path
+    {
+        CWallet keystore(chain.get(), "", CreateMockableWalletDatabase());
+        keystore.SetupLegacyScriptPubKeyMan();
+        LOCK(keystore.GetLegacyScriptPubKeyMan()->cs_KeyStore);
+
+        CScript witnessScript = GetScriptForMultisig(1, {pubkeys[0]});
+        CScript redeemScript = GetScriptForDestination(WitnessV0ScriptHash(witnessScript));
+        scriptPubKey = GetScriptForDestination(ScriptHash(redeemScript));
+
+        BOOST_CHECK(keystore.GetLegacyScriptPubKeyMan()->ImportScripts({redeemScript, witnessScript}, /*timestamp=*/1));
+        BOOST_CHECK(keystore.GetLegacyScriptPubKeyMan()->ImportPrivKeys({{pubkeys[0].GetID(), keys[0]}}, /*timestamp=*/1));
+        result = keystore.GetLegacyScriptPubKeyMan()->IsMine(scriptPubKey);
+        BOOST_CHECK_EQUAL(result, ISMINE_SPENDABLE);
+        BOOST_CHECK(keystore.GetLegacyScriptPubKeyMan()->GetScriptPubKeys().count(scriptPubKey) == 1);
+    }
+
+    // Wallet-level legacy imports invalidate stale IsMine cache entries
+    {
+        CWallet keystore(chain.get(), "", CreateMockableWalletDatabase());
+        keystore.SetupLegacyScriptPubKeyMan();
+        LOCK(keystore.cs_wallet);
+
+        CScript witnessScript = GetScriptForMultisig(1, {pubkeys[0]});
+        CScript redeemScript = GetScriptForDestination(WitnessV0ScriptHash(witnessScript));
+        scriptPubKey = GetScriptForDestination(ScriptHash(redeemScript));
+
+        BOOST_CHECK_EQUAL(keystore.IsMine(scriptPubKey), ISMINE_NO);
+        BOOST_CHECK(keystore.ImportScripts({redeemScript, witnessScript}, /*timestamp=*/1));
+        BOOST_CHECK(keystore.ImportPrivKeys({{pubkeys[0].GetID(), keys[0]}}, /*timestamp=*/1));
+        BOOST_CHECK_EQUAL(keystore.IsMine(scriptPubKey), ISMINE_SPENDABLE);
+    }
+
     // P2WSH multisig wrapped in P2SH - Descriptor
     {
         CWallet keystore(chain.get(), "", CreateMockableWalletDatabase());

--- a/src/wallet/test/p2mr_tests.cpp
+++ b/src/wallet/test/p2mr_tests.cpp
@@ -2,9 +2,22 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <test/util/setup_common.h>
+#include <addresstype.h>
+#include <key.h>
+#include <policy/policy.h>
+#include <primitives/transaction.h>
+#include <script/interpreter.h>
+#include <script/script.h>
+#include <script/sign.h>
+#include <script/signingprovider.h>
 #include <univalue.h>
 #include <util/strencodings.h>
+#include <util/vector.h>
 #include <wallet/p2mr.h>
+#include <wallet/test/util.h>
+#include <wallet/wallet.h>
+#include <wallet/walletdb.h>
 
 #include <boost/test/unit_test.hpp>
 
@@ -20,6 +33,20 @@ static UniValue MakeOpTrueTreeJSON()
     UniValue tree(UniValue::VARR);
     tree.push_back(leaf);
     return tree;
+}
+
+static std::vector<P2MRTreeLeaf> MakeOpTrueTree()
+{
+    auto parsed = ParseP2MRTreeChecked(MakeOpTrueTreeJSON());
+    BOOST_REQUIRE(parsed);
+    return *parsed;
+}
+
+static std::unique_ptr<CWallet> MakeP2MRTestWallet(interfaces::Chain& chain)
+{
+    auto wallet = std::make_unique<CWallet>(&chain, "", CreateMockableWalletDatabase());
+    wallet->LoadWallet();
+    return wallet;
 }
 
 // Round-trips the OP_TRUE template through ParseP2MRTreeChecked,
@@ -96,10 +123,41 @@ BOOST_AUTO_TEST_CASE(reject_invalid_hex_script)
     BOOST_CHECK(!parsed);
 }
 
+BOOST_AUTO_TEST_CASE(reject_leaf_version_with_control_parity_bit)
+{
+    UniValue leaf(UniValue::VOBJ);
+    leaf.pushKV("depth", 0);
+    leaf.pushKV("leaf_version", 193); // 0xc1: control-block parity bit is not part of the leaf version
+    leaf.pushKV("script", "51");
+    UniValue tree(UniValue::VARR);
+    tree.push_back(leaf);
+
+    auto parsed = ParseP2MRTreeChecked(tree);
+    BOOST_CHECK(!parsed);
+
+    std::vector<P2MRTreeLeaf> leaves{{0, 193, {0x51}}};
+    auto built = BuildP2MRTreeChecked(leaves);
+    BOOST_CHECK(!built);
+}
+
 BOOST_AUTO_TEST_CASE(build_rejects_empty_leaves_vector)
 {
     std::vector<P2MRTreeLeaf> empty;
     auto built = BuildP2MRTreeChecked(empty);
+    BOOST_CHECK(!built);
+}
+
+BOOST_AUTO_TEST_CASE(build_rejects_out_of_range_depth)
+{
+    std::vector<P2MRTreeLeaf> leaves{{129, 192, {0x51}}};
+    auto built = BuildP2MRTreeChecked(leaves);
+    BOOST_CHECK(!built);
+}
+
+BOOST_AUTO_TEST_CASE(build_rejects_incomplete_tree_without_asserting)
+{
+    std::vector<P2MRTreeLeaf> leaves{{1, 192, {0x51}}};
+    auto built = BuildP2MRTreeChecked(leaves);
     BOOST_CHECK(!built);
 }
 
@@ -128,6 +186,120 @@ BOOST_AUTO_TEST_CASE(reject_typeerror_on_script_int)
     tree.push_back(leaf);
     auto parsed = ParseP2MRTreeChecked(tree);
     BOOST_CHECK(!parsed);
+}
+
+BOOST_FIXTURE_TEST_CASE(create_is_idempotent_for_identical_tree, BasicTestingSetup)
+{
+    auto wallet = MakeP2MRTestWallet(*m_node.chain);
+    LOCK(wallet->cs_wallet);
+    const auto leaves = MakeOpTrueTree();
+
+    auto first = CreateP2MR(*wallet, leaves, "first");
+    BOOST_REQUIRE(first);
+    auto second = CreateP2MR(*wallet, leaves, "second");
+    BOOST_REQUIRE(second);
+
+    BOOST_CHECK_EQUAL(second->id, first->id);
+    BOOST_CHECK_EQUAL(second->address, first->address);
+    BOOST_CHECK_EQUAL(HexStr(second->script_pub_key), HexStr(first->script_pub_key));
+    BOOST_CHECK_EQUAL(ListP2MR(*wallet).size(), 1U);
+}
+
+BOOST_FIXTURE_TEST_CASE(tracked_balance_deduplicates_legacy_duplicate_metadata, BasicTestingSetup)
+{
+    auto wallet = MakeP2MRTestWallet(*m_node.chain);
+    LOCK(wallet->cs_wallet);
+    const auto leaves = MakeOpTrueTree();
+
+    auto created = CreateP2MR(*wallet, leaves, "original");
+    BOOST_REQUIRE(created);
+
+    UniValue duplicate_meta(UniValue::VOBJ);
+    duplicate_meta.pushKV("id", "legacy-duplicate");
+    duplicate_meta.pushKV("address", created->address);
+    duplicate_meta.pushKV("scriptPubKey", HexStr(created->script_pub_key));
+    duplicate_meta.pushKV("merkle_root", HexStr(created->merkle_root));
+    duplicate_meta.pushKV("created_at", int64_t{1});
+    duplicate_meta.pushKV("label", "duplicate");
+    duplicate_meta.pushKV("state", "created");
+    duplicate_meta.pushKV("tree", P2MRTreeToUniValue(leaves));
+
+    WalletBatch batch(wallet->GetDatabase(), /*fFlushOnClose=*/false);
+    BOOST_REQUIRE(wallet->SetP2MRMetadata(batch, created->dest, "legacy-duplicate", duplicate_meta.write()));
+    BOOST_REQUIRE_EQUAL(ListP2MR(*wallet).size(), 2U);
+
+    const CAmount amount{5 * COIN};
+    CMutableTransaction tx;
+    tx.nLockTime = 1;
+    tx.vout.emplace_back(amount, created->script_pub_key);
+    const uint256 txid = tx.GetHash();
+    auto inserted = wallet->mapWallet.emplace(std::piecewise_construct,
+        std::forward_as_tuple(txid),
+        std::forward_as_tuple(MakeTransactionRef(std::move(tx)), TxStateInactive{}));
+    BOOST_REQUIRE(inserted.second);
+
+    auto original_entry = GetP2MR(*wallet, created->id);
+    BOOST_REQUIRE(original_entry);
+    BOOST_CHECK_EQUAL(GetP2MREntryBalance(*wallet, *original_entry, /*min_depth=*/0), amount);
+
+    auto duplicate_entry = GetP2MR(*wallet, "legacy-duplicate");
+    BOOST_REQUIRE(duplicate_entry);
+    BOOST_CHECK_EQUAL(GetP2MREntryBalance(*wallet, *duplicate_entry, /*min_depth=*/0), amount);
+
+    BOOST_CHECK_EQUAL(GetTrackedP2MRBalance(*wallet, /*min_depth=*/0), amount);
+}
+
+BOOST_FIXTURE_TEST_CASE(produce_signature_preserves_p2mr_witness_stack, BasicTestingSetup)
+{
+    CKey key;
+    key.MakeNewKey(/*fCompressedIn=*/true);
+    const CPubKey pubkey = key.GetPubKey();
+    const XOnlyPubKey xonly_pubkey{pubkey};
+
+    const CScript leaf_script = CScript() << ToByteVector(xonly_pubkey) << OP_CHECKSIG;
+    const std::vector<unsigned char> leaf_bytes{leaf_script.begin(), leaf_script.end()};
+
+    P2MRBuilder builder;
+    builder.Add(/*depth=*/0, leaf_bytes, TAPROOT_LEAF_TAPSCRIPT).Finalize();
+    BOOST_REQUIRE(builder.IsValid());
+    BOOST_REQUIRE(builder.IsComplete());
+
+    const WitnessV2P2MR output = builder.GetOutput();
+    const CScript script_pubkey = GetScriptForDestination(output);
+    const CAmount amount = COIN;
+
+    FlatSigningProvider provider;
+    provider.keys.emplace(pubkey.GetID(), key);
+    provider.pubkeys.emplace(pubkey.GetID(), pubkey);
+    provider.p2mr_trees.emplace(output, builder);
+
+    CMutableTransaction tx_to;
+    tx_to.nVersion = 2;
+    tx_to.vin.emplace_back(COutPoint(uint256::ONE, 0));
+    tx_to.vout.emplace_back(amount - 1000, CScript() << OP_TRUE);
+
+    std::vector<CTxOut> spent_outputs;
+    spent_outputs.emplace_back(amount, script_pubkey);
+    PrecomputedTransactionData txdata;
+    txdata.Init(tx_to, std::move(spent_outputs), /*force=*/true);
+
+    SignatureData sigdata;
+    MutableTransactionSignatureCreator creator(tx_to, /*input_idx=*/0, amount, &txdata, SIGHASH_DEFAULT);
+    BOOST_REQUIRE(ProduceSignature(provider, creator, script_pubkey, sigdata));
+    BOOST_CHECK(sigdata.complete);
+    BOOST_CHECK(sigdata.witness);
+    BOOST_REQUIRE_EQUAL(sigdata.scriptWitness.stack.size(), 3U);
+    BOOST_CHECK_EQUAL(sigdata.scriptWitness.stack[0].size(), 64U);
+    BOOST_CHECK_EQUAL(HexStr(sigdata.scriptWitness.stack[1]), HexStr(leaf_script));
+    BOOST_CHECK_EQUAL(sigdata.scriptWitness.stack[2].size(), P2MR_CONTROL_BASE_SIZE);
+
+    UpdateInput(tx_to.vin[0], sigdata);
+    const CTransaction signed_tx{tx_to};
+    TransactionSignatureChecker checker(&signed_tx, /*nInIn=*/0, amount, txdata, MissingDataBehavior::FAIL);
+    ScriptError serror{SCRIPT_ERR_OK};
+    BOOST_CHECK_MESSAGE(
+        VerifyScript(tx_to.vin[0].scriptSig, script_pubkey, &tx_to.vin[0].scriptWitness, STANDARD_SCRIPT_VERIFY_FLAGS, checker, &serror),
+        ScriptErrorString(serror));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/test/scriptpubkeyman_tests.cpp
+++ b/src/wallet/test/scriptpubkeyman_tests.cpp
@@ -131,6 +131,102 @@ BOOST_AUTO_TEST_CASE(dilithium_getnewdestination_uses_hd_seed)
     BOOST_CHECK(std::get<DilithiumPKHash>(*dest) == DilithiumPKHash(child0.key.GetPubKey().GetID()));
 }
 
+BOOST_AUTO_TEST_CASE(dilithium_bech32_generation_disabled)
+{
+    CWallet wallet(m_node.chain.get(), "", CreateMockableWalletDatabase());
+    LegacyScriptPubKeyMan& keyman = *wallet.GetOrCreateLegacyScriptPubKeyMan();
+
+    util::Result<CTxDestination> dest = keyman.GetNewDestination(OutputType::DILITHIUM_BECH32);
+    BOOST_CHECK(!dest);
+}
+
+BOOST_AUTO_TEST_CASE(get_affected_keys_includes_dilithium_pubkeys)
+{
+    CDilithiumKey key;
+    key.MakeNewKey();
+    const CDilithiumPubKey pubkey = key.GetPubKey();
+    const DilithiumPKHash key_hash{pubkey};
+    const CKeyID key_id{static_cast<uint160>(key_hash)};
+
+    FlatSigningProvider provider;
+    provider.dilithium_pubkeys[key_hash] = pubkey;
+
+    const std::vector<CKeyID> affected_keys = GetAffectedKeys(GetScriptForDestination(key_hash), provider);
+    BOOST_REQUIRE_EQUAL(affected_keys.size(), 1);
+    BOOST_CHECK(affected_keys[0] == key_id);
+}
+
+BOOST_AUTO_TEST_CASE(legacy_encrypt_migrates_dilithium_keys)
+{
+    CWallet wallet(m_node.chain.get(), "", CreateMockableWalletDatabase());
+    LegacyScriptPubKeyMan& keyman = *wallet.GetOrCreateLegacyScriptPubKeyMan();
+
+    CKeyID key_id;
+    CDilithiumKey before_encrypt;
+    {
+        LOCK(keyman.cs_KeyStore);
+        BOOST_REQUIRE(keyman.SetupGeneration(true));
+
+        WalletBatch batch(wallet.GetDatabase());
+        CHDChain hd_chain = keyman.GetHDChain();
+        const CDilithiumPubKey pubkey = keyman.GenerateNewDilithiumKey(batch, hd_chain, /*internal=*/false);
+        key_id = CKeyID(pubkey.GetID());
+        BOOST_REQUIRE(keyman.GetDilithiumKey(key_id, before_encrypt));
+    }
+
+    BOOST_REQUIRE(wallet.EncryptWallet("encrypt"));
+    BOOST_CHECK(wallet.IsCrypted());
+    BOOST_CHECK(wallet.IsLocked());
+    BOOST_CHECK(keyman.HaveDilithiumKey(key_id));
+
+    BOOST_REQUIRE(wallet.Unlock("encrypt"));
+    CDilithiumKey after_encrypt;
+    BOOST_REQUIRE(keyman.GetDilithiumKey(key_id, after_encrypt));
+    BOOST_CHECK(after_encrypt == before_encrypt);
+}
+
+BOOST_AUTO_TEST_CASE(descriptor_encrypt_migrates_dilithium_keys)
+{
+    CWallet wallet(m_node.chain.get(), "", CreateMockableWalletDatabase());
+    DescriptorScriptPubKeyMan* keyman{nullptr};
+    {
+        LOCK(wallet.cs_wallet);
+        wallet.SetWalletFlag(WALLET_FLAG_DESCRIPTORS);
+        wallet.SetupDescriptorScriptPubKeyMans();
+        keyman = dynamic_cast<DescriptorScriptPubKeyMan*>(wallet.GetScriptPubKeyMan(OutputType::LEGACY, /*internal=*/false));
+    }
+    BOOST_REQUIRE(keyman);
+
+    const util::Result<CTxDestination> dest = keyman->GetNewDestination(OutputType::DILITHIUM_LEGACY);
+    BOOST_REQUIRE(dest);
+    BOOST_REQUIRE(std::holds_alternative<DilithiumPKHash>(*dest));
+    const CKeyID key_id{static_cast<uint160>(std::get<DilithiumPKHash>(*dest))};
+
+    CDilithiumKey before_encrypt;
+    {
+        LOCK(keyman->cs_desc_man);
+        BOOST_REQUIRE(keyman->GetDilithiumKey(key_id, before_encrypt));
+    }
+
+    BOOST_REQUIRE(wallet.EncryptWallet("encrypt"));
+    BOOST_CHECK(wallet.IsCrypted());
+    BOOST_CHECK(wallet.IsLocked());
+    {
+        LOCK(keyman->cs_desc_man);
+        CDilithiumKey locked_key;
+        BOOST_CHECK(keyman->HaveDilithiumKey(key_id));
+        BOOST_CHECK(!keyman->GetDilithiumKey(key_id, locked_key));
+    }
+
+    BOOST_REQUIRE(wallet.Unlock("encrypt"));
+    CDilithiumKey after_encrypt;
+    {
+        LOCK(keyman->cs_desc_man);
+        BOOST_REQUIRE(keyman->GetDilithiumKey(key_id, after_encrypt));
+    }
+    BOOST_CHECK(after_encrypt == before_encrypt);
+}
+
 // BTQ-AUDIT-001/009: encryptwallet must migrate plaintext Dilithium keys to crypted map.
 BOOST_AUTO_TEST_CASE(dilithium_encrypt_wallet_roundtrip)
 {

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -32,10 +32,13 @@
 #include <boost/test/unit_test.hpp>
 #include <univalue.h>
 
+#include <fstream>
+
 using node::MAX_BLOCKFILE_SIZE;
 
 namespace wallet {
 RPCHelpMan importmulti();
+RPCHelpMan importprivkey();
 RPCHelpMan dumpwallet();
 RPCHelpMan importwallet();
 
@@ -45,6 +48,11 @@ static_assert(DEFAULT_TRANSACTION_MINFEE >= DEFAULT_MIN_RELAY_TX_FEE, "wallet mi
 static_assert(WALLET_INCREMENTAL_RELAY_FEE >= DEFAULT_INCREMENTAL_RELAY_FEE, "wallet incremental fee is smaller than default incremental relay fee");
 
 BOOST_FIXTURE_TEST_SUITE(wallet_tests, WalletTestingSetup)
+
+static CAmount TestBlockSubsidy()
+{
+    return GetBlockSubsidy(/*nHeight=*/1, Params().GetConsensus());
+}
 
 static CMutableTransaction TestSimpleSpend(const CTransaction& from, uint32_t index, const CKey& key, const CScript& pubkey)
 {
@@ -126,7 +134,7 @@ BOOST_FIXTURE_TEST_CASE(scan_for_wallet_transactions, TestChain100Setup)
         BOOST_CHECK(result.last_failed_block.IsNull());
         BOOST_CHECK_EQUAL(result.last_scanned_block, newTip->GetBlockHash());
         BOOST_CHECK_EQUAL(*result.last_scanned_height, newTip->nHeight);
-        BOOST_CHECK_EQUAL(GetBalance(wallet).m_mine_immature, 100 * COIN);
+        BOOST_CHECK_EQUAL(GetBalance(wallet).m_mine_immature, 2 * TestBlockSubsidy());
 
         {
             CBlockLocator locator;
@@ -162,7 +170,7 @@ BOOST_FIXTURE_TEST_CASE(scan_for_wallet_transactions, TestChain100Setup)
         BOOST_CHECK_EQUAL(result.last_failed_block, oldTip->GetBlockHash());
         BOOST_CHECK_EQUAL(result.last_scanned_block, newTip->GetBlockHash());
         BOOST_CHECK_EQUAL(*result.last_scanned_height, newTip->nHeight);
-        BOOST_CHECK_EQUAL(GetBalance(wallet).m_mine_immature, 50 * COIN);
+        BOOST_CHECK_EQUAL(GetBalance(wallet).m_mine_immature, TestBlockSubsidy());
     }
 
     // Prune the remaining block file.
@@ -330,6 +338,124 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
     }
 }
 
+BOOST_FIXTURE_TEST_CASE(dumpwallet_importwallet_roundtrips_dilithium_keys, WalletTestingSetup)
+{
+    const int64_t key_time = WITH_LOCK(Assert(m_node.chainman)->GetMutex(), return m_node.chainman->ActiveChain().Tip()->GetBlockTimeMax());
+    const fs::path backup_file_path = m_args.GetDataDirNet() / "dilithium-wallet.backup";
+    const std::string backup_file = fs::PathToString(backup_file_path);
+
+    CDilithiumKey key;
+    key.MakeNewKey();
+    BOOST_REQUIRE(key.IsValid());
+    const CDilithiumPubKey pubkey = key.GetPubKey();
+    const CKeyID keyid{pubkey.GetID()};
+    const CTxDestination destination{DilithiumPKHash(keyid)};
+
+    {
+        WalletContext context;
+        context.args = &m_args;
+        const std::shared_ptr<CWallet> wallet = std::make_shared<CWallet>(m_node.chain.get(), "", CreateMockableWalletDatabase());
+        auto spk_man = wallet->GetOrCreateLegacyScriptPubKeyMan();
+        {
+            LOCK2(wallet->cs_wallet, spk_man->cs_KeyStore);
+            spk_man->mapKeyMetadata[keyid].nCreateTime = key_time;
+            BOOST_REQUIRE(spk_man->AddDilithiumKeyPubKey(key, CPubKey(pubkey.begin(), pubkey.end())));
+            BOOST_REQUIRE(wallet->SetAddressBook(destination, "dilithium backup", AddressPurpose::RECEIVE));
+            AddWallet(context, wallet);
+            LOCK(Assert(m_node.chainman)->GetMutex());
+            wallet->SetLastBlockProcessed(m_node.chainman->ActiveChain().Height(), m_node.chainman->ActiveChain().Tip()->GetBlockHash());
+        }
+
+        JSONRPCRequest request;
+        request.context = &context;
+        request.params.setArray();
+        request.params.push_back(backup_file);
+
+        wallet::dumpwallet().HandleRequest(request);
+        RemoveWallet(context, wallet, /* load_on_start= */ std::nullopt);
+    }
+
+    {
+        std::ifstream dump_file{backup_file_path};
+        BOOST_REQUIRE(dump_file.is_open());
+        const std::string dump_contents{std::istreambuf_iterator<char>{dump_file}, std::istreambuf_iterator<char>{}};
+        BOOST_CHECK(dump_contents.find(EncodeDilithiumSecret(key)) != std::string::npos);
+        BOOST_CHECK(dump_contents.find("label=dilithium") != std::string::npos);
+        BOOST_CHECK(dump_contents.find(EncodeDestination(destination)) != std::string::npos);
+    }
+
+    {
+        WalletContext context;
+        context.args = &m_args;
+        const std::shared_ptr<CWallet> wallet = std::make_shared<CWallet>(m_node.chain.get(), "", CreateMockableWalletDatabase());
+        wallet->SetupLegacyScriptPubKeyMan();
+
+        JSONRPCRequest request;
+        request.context = &context;
+        request.params.setArray();
+        request.params.push_back(backup_file);
+        AddWallet(context, wallet);
+        {
+            LOCK(Assert(m_node.chainman)->GetMutex());
+            LOCK(wallet->cs_wallet);
+            wallet->SetLastBlockProcessed(m_node.chainman->ActiveChain().Height(), m_node.chainman->ActiveChain().Tip()->GetBlockHash());
+        }
+
+        wallet::importwallet().HandleRequest(request);
+        RemoveWallet(context, wallet, /* load_on_start= */ std::nullopt);
+
+        CDilithiumKey recovered;
+        LegacyScriptPubKeyMan* spk_man = wallet->GetLegacyScriptPubKeyMan();
+        BOOST_REQUIRE(spk_man);
+        BOOST_REQUIRE(spk_man->GetDilithiumKey(keyid, recovered));
+        BOOST_CHECK(recovered == key);
+        const auto* address_book_entry = wallet->FindAddressBookEntry(destination);
+        BOOST_REQUIRE(address_book_entry);
+        BOOST_CHECK_EQUAL(address_book_entry->GetLabel(), "dilithium backup");
+    }
+}
+
+BOOST_FIXTURE_TEST_CASE(importprivkey_stores_dilithium_key_by_dilithium_id, WalletTestingSetup)
+{
+    CDilithiumKey key;
+    key.MakeNewKey();
+    BOOST_REQUIRE(key.IsValid());
+    const CDilithiumPubKey pubkey = key.GetPubKey();
+    const CKeyID keyid{pubkey.GetID()};
+    const CTxDestination destination{DilithiumPKHash(keyid)};
+
+    WalletContext context;
+    context.args = &m_args;
+    const std::shared_ptr<CWallet> wallet = std::make_shared<CWallet>(m_node.chain.get(), "", CreateMockableWalletDatabase());
+    wallet->SetupLegacyScriptPubKeyMan();
+    AddWallet(context, wallet);
+
+    JSONRPCRequest request;
+    request.context = &context;
+    request.params.setArray();
+    request.params.push_back(EncodeDilithiumSecret(key));
+    request.params.push_back("direct dilithium import");
+    request.params.push_back(false);
+    wallet::importprivkey().HandleRequest(request);
+
+    CDilithiumKey recovered;
+    LegacyScriptPubKeyMan* spk_man = wallet->GetLegacyScriptPubKeyMan();
+    BOOST_REQUIRE(spk_man);
+    BOOST_REQUIRE(spk_man->GetDilithiumKey(keyid, recovered));
+    BOOST_CHECK(recovered == key);
+
+    std::string label;
+    {
+        LOCK(wallet->cs_wallet);
+        const auto* address_book_entry = wallet->FindAddressBookEntry(destination);
+        BOOST_REQUIRE(address_book_entry);
+        label = address_book_entry->GetLabel();
+    }
+    BOOST_CHECK_EQUAL(label, "direct dilithium import");
+
+    RemoveWallet(context, wallet, /* load_on_start= */ std::nullopt);
+}
+
 // Check that GetImmatureCredit() returns a newly calculated value instead of
 // the cached value after a MarkDirty() call.
 //
@@ -356,7 +482,7 @@ BOOST_FIXTURE_TEST_CASE(coin_mark_dirty_immature_credit, TestChain100Setup)
     // credit amount is calculated.
     wtx.MarkDirty();
     AddKey(wallet, coinbaseKey);
-    BOOST_CHECK_EQUAL(CachedTxGetImmatureCredit(wallet, wtx, ISMINE_SPENDABLE), 50*COIN);
+    BOOST_CHECK_EQUAL(CachedTxGetImmatureCredit(wallet, wtx, ISMINE_SPENDABLE), TestBlockSubsidy());
 }
 
 static int64_t AddTx(ChainstateManager& chainman, CWallet& wallet, uint32_t lockTime, int64_t mockTime, int64_t blockTime)
@@ -599,7 +725,7 @@ BOOST_FIXTURE_TEST_CASE(ListCoinsTest, ListCoinsTestingSetup)
     BOOST_CHECK_EQUAL(list.begin()->second.size(), 1U);
 
     // Check initial balance from one mature coinbase transaction.
-    BOOST_CHECK_EQUAL(50 * COIN, WITH_LOCK(wallet->cs_wallet, return AvailableCoins(*wallet).GetTotalAmount()));
+    BOOST_CHECK_EQUAL(TestBlockSubsidy(), WITH_LOCK(wallet->cs_wallet, return AvailableCoins(*wallet).GetTotalAmount()));
 
     // Add a transaction creating a change address, and confirm ListCoins still
     // returns the coin associated with the change address underneath the
@@ -675,6 +801,7 @@ BOOST_FIXTURE_TEST_CASE(BasicOutputTypesTest, ListCoinsTest)
 
     for (const auto& out_type : OUTPUT_TYPES) {
         if (out_type == OutputType::UNKNOWN) continue;
+        if (out_type == OutputType::DILITHIUM_LEGACY || out_type == OutputType::DILITHIUM_BECH32) continue;
         expected_coins_sizes[out_type] = 2U;
         TestCoinsResult(*this, out_type, 1 * COIN, expected_coins_sizes);
     }

--- a/src/wallet/test/walletdb_tests.cpp
+++ b/src/wallet/test/walletdb_tests.cpp
@@ -4,10 +4,12 @@
 
 #include <test/util/setup_common.h>
 #include <clientversion.h>
+#include <crypto/dilithium_key.h>
 #include <streams.h>
 #include <uint256.h>
 #include <wallet/test/util.h>
 #include <wallet/wallet.h>
+#include <wallet/walletdb.h>
 
 #include <boost/test/unit_test.hpp>
 
@@ -52,6 +54,50 @@ BOOST_AUTO_TEST_CASE(walletdb_read_write_deadlock)
 
         // Now delete all records, which performs a read write operation.
         BOOST_CHECK(wallet->GetLegacyScriptPubKeyMan()->DeleteRecords());
+    }
+}
+
+BOOST_AUTO_TEST_CASE(walletdb_loads_dilithium_key_metadata)
+{
+    CDilithiumKey key;
+    key.MakeNewKey();
+    BOOST_REQUIRE(key.IsValid());
+    const CKeyID key_id{key.GetPubKey().GetID()};
+
+    CKeyMetadata metadata{123456789};
+    metadata.hdKeypath = "m/0'/0'/7'";
+
+    MockableData records;
+    {
+        auto wallet = std::make_shared<CWallet>(m_node.chain.get(), "", CreateMockableWalletDatabase());
+        LOCK(wallet->cs_wallet);
+        wallet->SetupLegacyScriptPubKeyMan();
+        WalletBatch batch{wallet->GetDatabase()};
+        const std::vector<unsigned char> secret{key.begin(), key.end()};
+        BOOST_REQUIRE(batch.WriteDilithiumKeyByID(key_id, secret, metadata));
+        wallet->Flush();
+        records = GetMockableDatabase(*wallet).m_records;
+    }
+
+    {
+        auto wallet = std::make_shared<CWallet>(m_node.chain.get(), "", CreateMockableWalletDatabase(records));
+        {
+            LOCK(wallet->cs_wallet);
+            wallet->SetupLegacyScriptPubKeyMan();
+        }
+        BOOST_CHECK_EQUAL(wallet->LoadWallet(), DBErrors::LOAD_OK);
+
+        LegacyScriptPubKeyMan* spk_man = wallet->GetLegacyScriptPubKeyMan();
+        BOOST_REQUIRE(spk_man);
+        CDilithiumKey loaded_key;
+        BOOST_REQUIRE(spk_man->GetDilithiumKey(key_id, loaded_key));
+        BOOST_CHECK(loaded_key == key);
+
+        LOCK(spk_man->cs_KeyStore);
+        const auto it = spk_man->mapKeyMetadata.find(key_id);
+        BOOST_REQUIRE(it != spk_man->mapKeyMetadata.end());
+        BOOST_CHECK_EQUAL(it->second.nCreateTime, metadata.nCreateTime);
+        BOOST_CHECK_EQUAL(it->second.hdKeypath, metadata.hdKeypath);
     }
 }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1726,7 +1726,9 @@ bool CWallet::ImportScripts(const std::set<CScript> scripts, int64_t timestamp)
         return false;
     }
     LOCK(spk_man->cs_KeyStore);
-    return spk_man->ImportScripts(scripts, timestamp);
+    const bool result{spk_man->ImportScripts(scripts, timestamp)};
+    if (result) m_ismine_cache.clear();
+    return result;
 }
 
 bool CWallet::ImportPrivKeys(const std::map<CKeyID, CKey>& privkey_map, const int64_t timestamp)
@@ -1736,7 +1738,9 @@ bool CWallet::ImportPrivKeys(const std::map<CKeyID, CKey>& privkey_map, const in
         return false;
     }
     LOCK(spk_man->cs_KeyStore);
-    return spk_man->ImportPrivKeys(privkey_map, timestamp);
+    const bool result{spk_man->ImportPrivKeys(privkey_map, timestamp)};
+    if (result) m_ismine_cache.clear();
+    return result;
 }
 
 bool CWallet::ImportPubKeys(const std::vector<CKeyID>& ordered_pubkeys, const std::map<CKeyID, CPubKey>& pubkey_map, const std::map<CKeyID, std::pair<CPubKey, KeyOriginInfo>>& key_origins, const bool add_keypool, const bool internal, const int64_t timestamp)
@@ -1746,7 +1750,9 @@ bool CWallet::ImportPubKeys(const std::vector<CKeyID>& ordered_pubkeys, const st
         return false;
     }
     LOCK(spk_man->cs_KeyStore);
-    return spk_man->ImportPubKeys(ordered_pubkeys, pubkey_map, key_origins, add_keypool, internal, timestamp);
+    const bool result{spk_man->ImportPubKeys(ordered_pubkeys, pubkey_map, key_origins, add_keypool, internal, timestamp)};
+    if (result) m_ismine_cache.clear();
+    return result;
 }
 
 bool CWallet::ImportScriptPubKeys(const std::string& label, const std::set<CScript>& script_pub_keys, const bool have_solving_data, const bool apply_label, const int64_t timestamp)
@@ -1759,6 +1765,7 @@ bool CWallet::ImportScriptPubKeys(const std::string& label, const std::set<CScri
     if (!spk_man->ImportScriptPubKeys(script_pub_keys, have_solving_data, timestamp)) {
         return false;
     }
+    m_ismine_cache.clear();
     if (apply_label) {
         WalletBatch batch(GetDatabase());
         for (const CScript& script : script_pub_keys) {
@@ -2681,6 +2688,11 @@ void CWallet::GetKeyBirthTimes(std::map<CKeyID, int64_t>& mapKeyBirth) const {
         for (const CKeyID &keyid : spk_man->GetKeys()) {
             if (mapKeyBirth.count(keyid) == 0)
                 mapKeyFirstBlock[keyid] = &max_confirm;
+        }
+        for (const CKeyID& keyid : spk_man->GetDilithiumKeyIDs()) {
+            if (mapKeyBirth.count(keyid) == 0) {
+                mapKeyFirstBlock[keyid] = &max_confirm;
+            }
         }
 
         // if there are no such keys, we're done

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -140,8 +140,9 @@ constexpr CAmount DEFAULT_TRANSACTION_MAXFEE{COIN / 10};
 constexpr CAmount HIGH_TX_FEE_PER_KB{COIN / 100};
 //! -maxtxfee will warn if called with a higher fee than this amount (in satoshis)
 constexpr CAmount HIGH_MAX_TX_FEE{100 * HIGH_TX_FEE_PER_KB};
-//! Pre-calculated constants for input size estimation in *virtual size*
-static constexpr size_t DUMMY_NESTED_P2WPKH_INPUT_SIZE = 91;
+//! Pre-calculated constants for input size estimation in *virtual size*.
+//! BTQ's 16x witness scale makes nested P2WPKH smaller in vbytes than Bitcoin's 4x scale.
+static constexpr size_t DUMMY_NESTED_P2WPKH_INPUT_SIZE = 71;
 
 class CCoinControl;
 

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -905,6 +905,38 @@ static DBErrors LoadLegacyWalletRecords(CWallet* pwallet, DatabaseBatch& batch, 
     });
     result = std::max(result, keymeta_res.m_result);
 
+    LoadResult dilithium_keymeta_res = LoadRecords(pwallet, batch, DBKeys::DILITHIUM_KEYMETA,
+        [] (CWallet* pwallet, DataStream& key, CDataStream& value, std::string& strErr) {
+        CKeyID key_id;
+        DataStream key_id_stream{key};
+        try {
+            key_id_stream >> key_id;
+            if (!key_id_stream.empty()) {
+                throw std::ios_base::failure{"trailing data after Dilithium key id"};
+            }
+        } catch (const std::exception&) {
+            try {
+                DataStream pubkey_stream{key};
+                CPubKey pubkey;
+                pubkey_stream >> pubkey;
+                if (!pubkey_stream.empty()) {
+                    strErr = "Error reading wallet database: dilithiumkeymeta key has trailing data";
+                    return DBErrors::NONCRITICAL_ERROR;
+                }
+                key_id = pubkey.GetID();
+            } catch (const std::exception& e) {
+                strErr = strprintf("Error reading wallet database: failed to parse dilithiumkeymeta key: %s", e.what());
+                return DBErrors::NONCRITICAL_ERROR;
+            }
+        }
+
+        CKeyMetadata key_meta;
+        value >> key_meta;
+        pwallet->GetOrCreateLegacyScriptPubKeyMan()->LoadKeyMetadata(key_id, key_meta);
+        return DBErrors::LOAD_OK;
+    });
+    result = std::max(result, dilithium_keymeta_res.m_result);
+
     // Set inactive chains
     if (!hd_chains.empty()) {
         LegacyScriptPubKeyMan* legacy_spkm = pwallet->GetLegacyScriptPubKeyMan();

--- a/test/functional/feature_block.py
+++ b/test/functional/feature_block.py
@@ -13,6 +13,7 @@ from test_framework.blocktools import (
     create_tx_with_script,
     get_legacy_sigopcount_block,
     MAX_BLOCK_SIGOPS,
+    MAX_FUTURE_BLOCK_TIME,
 )
 from test_framework.messages import (
     CBlock,
@@ -23,6 +24,7 @@ from test_framework.messages import (
     CTxOut,
     MAX_BLOCK_WEIGHT,
     SEQUENCE_FINAL,
+    WITNESS_SCALE_FACTOR,
     uint256_from_compact,
     uint256_from_str,
 )
@@ -55,6 +57,9 @@ from test_framework.util import (
 )
 from test_framework.wallet_util import generate_keypair
 from data import invalid_txs
+
+
+BLOCK_FILL_TX_OVERHEAD_BYTES = 69
 
 
 #  Use this class for tests that require behavior other than normal p2p behavior.
@@ -321,7 +326,7 @@ class FullBlockTest(BTQTestFramework):
         self.move_tip(15)
         b23 = self.next_block(23, spend=out[6])
         tx = CTransaction()
-        script_length = (MAX_BLOCK_WEIGHT - b23.get_weight() - 276) // 4
+        script_length = (MAX_BLOCK_WEIGHT - b23.get_weight()) // WITNESS_SCALE_FACTOR - BLOCK_FILL_TX_OVERHEAD_BYTES
         script_output = CScript([b'\x00' * script_length])
         tx.vout.append(CTxOut(0, script_output))
         tx.vin.append(CTxIn(COutPoint(b23.vtx[1].sha256, 0)))
@@ -331,14 +336,14 @@ class FullBlockTest(BTQTestFramework):
         self.send_blocks([b23], True)
         self.save_spendable_output()
 
-        self.log.info("Reject a block of weight MAX_BLOCK_WEIGHT + 4")
+        self.log.info("Reject a block of weight MAX_BLOCK_WEIGHT + WITNESS_SCALE_FACTOR")
         self.move_tip(15)
         b24 = self.next_block(24, spend=out[6])
-        script_length = (MAX_BLOCK_WEIGHT - b24.get_weight() - 276) // 4
+        script_length = (MAX_BLOCK_WEIGHT - b24.get_weight()) // WITNESS_SCALE_FACTOR - BLOCK_FILL_TX_OVERHEAD_BYTES
         script_output = CScript([b'\x00' * (script_length + 1)])
         tx.vout = [CTxOut(0, script_output)]
         b24 = self.update_block(24, [tx])
-        assert_equal(b24.get_weight(), MAX_BLOCK_WEIGHT + 1 * 4)
+        assert_equal(b24.get_weight(), MAX_BLOCK_WEIGHT + WITNESS_SCALE_FACTOR)
         self.send_blocks([b24], success=False, reject_reason='bad-blk-length', reconnect=True)
 
         b25 = self.next_block(25, spend=out[7])
@@ -641,10 +646,10 @@ class FullBlockTest(BTQTestFramework):
             b47.rehash()
         self.send_blocks([b47], False, force_send=True, reject_reason='high-hash', reconnect=True)
 
-        self.log.info("Reject a block with a timestamp >2 hours in the future")
+        self.log.info("Reject a block with a timestamp too far in the future")
         self.move_tip(44)
         b48 = self.next_block(48)
-        b48.nTime = int(time.time()) + 60 * 60 * 3
+        b48.nTime = int(time.time()) + MAX_FUTURE_BLOCK_TIME + 1
         # Header timestamp has changed. Re-solve the block.
         b48.solve()
         self.send_blocks([b48], False, force_send=True, reject_reason='time-too-new')
@@ -701,14 +706,14 @@ class FullBlockTest(BTQTestFramework):
         self.send_blocks([b55], True)
         self.save_spendable_output()
 
-        # The block which was previously rejected because of being "too far(3 hours)" must be accepted 2 hours later.
-        # The new block is only 1 hour into future now and we must reorg onto to the new longer chain.
+        # The block which was previously rejected for being too far in the future
+        # must be accepted once mocktime advances inside BTQ's future-time window.
         # The new bestblock b48p is invalidated manually.
         #  -> b31 (8) -> b33 (9) -> b35 (10) -> b39 (11) -> b42 (12) -> b43 (13) -> b53 (14) -> b55 (15)
         #                                                                                   \-> b54 (15)
         #                                                                        -> b44 (14)\-> b48 () -> b48p ()
         self.log.info("Accept a previously rejected future block at a later time")
-        node.setmocktime(int(time.time()) + 2*60*60)
+        node.setmocktime(b48.nTime)
         self.move_tip(48)
         self.block_heights[b48.sha256] = self.block_heights[b44.sha256] + 1 # b48 is a parent of b44
         b48p = self.next_block("48p")
@@ -919,12 +924,14 @@ class FullBlockTest(BTQTestFramework):
         tx = CTransaction()
 
         # use canonical serialization to calculate size
-        script_length = (MAX_BLOCK_WEIGHT - 4 * len(b64a.normal_serialize()) - 276) // 4
+        script_length = (
+            MAX_BLOCK_WEIGHT - WITNESS_SCALE_FACTOR * len(b64a.normal_serialize())
+        ) // WITNESS_SCALE_FACTOR - BLOCK_FILL_TX_OVERHEAD_BYTES
         script_output = CScript([b'\x00' * script_length])
         tx.vout.append(CTxOut(0, script_output))
         tx.vin.append(CTxIn(COutPoint(b64a.vtx[1].sha256, 0)))
         b64a = self.update_block("64a", [tx])
-        assert_equal(b64a.get_weight(), MAX_BLOCK_WEIGHT + 8 * 4)
+        assert_equal(b64a.get_weight(), MAX_BLOCK_WEIGHT + 8 * WITNESS_SCALE_FACTOR)
         self.send_blocks([b64a], success=False, reject_reason='non-canonical ReadCompactSize()')
 
         # btqd doesn't disconnect us for sending a bloated block, but if we subsequently
@@ -1159,18 +1166,18 @@ class FullBlockTest(BTQTestFramework):
         self.log.info("Test transaction resurrection during a re-org")
         self.move_tip(76)
         self.next_block(77)
-        tx77 = self.create_and_sign_transaction(out[24], 10 * COIN)
+        tx77 = self.create_and_sign_transaction(out[24], 4 * COIN)
         b77 = self.update_block(77, [tx77])
         self.send_blocks([b77], True)
         self.save_spendable_output()
 
         self.next_block(78)
-        tx78 = self.create_tx(tx77, 0, 9 * COIN)
+        tx78 = self.create_tx(tx77, 0, 3 * COIN)
         b78 = self.update_block(78, [tx78])
         self.send_blocks([b78], True)
 
         self.next_block(79)
-        tx79 = self.create_tx(tx78, 0, 8 * COIN)
+        tx79 = self.create_tx(tx78, 0, 2 * COIN)
         b79 = self.update_block(79, [tx79])
         self.send_blocks([b79], True)
 
@@ -1272,7 +1279,7 @@ class FullBlockTest(BTQTestFramework):
         for i in range(89, LARGE_REORG_SIZE + 89):
             b = self.next_block(i, spend)
             tx = CTransaction()
-            script_length = (MAX_BLOCK_WEIGHT - b.get_weight() - 276) // 4
+            script_length = (MAX_BLOCK_WEIGHT - b.get_weight()) // WITNESS_SCALE_FACTOR - BLOCK_FILL_TX_OVERHEAD_BYTES
             script_output = CScript([b'\x00' * script_length])
             tx.vout.append(CTxOut(0, script_output))
             tx.vin.append(CTxIn(COutPoint(b.vtx[1].sha256, 0)))
@@ -1282,6 +1289,7 @@ class FullBlockTest(BTQTestFramework):
             self.save_spendable_output()
             spend = self.get_spendable_output()
 
+        node.setmocktime(blocks[-1].nTime)
         self.send_blocks(blocks, True, timeout=2440)
         chain1_tip = i
 
@@ -1290,17 +1298,21 @@ class FullBlockTest(BTQTestFramework):
         blocks2 = []
         for i in range(89, LARGE_REORG_SIZE + 89):
             blocks2.append(self.next_block("alt" + str(i)))
+        node.setmocktime(blocks2[-1].nTime)
         self.send_blocks(blocks2, False, force_send=False)
 
         # extend alt chain to trigger re-org
         block = self.next_block("alt" + str(chain1_tip + 1))
+        node.setmocktime(block.nTime)
         self.send_blocks([block], True, timeout=2440)
 
         # ... and re-org back to the first chain
         self.move_tip(chain1_tip)
         block = self.next_block(chain1_tip + 1)
+        node.setmocktime(max(block.nTime, blocks2[-1].nTime))
         self.send_blocks([block], False, force_send=True)
         block = self.next_block(chain1_tip + 2)
+        node.setmocktime(max(block.nTime, blocks2[-1].nTime))
         self.send_blocks([block], True, timeout=2440)
 
         self.log.info("Reject a block with an invalid block header version")
@@ -1314,6 +1326,7 @@ class FullBlockTest(BTQTestFramework):
         b_cb34.hashMerkleRoot = b_cb34.calc_merkle_root()
         b_cb34.solve()
         self.send_blocks([b_cb34], success=False, reject_reason='bad-cb-height', reconnect=True)
+        node.setmocktime(0)
 
     # Helper methods
     ################

--- a/test/functional/feature_dilithium_sigops.py
+++ b/test/functional/feature_dilithium_sigops.py
@@ -40,6 +40,7 @@ from test_framework.script import (
     CScript,
     CScriptNum,
     CScriptOp,
+    DILITHIUM_SIGOP_COST,
     LEAF_VERSION_TAPSCRIPT,
     OP_0,
     OP_1,
@@ -67,13 +68,8 @@ from test_framework.test_framework import BTQTestFramework
 from test_framework.util import assert_equal
 from test_framework.wallet import MiniWallet
 
-# ============================================================================
-#  Constants
-# ============================================================================
 TAPROOT_LEAF_MASK = 0xfe
 TAPROOT_LEAF_TAPSCRIPT = 0xc0
-MAX_BLOCK_SIGOPS_COST = 80000
-WITNESS_SCALE_FACTOR = 16
 
 
 # ============================================================================
@@ -112,18 +108,23 @@ def get_sigop_count(script_bytes):
             last_opcode = opcode
             continue
 
-        # ---- single-sig opcodes (+1 each) ----
-        if opcode in (0xac, 0xad,   # OP_CHECKSIG, OP_CHECKSIGVERIFY
-                      0xbb, 0xbc):  # OP_CHECKSIGDILITHIUM, OP_CHECKSIGDILITHIUMVERIFY
+        # ---- single-sig opcodes ----
+        if opcode in (0xac, 0xad):  # OP_CHECKSIG, OP_CHECKSIGVERIFY
             n += 1
+        elif opcode in (0xbb, 0xbc):  # OP_CHECKSIGDILITHIUM, OP_CHECKSIGDILITHIUMVERIFY
+            n += DILITHIUM_SIGOP_COST
 
-        # ---- multisig opcodes (+N or +20) ----
-        elif opcode in (0xae, 0xaf,   # OP_CHECKMULTISIG(VERIFY)
-                        0xbd, 0xbe):  # OP_CHECKMULTISIGDILITHIUM(VERIFY)
+        # ---- multisig opcodes (+N or +20 keys) ----
+        elif opcode in (0xae, 0xaf):  # OP_CHECKMULTISIG(VERIFY)
             if 0x51 <= last_opcode <= 0x60:   # OP_1 .. OP_16
                 n += last_opcode - 0x50
             else:
                 n += 20  # MAX_PUBKEYS_PER_MULTISIG
+        elif opcode in (0xbd, 0xbe):  # OP_CHECKMULTISIGDILITHIUM(VERIFY)
+            if 0x51 <= last_opcode <= 0x60:   # OP_1 .. OP_16
+                n += (last_opcode - 0x50) * DILITHIUM_SIGOP_COST
+            else:
+                n += 20 * DILITHIUM_SIGOP_COST
 
         last_opcode = opcode
     return n
@@ -222,22 +223,22 @@ class DilithiumSigopsTest(BTQTestFramework):
         self._test_1e_non_sigops()
 
     def _test_1a_basic_checksig(self):
-        print(sub_test('1a. OP_CHECKSIGDILITHIUM counts as 1 sigop'))
+        print(sub_test('1a. OP_CHECKSIGDILITHIUM counts at Dilithium cost'))
 
         cases = [
-            (CScript([OP_CHECKSIGDILITHIUM]),         1, 'single OP_CHECKSIGDILITHIUM'),
-            (CScript([OP_CHECKSIGDILITHIUMVERIFY]),    1, 'single OP_CHECKSIGDILITHIUMVERIFY'),
+            (CScript([OP_CHECKSIGDILITHIUM]),         DILITHIUM_SIGOP_COST, 'single OP_CHECKSIGDILITHIUM'),
+            (CScript([OP_CHECKSIGDILITHIUMVERIFY]),   DILITHIUM_SIGOP_COST, 'single OP_CHECKSIGDILITHIUMVERIFY'),
             (CScript([OP_CHECKSIGDILITHIUM,
-                      OP_CHECKSIGDILITHIUMVERIFY]),    2, 'both Dilithium checksig variants'),
+                      OP_CHECKSIGDILITHIUMVERIFY]),    2 * DILITHIUM_SIGOP_COST, 'both Dilithium checksig variants'),
             (CScript([OP_CHECKSIG]),                   1, 'ECDSA OP_CHECKSIG (control)'),
             (CScript([OP_CHECKSIG,
-                      OP_CHECKSIGDILITHIUM]),          2, 'ECDSA + Dilithium mixed'),
+                      OP_CHECKSIGDILITHIUM]),          1 + DILITHIUM_SIGOP_COST, 'ECDSA + Dilithium mixed'),
         ]
 
         for script, expected, label in cases:
             actual = get_sigop_count(bytes(script))
             assert_equal(actual, expected)
-            print(info(f'{label}: {actual} sigop(s)'))
+            print(info(f'{label}: {actual} sigop cost unit(s)'))
 
         print(passed())
 
@@ -245,23 +246,23 @@ class DilithiumSigopsTest(BTQTestFramework):
         print(sub_test('1b. OP_CHECKMULTISIGDILITHIUM uses N-of-M counting'))
 
         cases = [
-            (CScript([OP_3, OP_CHECKMULTISIGDILITHIUM]),              3,  '3 keys (OP_3 prefix)'),
-            (CScript([OP_2, OP_CHECKMULTISIGDILITHIUMVERIFY]),        2,  '2 keys (OP_2 prefix)'),
-            (CScript([OP_1, OP_CHECKMULTISIGDILITHIUMVERIFY]),        1,  '1 key  (OP_1 prefix)'),
-            (CScript([OP_DROP, OP_CHECKMULTISIGDILITHIUM]),           20, 'no OP_N prefix -> 20 (MAX)'),
+            (CScript([OP_3, OP_CHECKMULTISIGDILITHIUM]),              3 * DILITHIUM_SIGOP_COST,  '3 keys (OP_3 prefix)'),
+            (CScript([OP_2, OP_CHECKMULTISIGDILITHIUMVERIFY]),        2 * DILITHIUM_SIGOP_COST,  '2 keys (OP_2 prefix)'),
+            (CScript([OP_1, OP_CHECKMULTISIGDILITHIUMVERIFY]),        DILITHIUM_SIGOP_COST,      '1 key  (OP_1 prefix)'),
+            (CScript([OP_DROP, OP_CHECKMULTISIGDILITHIUM]),           20 * DILITHIUM_SIGOP_COST, 'no OP_N prefix -> 20 (MAX)'),
             (CScript([OP_3, OP_CHECKMULTISIG]),                       3,  'ECDSA 3-key multisig (control)'),
         ]
 
         for script, expected, label in cases:
             actual = get_sigop_count(bytes(script))
             assert_equal(actual, expected)
-            print(info(f'{label}: {actual} sigop(s)'))
+            print(info(f'{label}: {actual} sigop cost unit(s)'))
 
-        # Parity check: ECDSA and Dilithium multisig count identically
+        # Cost check: Dilithium multisig is deliberately more expensive than ECDSA.
         ecdsa = get_sigop_count(bytes(CScript([OP_3, OP_CHECKMULTISIG])))
         dilithium = get_sigop_count(bytes(CScript([OP_3, OP_CHECKMULTISIGDILITHIUM])))
-        assert_equal(ecdsa, dilithium)
-        print(info(f'ECDSA vs Dilithium parity: both = {ecdsa}'))
+        assert_equal(dilithium, ecdsa * DILITHIUM_SIGOP_COST)
+        print(info(f'ECDSA 3-key cost = {ecdsa}; Dilithium 3-key cost = {dilithium}'))
 
         print(passed())
 
@@ -275,10 +276,11 @@ class DilithiumSigopsTest(BTQTestFramework):
             OP_CHECKSIGDILITHIUMVERIFY,                     # +1  Dilithium
             OP_3, OP_CHECKMULTISIG,                         # +3  ECDSA multisig
             OP_2, OP_CHECKMULTISIGDILITHIUM,                # +2  Dilithium multisig
-        ])                                                  # ---
-        actual = get_sigop_count(bytes(script))             #  9  total
-        assert_equal(actual, 9)
-        print(info(f'1+1+1+1+3+2 = {actual} sigops'))
+        ])
+        actual = get_sigop_count(bytes(script))
+        expected = 1 + 1 + DILITHIUM_SIGOP_COST + DILITHIUM_SIGOP_COST + 3 + 2 * DILITHIUM_SIGOP_COST
+        assert_equal(actual, expected)
+        print(info(f'1+1+50+50+3+100 = {actual} sigop cost units'))
 
         print(passed())
 
@@ -288,8 +290,8 @@ class DilithiumSigopsTest(BTQTestFramework):
         for count in [10, 50, 100]:
             script = CScript([OP_CHECKSIGDILITHIUMVERIFY] * count)
             actual = get_sigop_count(bytes(script))
-            assert_equal(actual, count)
-            print(info(f'{count} repeated CHECKSIGDILITHIUMVERIFY -> {actual} sigops'))
+            assert_equal(actual, count * DILITHIUM_SIGOP_COST)
+            print(info(f'{count} repeated CHECKSIGDILITHIUMVERIFY -> {actual} sigop cost units'))
 
         print(passed('DoS vector properly bounded by sigop counting'))
 

--- a/test/functional/feature_p2mr_rpc.py
+++ b/test/functional/feature_p2mr_rpc.py
@@ -40,7 +40,11 @@ class P2MRRPCTest(BTQTestFramework):
         created = wallet.getnewp2mraddress(tree, "rpc-p2mr")
         assert created["address"]
         assert created["p2mr_id"]
+        duplicate = wallet.getnewp2mraddress(tree, "rpc-p2mr-duplicate")
+        assert_equal(duplicate["address"], created["address"])
+        assert_equal(duplicate["p2mr_id"], created["p2mr_id"])
         listed = wallet.listp2mr()
+        assert_equal(sum(1 for e in listed if e["address"] == created["address"]), 1)
         assert any(e["id"] == created["p2mr_id"] for e in listed)
         assert_equal(wallet.getp2mrinfo(created["p2mr_id"])["id"], created["p2mr_id"])
         assert_raises_rpc_error(-8, "unknown p2mr_id", wallet.getp2mrinfo, "does-not-exist")
@@ -48,6 +52,7 @@ class P2MRRPCTest(BTQTestFramework):
         self.log.info("Fund through convenience RPC")
         funded = wallet.sendtop2mr(tree, Decimal("1.0"), "rpc-p2mr-fund")
         assert funded["txid"]
+        assert_equal(funded["p2mr_id"], created["p2mr_id"])
         self.generate(node, 1)
 
         p2mr_id = funded["p2mr_id"]
@@ -66,6 +71,20 @@ class P2MRRPCTest(BTQTestFramework):
         self.generate(node, 1)
         tx = wallet.gettransaction(txid, True)
         assert tx["confirmations"] > 0
+
+        self.log.info("Do not mark a single-leaf P2MR script complete without required witness data")
+        needs_stack_tree = [{
+            "depth": 0,
+            "leaf_version": LEAF_VERSION_TAPSCRIPT,
+            "script": "7551",  # OP_DROP OP_TRUE
+        }]
+        needs_stack = wallet.sendtop2mr(needs_stack_tree, Decimal("0.1"), "rpc-p2mr-needs-stack")
+        self.generate(node, 1)
+        needs_stack_spend = wallet.createp2mrspend(needs_stack["p2mr_id"], destination, Decimal("0.05"))
+        incomplete = wallet.signp2mrtransaction(needs_stack_spend["hex"], needs_stack["p2mr_id"])
+        assert_equal(incomplete["complete"], False)
+        rejected = wallet.testp2mrtransaction(incomplete["hex"])
+        assert_equal(rejected[0]["allowed"], False)
 
 
 if __name__ == "__main__":

--- a/test/functional/feature_segwit.py
+++ b/test/functional/feature_segwit.py
@@ -14,6 +14,7 @@ from test_framework.address import (
     script_to_p2wsh,
 )
 from test_framework.blocktools import (
+    MAX_BLOCK_SIGOPS,
     send_to_witness,
     witness_script,
 )
@@ -24,6 +25,8 @@ from test_framework.messages import (
     CTransaction,
     CTxIn,
     CTxOut,
+    MAX_BLOCK_WEIGHT,
+    WITNESS_SCALE_FACTOR,
     tx_from_hex,
 )
 from test_framework.script import (
@@ -57,6 +60,7 @@ NODE_0 = 0
 NODE_2 = 2
 P2WPKH = 0
 P2WSH = 1
+LISTUNSPENT_TEST_OUTPUT_VALUE = 1_000_000
 
 
 def getutxo(txid):
@@ -116,23 +120,23 @@ class SegWitTest(BTQTestFramework):
         self.sync_all()
 
     def success_mine(self, node, txid, sign, redeem_script=""):
-        send_to_witness(1, node, getutxo(txid), self.pubkey[0], False, Decimal("49.998"), sign, redeem_script)
+        send_to_witness(1, node, getutxo(txid), self.pubkey[0], False, Decimal("4.998"), sign, redeem_script)
         block = self.generate(node, 1)
         assert_equal(len(node.getblock(block[0])["tx"]), 2)
         self.sync_blocks()
 
     def fail_accept(self, node, error_msg, txid, sign, redeem_script=""):
-        assert_raises_rpc_error(-26, error_msg, send_to_witness, use_p2wsh=1, node=node, utxo=getutxo(txid), pubkey=self.pubkey[0], encode_p2sh=False, amount=Decimal("49.998"), sign=sign, insert_redeem_script=redeem_script)
+        assert_raises_rpc_error(-26, error_msg, send_to_witness, use_p2wsh=1, node=node, utxo=getutxo(txid), pubkey=self.pubkey[0], encode_p2sh=False, amount=Decimal("4.998"), sign=sign, insert_redeem_script=redeem_script)
 
     def run_test(self):
-        self.generate(self.nodes[0], 161)  # block 161
+        self.generatetoaddress(self.nodes[0], 161, self.nodes[0].getnewaddress())  # block 161
 
         self.log.info("Verify sigops are counted in GBT with pre-BIP141 rules before the fork")
         txid = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 1)
         tmpl = self.nodes[0].getblocktemplate({'rules': ['segwit']})
-        assert_equal(tmpl['sizelimit'], 1000000)
+        assert_equal(tmpl['sizelimit'], MAX_BLOCK_WEIGHT // WITNESS_SCALE_FACTOR)
         assert 'weightlimit' not in tmpl
-        assert_equal(tmpl['sigoplimit'], 20000)
+        assert_equal(tmpl['sigoplimit'], MAX_BLOCK_SIGOPS)
         assert_equal(tmpl['transactions'][0]['hash'], txid)
         assert_equal(tmpl['transactions'][0]['sigops'], 2)
         assert '!segwit' not in tmpl['rules']
@@ -164,17 +168,49 @@ class SegWitTest(BTQTestFramework):
 
             if self.options.descriptors:
                 res = self.nodes[i].importdescriptors([
-                {"desc": p2sh_ms_desc, "timestamp": "now"},
-                {"desc": bip173_ms_desc, "timestamp": "now"},
-                {"desc": sh_wpkh_desc, "timestamp": "now"},
-                {"desc": wpkh_desc, "timestamp": "now"},
-            ])
-            else:
-                # The nature of the legacy wallet is that this import results in also adding all of the necessary scripts
-                res = self.nodes[i].importmulti([
                     {"desc": p2sh_ms_desc, "timestamp": "now"},
+                    {"desc": bip173_ms_desc, "timestamp": "now"},
+                    {"desc": sh_wpkh_desc, "timestamp": "now"},
+                    {"desc": wpkh_desc, "timestamp": "now"},
                 ])
-            assert all([r["success"] for r in res])
+                assert all([r["success"] for r in res]), res
+            else:
+                res = self.nodes[i].importmulti([
+                    {
+                        "scriptPubKey": {"address": p2sh_ms_addr},
+                        "redeemscript": script_to_p2wsh_script(multiscript).hex(),
+                        "witnessscript": multiscript.hex(),
+                        "keys": [key.privkey],
+                        "timestamp": "now",
+                    },
+                    {
+                        "scriptPubKey": {"address": bip173_ms_addr},
+                        "witnessscript": multiscript.hex(),
+                        "keys": [key.privkey],
+                        "timestamp": "now",
+                    },
+                    {
+                        "scriptPubKey": {"address": key.p2sh_p2wpkh_addr},
+                        "redeemscript": key.p2sh_p2wpkh_redeem_script,
+                        "keys": [key.privkey],
+                        "timestamp": "now",
+                    },
+                    {
+                        "scriptPubKey": {"address": key.p2wpkh_addr},
+                        "keys": [key.privkey],
+                        "timestamp": "now",
+                    },
+                ])
+                # Legacy imports can learn related compressed-key witness scripts
+                # while processing earlier requests in this batch. A duplicate
+                # private-key error is therefore a positive ownership check for
+                # the concrete script form being requested.
+                assert all([
+                    r["success"] or (
+                        r["error"]["code"] == -4
+                        and "already contains the private key" in r["error"]["message"]
+                    ) for r in res
+                ]), res
 
             p2sh_ids.append([])
             wit_ids.append([])
@@ -185,15 +221,15 @@ class SegWitTest(BTQTestFramework):
         for _ in range(5):
             for n in range(3):
                 for v in range(2):
-                    wit_ids[n][v].append(send_to_witness(v, self.nodes[0], find_spendable_utxo(self.nodes[0], 50), self.pubkey[n], False, Decimal("49.999")))
-                    p2sh_ids[n][v].append(send_to_witness(v, self.nodes[0], find_spendable_utxo(self.nodes[0], 50), self.pubkey[n], True, Decimal("49.999")))
+                    wit_ids[n][v].append(send_to_witness(v, self.nodes[0], find_spendable_utxo(self.nodes[0], 5), self.pubkey[n], False, Decimal("4.999")))
+                    p2sh_ids[n][v].append(send_to_witness(v, self.nodes[0], find_spendable_utxo(self.nodes[0], 5), self.pubkey[n], True, Decimal("4.999")))
 
         self.generate(self.nodes[0], 1)  # block 163
 
         # Make sure all nodes recognize the transactions as theirs
-        assert_equal(self.nodes[0].getbalance(), balance_presetup - 60 * 50 + 20 * Decimal("49.999") + 50)
-        assert_equal(self.nodes[1].getbalance(), 20 * Decimal("49.999"))
-        assert_equal(self.nodes[2].getbalance(), 20 * Decimal("49.999"))
+        assert_equal(self.nodes[0].getbalance(), balance_presetup - 60 * 5 + 20 * Decimal("4.999") + 5)
+        assert_equal(self.nodes[1].getbalance(), 20 * Decimal("4.999"))
+        assert_equal(self.nodes[2].getbalance(), 20 * Decimal("4.999"))
 
         self.log.info("Verify unsigned p2sh witness txs without a redeem script are invalid")
         self.fail_accept(self.nodes[2], "mandatory-script-verify-flag-failed (Operation not valid with the current stack size)", p2sh_ids[NODE_2][P2WPKH][1], sign=False)
@@ -203,10 +239,10 @@ class SegWitTest(BTQTestFramework):
 
         self.log.info("Verify witness txs are mined as soon as segwit activates")
 
-        send_to_witness(1, self.nodes[2], getutxo(wit_ids[NODE_2][P2WPKH][0]), self.pubkey[0], encode_p2sh=False, amount=Decimal("49.998"), sign=True)
-        send_to_witness(1, self.nodes[2], getutxo(wit_ids[NODE_2][P2WSH][0]), self.pubkey[0], encode_p2sh=False, amount=Decimal("49.998"), sign=True)
-        send_to_witness(1, self.nodes[2], getutxo(p2sh_ids[NODE_2][P2WPKH][0]), self.pubkey[0], encode_p2sh=False, amount=Decimal("49.998"), sign=True)
-        send_to_witness(1, self.nodes[2], getutxo(p2sh_ids[NODE_2][P2WSH][0]), self.pubkey[0], encode_p2sh=False, amount=Decimal("49.998"), sign=True)
+        send_to_witness(1, self.nodes[2], getutxo(wit_ids[NODE_2][P2WPKH][0]), self.pubkey[0], encode_p2sh=False, amount=Decimal("4.998"), sign=True)
+        send_to_witness(1, self.nodes[2], getutxo(wit_ids[NODE_2][P2WSH][0]), self.pubkey[0], encode_p2sh=False, amount=Decimal("4.998"), sign=True)
+        send_to_witness(1, self.nodes[2], getutxo(p2sh_ids[NODE_2][P2WPKH][0]), self.pubkey[0], encode_p2sh=False, amount=Decimal("4.998"), sign=True)
+        send_to_witness(1, self.nodes[2], getutxo(p2sh_ids[NODE_2][P2WSH][0]), self.pubkey[0], encode_p2sh=False, amount=Decimal("4.998"), sign=True)
 
         assert_equal(len(self.nodes[2].getrawmempool()), 4)
         blockhash = self.generate(self.nodes[2], 1)[0]  # block 165 (first block with new rules)
@@ -261,10 +297,12 @@ class SegWitTest(BTQTestFramework):
         raw_tx = self.nodes[0].getrawtransaction(txid, True)
         tmpl = self.nodes[0].getblocktemplate({'rules': ['segwit']})
         assert_greater_than_or_equal(tmpl['sizelimit'], 3999577)  # actual maximum size is lower due to minimum mandatory non-witness data
-        assert_equal(tmpl['weightlimit'], 4000000)
-        assert_equal(tmpl['sigoplimit'], 80000)
+        assert_equal(tmpl['weightlimit'], MAX_BLOCK_WEIGHT)
+        assert_equal(tmpl['sigoplimit'], MAX_BLOCK_SIGOPS * WITNESS_SCALE_FACTOR)
         assert_equal(tmpl['transactions'][0]['txid'], txid)
-        expected_sigops = 9 if 'txinwitness' in raw_tx["vin"][0] else 8
+        expected_sigops = 2 * WITNESS_SCALE_FACTOR
+        if 'txinwitness' in raw_tx["vin"][0]:
+            expected_sigops += 1
         assert_equal(tmpl['transactions'][0]['sigops'], expected_sigops)
         assert '!segwit' in tmpl['rules']
 
@@ -275,7 +313,7 @@ class SegWitTest(BTQTestFramework):
         #                      tx2 (segwit input, paying to a non-segwit output) ->
         #                      tx3 (non-segwit input, paying to a non-segwit output).
         # tx1 is allowed to appear in the block, but no others.
-        txid1 = send_to_witness(1, self.nodes[0], find_spendable_utxo(self.nodes[0], 50), self.pubkey[0], False, Decimal("49.996"))
+        txid1 = send_to_witness(1, self.nodes[0], find_spendable_utxo(self.nodes[0], 5), self.pubkey[0], False, Decimal("4.996"))
         hex_tx = self.nodes[0].gettransaction(txid)['hex']
         tx = tx_from_hex(hex_tx)
         assert tx.wit.is_null()  # This should not be a segwit input
@@ -294,7 +332,7 @@ class SegWitTest(BTQTestFramework):
         # Now create tx2, which will spend from txid1.
         tx = CTransaction()
         tx.vin.append(CTxIn(COutPoint(int(txid1, 16), 0), b''))
-        tx.vout.append(CTxOut(int(49.99 * COIN), CScript([OP_TRUE, OP_DROP] * 15 + [OP_TRUE])))
+        tx.vout.append(CTxOut(int(4.99 * COIN), CScript([OP_TRUE, OP_DROP] * 15 + [OP_TRUE])))
         tx2_hex = self.nodes[0].signrawtransactionwithwallet(tx.serialize().hex())['hex']
         txid2 = self.nodes[0].sendrawtransaction(tx2_hex)
         tx = tx_from_hex(tx2_hex)
@@ -310,7 +348,7 @@ class SegWitTest(BTQTestFramework):
         # Now create tx3, which will spend from txid2
         tx = CTransaction()
         tx.vin.append(CTxIn(COutPoint(int(txid2, 16), 0), b""))
-        tx.vout.append(CTxOut(int(49.95 * COIN), CScript([OP_TRUE, OP_DROP] * 15 + [OP_TRUE])))  # Huge fee
+        tx.vout.append(CTxOut(int(4.95 * COIN), CScript([OP_TRUE, OP_DROP] * 15 + [OP_TRUE])))  # Huge fee
         tx.calc_sha256()
         txid3 = self.nodes[0].sendrawtransaction(hexstring=tx.serialize().hex(), maxfeerate=0)
         assert tx.wit.is_null()
@@ -619,11 +657,11 @@ class SegWitTest(BTQTestFramework):
         self.nodes[0].assert_start_raises_init_error(["-rpcserialversion=100"], "Error: Unknown rpcserialversion requested.")
 
     def mine_and_test_listunspent(self, script_list, ismine):
-        utxo = find_spendable_utxo(self.nodes[0], 50)
+        utxo = find_spendable_utxo(self.nodes[0], 5)
         tx = CTransaction()
         tx.vin.append(CTxIn(COutPoint(int('0x' + utxo['txid'], 0), utxo['vout'])))
         for i in script_list:
-            tx.vout.append(CTxOut(10000000, i))
+            tx.vout.append(CTxOut(LISTUNSPENT_TEST_OUTPUT_VALUE, i))
         tx.rehash()
         signresults = self.nodes[0].signrawtransactionwithwallet(tx.serialize_without_witness().hex())['hex']
         txid = self.nodes[0].sendrawtransaction(hexstring=signresults, maxfeerate=0)

--- a/test/functional/p2p_invalid_messages.py
+++ b/test/functional/p2p_invalid_messages.py
@@ -11,7 +11,7 @@ import time
 from test_framework.messages import (
     CBlockHeader,
     CInv,
-    MAX_HEADERS_RESULTS,
+MAX_HEADERS_RESULTS,
     MAX_INV_SIZE,
     MAX_PROTOCOL_MESSAGE_LENGTH,
     MSG_TX,
@@ -33,6 +33,7 @@ from test_framework.util import (
 )
 
 VALID_DATA_LIMIT = MAX_PROTOCOL_MESSAGE_LENGTH - 5  # Account for the 5-byte length prefix
+RESOURCE_EXHAUSTION_DATA_LIMIT = min(VALID_DATA_LIMIT, 4_000_000 - 5)
 
 
 class msg_unrecognized:
@@ -137,7 +138,9 @@ class InvalidMessagesTest(BTQTestFramework):
     def test_size(self):
         self.log.info("Test message with oversized payload disconnects peer")
         conn = self.nodes[0].add_p2p_connection(P2PDataStore())
-        with self.nodes[0].assert_debug_log(['Header error: Size too large (badmsg, 4000001 bytes)']):
+        with self.nodes[0].assert_debug_log([
+            f'Header error: Size too large (badmsg, {MAX_PROTOCOL_MESSAGE_LENGTH + 1} bytes)'
+        ]):
             msg = msg_unrecognized(str_data="d" * (VALID_DATA_LIMIT + 1))
             msg = conn.build_message(msg)
             conn.send_raw_message(msg)
@@ -308,10 +311,10 @@ class InvalidMessagesTest(BTQTestFramework):
         self.log.info("Test node stays up despite many large junk messages")
         conn = self.nodes[0].add_p2p_connection(P2PDataStore())
         conn2 = self.nodes[0].add_p2p_connection(P2PDataStore())
-        msg_at_size = msg_unrecognized(str_data="b" * VALID_DATA_LIMIT)
-        assert len(msg_at_size.serialize()) == MAX_PROTOCOL_MESSAGE_LENGTH
+        msg_at_size = msg_unrecognized(str_data="b" * RESOURCE_EXHAUSTION_DATA_LIMIT)
+        assert len(msg_at_size.serialize()) <= MAX_PROTOCOL_MESSAGE_LENGTH
 
-        self.log.info("(a) Send 80 messages, each of maximum valid data size (4MB)")
+        self.log.info(f"(a) Send 80 large valid messages, each {len(msg_at_size.serialize())} bytes")
         for _ in range(80):
             conn.send_message(msg_at_size)
 

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -28,6 +28,10 @@ from test_framework.util import (
 from test_framework.wallet import MiniWallet
 
 
+MAX_RPC_BODY_SIZE = 0x02000000
+RPC_HEX_MESSAGE_OVERHEAD = 1024
+
+
 def assert_net_servicesnames(servicesflag, servicenames):
     """Utility that checks if all flags are correctly decoded in
     `getpeerinfo` and `getnetworkinfo`.
@@ -364,10 +368,13 @@ class NetTest(BTQTestFramework):
         self.log.debug("Test that empty msg is allowed")
         node.sendmsgtopeer(peer_id=0, msg_type="addr", msg="FF")
 
-        self.log.debug("Test that oversized messages are allowed, but get us disconnected")
-        zero_byte_string = b'\x00' * 4000001
-        node.sendmsgtopeer(peer_id=0, msg_type="addr", msg=zero_byte_string.hex())
-        self.wait_until(lambda: len(self.nodes[0].getpeerinfo()) == 0, timeout=10)
+        if 2 * (test_framework.messages.MAX_PROTOCOL_MESSAGE_LENGTH + 1) + RPC_HEX_MESSAGE_OVERHEAD < MAX_RPC_BODY_SIZE:
+            self.log.debug("Test that oversized messages are allowed, but get us disconnected")
+            zero_byte_string = b'\x00' * (test_framework.messages.MAX_PROTOCOL_MESSAGE_LENGTH + 1)
+            node.sendmsgtopeer(peer_id=0, msg_type="addr", msg=zero_byte_string.hex())
+            self.wait_until(lambda: len(self.nodes[0].getpeerinfo()) == 0, timeout=10)
+        else:
+            self.log.debug("Skip oversized sendmsgtopeer disconnect test because the hex RPC body would exceed the RPC transport limit")
 
     def test_getaddrmaninfo(self):
         self.log.info("Test getaddrmaninfo")

--- a/test/functional/rpc_rawtransaction.py
+++ b/test/functional/rpc_rawtransaction.py
@@ -90,6 +90,7 @@ class RawTransactionsTest(BTQTestFramework):
         self.sendrawtransaction_tests()
         self.sendrawtransaction_testmempoolaccept_tests()
         self.decoderawtransaction_tests()
+        self.decodescript_p2mr_tests()
         self.transaction_version_number_tests()
         if self.is_specified_wallet_compiled() and not self.options.descriptors:
             self.import_deterministic_coinbase_privkeys()
@@ -360,7 +361,7 @@ class RawTransactionsTest(BTQTestFramework):
         tx_val = 0.001
         tx.vout = [CTxOut(int(Decimal(tx_val) * COIN), CScript([OP_FALSE] * 10001))]
         tx_hex = tx.serialize().hex()
-        assert_raises_rpc_error(-25, max_burn_exceeded, self.nodes[2].sendrawtransaction, tx_hex)
+        assert_raises_rpc_error(-26, "scriptpubkey", self.nodes[2].sendrawtransaction, tx_hex)
 
         # Test that script containing invalid opcode gets rejected by sendrawtransaction
         tx = self.wallet.create_self_transfer()['tx']
@@ -450,6 +451,14 @@ class RawTransactionsTest(BTQTestFramework):
         assert_raises_rpc_error(-22, 'TX decode failed', self.nodes[0].decoderawtransaction, encrawtx, False)  # fails to decode as non-witness transaction
         assert_equal(decrawtx, decrawtx_wit)  # the witness interpretation should be chosen
         assert_equal(decrawtx['vin'][0]['coinbase'], coinbase)
+
+    def decodescript_p2mr_tests(self):
+        self.log.info("Test decodescript does not offer legacy wrappers for P2MR witness programs")
+        decoded = self.nodes[0].decodescript("5220" + "11" * 32)
+        assert_equal(decoded["type"], "witness_v2_p2mr")
+        assert "address" in decoded
+        assert "p2sh" not in decoded
+        assert "segwit" not in decoded
 
     def transaction_version_number_tests(self):
         self.log.info("Test transaction version numbers")

--- a/test/functional/test_framework/blocktools.py
+++ b/test/functional/test_framework/blocktools.py
@@ -46,13 +46,13 @@ from .script_util import (
 from .util import assert_equal
 
 WITNESS_SCALE_FACTOR = 16
-MAX_BLOCK_SIGOPS = 20000
+MAX_BLOCK_SIGOPS = 5000
 MAX_BLOCK_SIGOPS_WEIGHT = MAX_BLOCK_SIGOPS * WITNESS_SCALE_FACTOR
 
 # Genesis block time (regtest)
-TIME_GENESIS_BLOCK = 1296688602
+TIME_GENESIS_BLOCK = 1771804800
 
-MAX_FUTURE_BLOCK_TIME = 2 * 60 * 60
+MAX_FUTURE_BLOCK_TIME = 15 * 60
 
 # Coinbase transaction outputs can only be spent after this number of new blocks (network rule)
 COINBASE_MATURITY = 100
@@ -122,7 +122,7 @@ def script_BIP34_coinbase_height(height):
     return CScript([CScriptNum(height)])
 
 
-def create_coinbase(height, pubkey=None, *, script_pubkey=None, extra_output_script=None, fees=0, nValue=50):
+def create_coinbase(height, pubkey=None, *, script_pubkey=None, extra_output_script=None, fees=0, nValue=5):
     """Create a coinbase transaction.
 
     If pubkey is passed in, the coinbase output will be a P2PK output;
@@ -134,8 +134,8 @@ def create_coinbase(height, pubkey=None, *, script_pubkey=None, extra_output_scr
     coinbase.vin.append(CTxIn(COutPoint(0, 0xffffffff), script_BIP34_coinbase_height(height), SEQUENCE_FINAL))
     coinbaseoutput = CTxOut()
     coinbaseoutput.nValue = nValue * COIN
-    if nValue == 50:
-        halvings = int(height / 150)  # regtest
+    if nValue == 5:
+        halvings = int(height / 1500)  # regtest
         coinbaseoutput.nValue >>= halvings
         coinbaseoutput.nValue += fees
     if pubkey is not None:

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -43,7 +43,7 @@ MAX_MONEY = 21000000 * COIN
 MAX_BIP125_RBF_SEQUENCE = 0xfffffffd  # Sequence number that is rbf-opt-in (BIP 125) and csv-opt-out (BIP 68)
 SEQUENCE_FINAL = 0xffffffff  # Sequence number that disables nLockTime if set for every input of a tx
 
-MAX_PROTOCOL_MESSAGE_LENGTH = 4000000  # Maximum length of incoming protocol messages
+MAX_PROTOCOL_MESSAGE_LENGTH = 70000000  # Maximum length of incoming protocol messages
 MAX_HEADERS_RESULTS = 2000  # Number of headers sent in one getheaders result
 MAX_INV_SIZE = 50000  # Maximum number of entries in an 'inv' protocol message
 

--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -141,10 +141,10 @@ MESSAGEMAP = {
 }
 
 MAGIC_BYTES = {
-    "mainnet": b"\xf9\xbe\xb4\xd9",   # mainnet
-    "testnet3": b"\x0b\x11\x09\x07",  # testnet3
+    "mainnet": b"\xf1\xb2\xa3\xd4",   # mainnet
+    "testnet3": b"\x0c\x12\x0a\x08",  # testnet3
     "regtest": b"\xfa\xbf\xb5\xda",   # regtest
-    "signet": b"\x0a\x03\xcf\x40",    # signet
+    "signet": b"\x7f\x2d\xf3\xca",    # signet
 }
 
 

--- a/test/functional/test_framework/script.py
+++ b/test/functional/test_framework/script.py
@@ -28,6 +28,7 @@ from .ripemd160 import ripemd160
 
 MAX_SCRIPT_ELEMENT_SIZE = 15000  # BTQ consensus cap (see src/script/script.h)
 MAX_PUBKEYS_PER_MULTI_A = 999
+DILITHIUM_SIGOP_COST = 50
 LOCKTIME_THRESHOLD = 500000000
 ANNEX_TAG = 0x50
 
@@ -601,11 +602,18 @@ class CScript(bytes):
         for (opcode, data, sop_idx) in self.raw_iter():
             if opcode in (OP_CHECKSIG, OP_CHECKSIGVERIFY):
                 n += 1
+            elif opcode in (OP_CHECKSIGDILITHIUM, OP_CHECKSIGDILITHIUMVERIFY):
+                n += DILITHIUM_SIGOP_COST
             elif opcode in (OP_CHECKMULTISIG, OP_CHECKMULTISIGVERIFY):
                 if fAccurate and (OP_1 <= lastOpcode <= OP_16):
-                    n += opcode.decode_op_n()
+                    n += lastOpcode - OP_1 + 1
                 else:
                     n += 20
+            elif opcode in (OP_CHECKMULTISIGDILITHIUM, OP_CHECKMULTISIGDILITHIUMVERIFY):
+                if fAccurate and (OP_1 <= lastOpcode <= OP_16):
+                    n += (lastOpcode - OP_1 + 1) * DILITHIUM_SIGOP_COST
+                else:
+                    n += 20 * DILITHIUM_SIGOP_COST
             lastOpcode = opcode
         return n
 

--- a/test/functional/test_framework/wallet.py
+++ b/test/functional/test_framework/wallet.py
@@ -33,6 +33,7 @@ from test_framework.messages import (
     CTxIn,
     CTxInWitness,
     CTxOut,
+    WITNESS_SCALE_FACTOR,
 )
 from test_framework.script import (
     CScript,
@@ -114,12 +115,13 @@ class MiniWallet:
         returns the tx
         """
         tx.vout.append(CTxOut(nValue=0, scriptPubKey=CScript([OP_RETURN, b'a'])))
-        dummy_vbytes = (target_weight - tx.get_weight() + 3) // 4
+        dummy_vbytes = (target_weight - tx.get_weight() + WITNESS_SCALE_FACTOR - 1) // WITNESS_SCALE_FACTOR
         tx.vout[-1].scriptPubKey = CScript([OP_RETURN, b'a' * dummy_vbytes])
         # Lower bound should always be off by at most 3
         assert_greater_than_or_equal(tx.get_weight(), target_weight)
-        # Higher bound should always be off by at most 3 + 12 weight (for encoding the length)
-        assert_greater_than_or_equal(target_weight + 15, tx.get_weight())
+        # Higher bound should always be off by at most one script byte plus
+        # three script length encoding bytes.
+        assert_greater_than_or_equal(target_weight + 4 * WITNESS_SCALE_FACTOR - 1, tx.get_weight())
 
     def get_balance(self):
         return sum(u['value'] for u in self._utxos)

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -109,6 +109,8 @@ BASE_SCRIPTS = [
     'feature_p2mr.py',
     'feature_p2mr_rpc.py --descriptors',
     'feature_block.py',
+    'btq_regtest_mining.py',
+    'btq_chain_identity.py',
     # vv Tests less than 2m vv
     'mining_getblocktemplate_longpoll.py',
     'p2p_segwit.py',
@@ -801,7 +803,7 @@ class TestResult():
 def check_script_prefixes():
     """Check that test scripts start with one of the allowed name prefixes."""
 
-    good_prefixes_re = re.compile("^(example|feature|interface|mempool|mining|p2p|rpc|wallet|tool)_")
+    good_prefixes_re = re.compile("^(btq|example|feature|interface|mempool|mining|p2p|rpc|wallet|tool)_")
     bad_script_names = [script for script in ALL_SCRIPTS if good_prefixes_re.match(script) is None]
 
     if bad_script_names:

--- a/test/functional/wallet_dilithium_send.py
+++ b/test/functional/wallet_dilithium_send.py
@@ -7,7 +7,7 @@
 from decimal import Decimal
 
 from test_framework.test_framework import BTQTestFramework
-from test_framework.util import assert_equal
+from test_framework.util import assert_equal, assert_raises_rpc_error
 
 
 class WalletDilithiumSendTest(BTQTestFramework):
@@ -31,17 +31,37 @@ class WalletDilithiumSendTest(BTQTestFramework):
         node.createwallet(wallet_name="repro", descriptors=True)
         repro = node.get_wallet_rpc("repro")
 
-        self.log.info("Fund repro wallet with confirmed Dilithium and bech32m UTXOs")
+        self.log.info("Descriptor Dilithium keys remain usable after wallet encryption")
         dilithium_address = repro.getnewdilithiumaddress()
+        msg = "descriptor encrypted dilithium signing"
+        sig = repro.signmessagewithdilithium(dilithium_address, msg)
+        assert repro.verifydilithiumsignature(msg, dilithium_address, sig)
+        repro.encryptwallet("pass")
+        assert_raises_rpc_error(
+            -13,
+            "Please enter the wallet passphrase with walletpassphrase first",
+            repro.signmessagewithdilithium,
+            dilithium_address,
+            msg,
+        )
+        repro.walletpassphrase("pass", 100000)
+        sig = repro.signmessagewithdilithium(dilithium_address, msg)
+        assert repro.verifydilithiumsignature(msg, dilithium_address, sig)
+
+        self.log.info("Fund repro wallet with confirmed Dilithium and bech32m UTXOs")
         taproot_address = repro.getnewaddress(address_type="bech32m")
+        # A second Dilithium UTXO so sendmany can be exercised independently.
+        dilithium_address2 = repro.getnewdilithiumaddress()
         funding.sendtoaddress(dilithium_address, Decimal("10"))
+        funding.sendtoaddress(dilithium_address2, Decimal("10"))
         funding.sendtoaddress(taproot_address, Decimal("10"))
         self.generate(node, 1)
 
         utxos = repro.listunspent()
-        assert_equal(len(utxos), 2)
+        assert_equal(len(utxos), 3)
 
         dilithium_utxo = next(utxo for utxo in utxos if utxo["address"] == dilithium_address)
+        dilithium_utxo2 = next(utxo for utxo in utxos if utxo["address"] == dilithium_address2)
         taproot_utxo = next(utxo for utxo in utxos if utxo["address"] == taproot_address)
 
         raw = repro.createrawtransaction(
@@ -52,12 +72,47 @@ class WalletDilithiumSendTest(BTQTestFramework):
         assert funded["hex"]
         assert funded["fee"] > 0
 
-        self.log.info("sendtoaddress must return success while spending the Dilithium UTXO")
-        repro.lockunspent(False, [{"txid": taproot_utxo["txid"], "vout": taproot_utxo["vout"]}])
+        self.log.info("sendtoaddress must return a valid, broadcastable tx spending the Dilithium UTXO")
+        # Lock every other input so coin selection is forced to spend the Dilithium UTXO,
+        # exercising the OP_CHECKSIGDILITHIUM signing path (regression for issue #41).
+        repro.lockunspent(False, [
+            {"txid": taproot_utxo["txid"], "vout": taproot_utxo["vout"]},
+            {"txid": dilithium_utxo2["txid"], "vout": dilithium_utxo2["vout"]},
+        ])
         destination = repro.getnewaddress()
         txid = repro.sendtoaddress(destination, Decimal("0.01"))
         assert txid
         assert txid in node.getrawmempool()
+
+        # The Dilithium UTXO must actually be the input that was spent.
+        spent_outpoints = {(vin["txid"], vin["vout"]) for vin in node.getrawtransaction(txid, True)["vin"]}
+        assert (dilithium_utxo["txid"], dilithium_utxo["vout"]) in spent_outpoints
+
+        # Crux of issue #41: the RPC reported success AND the tx is consensus-valid.
+        # Mining it proves the Dilithium signature verifies, not merely that it relayed.
+        self.generate(node, 1)
+        assert_equal(repro.gettransaction(txid)["confirmations"], 1)
+        unspent_after = {(u["txid"], u["vout"]) for u in repro.listunspent(0)}
+        assert (dilithium_utxo["txid"], dilithium_utxo["vout"]) not in unspent_after
+
+        self.log.info("sendmany must also spend a Dilithium UTXO and broadcast a valid tx")
+        repro.lockunspent(True)
+        # Leave only the second Dilithium UTXO spendable.
+        others = [
+            {"txid": u["txid"], "vout": u["vout"]}
+            for u in repro.listunspent(0)
+            if (u["txid"], u["vout"]) != (dilithium_utxo2["txid"], dilithium_utxo2["vout"])
+        ]
+        repro.lockunspent(False, others)
+        many_txid = repro.sendmany("", {
+            repro.getnewaddress(): Decimal("0.2"),
+            repro.getnewdilithiumaddress(): Decimal("0.3"),
+        })
+        assert many_txid in node.getrawmempool()
+        many_spent = {(vin["txid"], vin["vout"]) for vin in node.getrawtransaction(many_txid, True)["vin"]}
+        assert (dilithium_utxo2["txid"], dilithium_utxo2["vout"]) in many_spent
+        self.generate(node, 1)
+        assert_equal(repro.gettransaction(many_txid)["confirmations"], 1)
 
 
 if __name__ == "__main__":

--- a/test/lint/lint-btq-consensus-constants.py
+++ b/test/lint/lint-btq-consensus-constants.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2026 The BTQ Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+"""Check that BTQ consensus constants mirrored in the functional test framework
+stay synchronized with their C++ definitions."""
+
+from ast import (
+    Add,
+    Assign,
+    BinOp,
+    Constant,
+    Div,
+    FloorDiv,
+    FunctionDef,
+    Module,
+    Mult,
+    Name,
+    Sub,
+    UnaryOp,
+    USub,
+    literal_eval,
+    parse,
+)
+from pathlib import Path
+import hashlib
+import re
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def eval_int_expr(node, names):
+    if isinstance(node, Constant) and isinstance(node.value, int):
+        return node.value
+    if isinstance(node, Name):
+        return names[node.id]
+    if isinstance(node, UnaryOp) and isinstance(node.op, USub):
+        return -eval_int_expr(node.operand, names)
+    if isinstance(node, BinOp):
+        lhs = eval_int_expr(node.left, names)
+        rhs = eval_int_expr(node.right, names)
+        if isinstance(node.op, Add):
+            return lhs + rhs
+        if isinstance(node.op, Sub):
+            return lhs - rhs
+        if isinstance(node.op, Mult):
+            return lhs * rhs
+        if isinstance(node.op, (Div, FloorDiv)):
+            if lhs % rhs != 0:
+                raise ValueError(f"non-integral division in expression: {lhs} / {rhs}")
+            return lhs // rhs
+    raise ValueError(f"unsupported integer expression: {node!r}")
+
+
+def cpp_constant(path, name):
+    text = (REPO_ROOT / path).read_text(encoding="utf8")
+    match = re.search(
+        rf"\b{name}\b\s*=\s*(?P<expr>[^;]+);",
+        text,
+    )
+    if not match:
+        raise ValueError(f"could not find {name} in {path}")
+    expr = match.group("expr").split("//", 1)[0].strip()
+    tree = parse(expr, mode="eval")
+    return eval_int_expr(tree.body, {})
+
+
+def cpp_regex_int(path, pattern):
+    text = (REPO_ROOT / path).read_text(encoding="utf8")
+    match = re.search(pattern, text, re.DOTALL)
+    if not match:
+        raise ValueError(f"could not match {pattern!r} in {path}")
+    return int(match.group(1), 0)
+
+
+def cpp_message_start(class_name):
+    text = (REPO_ROOT / "src/kernel/chainparams.cpp").read_text(encoding="utf8")
+    match = re.search(
+        rf"class {class_name}[\s\S]*?"
+        r"pchMessageStart\[0\]\s*=\s*(0x[0-9a-fA-F]+);[\s\S]*?"
+        r"pchMessageStart\[1\]\s*=\s*(0x[0-9a-fA-F]+);[\s\S]*?"
+        r"pchMessageStart\[2\]\s*=\s*(0x[0-9a-fA-F]+);[\s\S]*?"
+        r"pchMessageStart\[3\]\s*=\s*(0x[0-9a-fA-F]+);",
+        text,
+    )
+    if not match:
+        raise ValueError(f"could not find {class_name} pchMessageStart")
+    return bytes(int(group, 16) for group in match.groups())
+
+
+def cpp_default_signet_message_start():
+    text = (REPO_ROOT / "src/kernel/chainparams.cpp").read_text(encoding="utf8")
+    match = re.search(r'bin = ParseHex\("([0-9a-fA-F]+)"\);', text)
+    if not match:
+        raise ValueError("could not find default signet challenge")
+    challenge = bytes.fromhex(match.group(1))
+    payload = bytes([len(challenge)]) + challenge
+    return hashlib.sha256(hashlib.sha256(payload).digest()).digest()[:4]
+
+
+def python_constants(path):
+    tree = parse((REPO_ROOT / path).read_text(encoding="utf8"))
+    assert isinstance(tree, Module)
+    names = {}
+    for statement in tree.body:
+        if not isinstance(statement, Assign):
+            continue
+        if len(statement.targets) != 1 or not isinstance(statement.targets[0], Name):
+            continue
+        try:
+            names[statement.targets[0].id] = eval_int_expr(statement.value, names)
+        except (KeyError, ValueError):
+            continue
+    return names
+
+
+def python_function_kw_default(path, function_name, kwarg_name):
+    tree = parse((REPO_ROOT / path).read_text(encoding="utf8"))
+    for statement in tree.body:
+        if not isinstance(statement, FunctionDef) or statement.name != function_name:
+            continue
+        for arg, default in zip(statement.args.kwonlyargs, statement.args.kw_defaults):
+            if arg.arg != kwarg_name:
+                continue
+            return eval_int_expr(default, {})
+    raise ValueError(f"could not find default for {function_name}({kwarg_name}) in {path}")
+
+
+def python_regex_int(path, pattern):
+    text = (REPO_ROOT / path).read_text(encoding="utf8")
+    match = re.search(pattern, text)
+    if not match:
+        raise ValueError(f"could not match {pattern!r} in {path}")
+    return int(match.group(1), 0)
+
+
+def python_magic_bytes():
+    text = (REPO_ROOT / "test/functional/test_framework/p2p.py").read_text(encoding="utf8")
+    match = re.search(r"MAGIC_BYTES\s*=\s*\{(?P<body>.*?)\n\}", text, re.DOTALL)
+    if not match:
+        raise ValueError("could not find MAGIC_BYTES in p2p.py")
+    values = {}
+    for item in re.finditer(r'"(?P<network>[^"]+)":\s*(?P<magic>b"[^"]+")', match.group("body")):
+        values[item.group("network")] = literal_eval(item.group("magic"))
+    return values
+
+
+MISSING = object()
+
+
+def check_equal(errors, label, actual, expected):
+    if actual is MISSING:
+        errors.append(f"{label}: missing, expected {expected}")
+        return
+    if actual != expected:
+        errors.append(f"{label}: got {actual}, expected {expected}")
+
+
+def main():
+    errors = []
+
+    consensus = {
+        "MAX_BLOCK_WEIGHT": cpp_constant("src/consensus/consensus.h", "MAX_BLOCK_WEIGHT"),
+        "MAX_BLOCK_SIGOPS_COST": cpp_constant("src/consensus/consensus.h", "MAX_BLOCK_SIGOPS_COST"),
+        "WITNESS_SCALE_FACTOR": cpp_constant("src/consensus/consensus.h", "WITNESS_SCALE_FACTOR"),
+        "COINBASE_MATURITY": cpp_constant("src/consensus/consensus.h", "COINBASE_MATURITY"),
+        "MAX_SCRIPT_ELEMENT_SIZE": cpp_constant("src/script/script.h", "MAX_SCRIPT_ELEMENT_SIZE"),
+        "DILITHIUM_SIGOP_COST": cpp_constant("src/script/script.h", "DILITHIUM_SIGOP_COST"),
+        "MAX_FUTURE_BLOCK_TIME": cpp_constant("src/chain.h", "MAX_FUTURE_BLOCK_TIME"),
+        "MAX_PROTOCOL_MESSAGE_LENGTH": cpp_constant("src/net.h", "MAX_PROTOCOL_MESSAGE_LENGTH"),
+        "INITIAL_SUBSIDY_BTQ": cpp_regex_int("src/validation.cpp", r"CAmount nSubsidy = (\d+) \* COIN;"),
+        "REGTEST_HALVING_INTERVAL": cpp_regex_int("src/kernel/chainparams.cpp", r"class CRegTestParams[\s\S]*?consensus\.nSubsidyHalvingInterval = (\d+);"),
+        "REGTEST_GENESIS_TIME": cpp_regex_int("src/kernel/chainparams.cpp", r"class CRegTestParams[\s\S]*?genesis = CreateGenesisBlock\([^;]*?,\s*(\d+),\s*3,\s*0x"),
+    }
+
+    messages = python_constants("test/functional/test_framework/messages.py")
+    blocktools = python_constants("test/functional/test_framework/blocktools.py")
+    script = python_constants("test/functional/test_framework/script.py")
+    magic_bytes = python_magic_bytes()
+
+    check_equal(errors, "messages.MAX_BLOCK_WEIGHT", messages.get("MAX_BLOCK_WEIGHT", MISSING), consensus["MAX_BLOCK_WEIGHT"])
+    check_equal(
+        errors,
+        "messages.MAX_PROTOCOL_MESSAGE_LENGTH",
+        messages.get("MAX_PROTOCOL_MESSAGE_LENGTH", MISSING),
+        consensus["MAX_PROTOCOL_MESSAGE_LENGTH"],
+    )
+    check_equal(
+        errors,
+        "blocktools.WITNESS_SCALE_FACTOR",
+        blocktools.get("WITNESS_SCALE_FACTOR", MISSING),
+        consensus["WITNESS_SCALE_FACTOR"],
+    )
+    check_equal(
+        errors,
+        "blocktools.MAX_BLOCK_SIGOPS_WEIGHT",
+        blocktools.get("MAX_BLOCK_SIGOPS_WEIGHT", MISSING),
+        consensus["MAX_BLOCK_SIGOPS_COST"],
+    )
+    check_equal(
+        errors,
+        "blocktools.MAX_BLOCK_SIGOPS",
+        blocktools.get("MAX_BLOCK_SIGOPS", MISSING),
+        consensus["MAX_BLOCK_SIGOPS_COST"] // consensus["WITNESS_SCALE_FACTOR"],
+    )
+    check_equal(
+        errors,
+        "blocktools.MAX_FUTURE_BLOCK_TIME",
+        blocktools.get("MAX_FUTURE_BLOCK_TIME", MISSING),
+        consensus["MAX_FUTURE_BLOCK_TIME"],
+    )
+    check_equal(
+        errors,
+        "blocktools.COINBASE_MATURITY",
+        blocktools.get("COINBASE_MATURITY", MISSING),
+        consensus["COINBASE_MATURITY"],
+    )
+    check_equal(
+        errors,
+        "blocktools.TIME_GENESIS_BLOCK",
+        blocktools.get("TIME_GENESIS_BLOCK", MISSING),
+        consensus["REGTEST_GENESIS_TIME"],
+    )
+    check_equal(
+        errors,
+        "blocktools.create_coinbase nValue default",
+        python_function_kw_default("test/functional/test_framework/blocktools.py", "create_coinbase", "nValue"),
+        consensus["INITIAL_SUBSIDY_BTQ"],
+    )
+    check_equal(
+        errors,
+        "blocktools.create_coinbase halving interval",
+        python_regex_int("test/functional/test_framework/blocktools.py", r"halvings = int\(height / (\d+)\)"),
+        consensus["REGTEST_HALVING_INTERVAL"],
+    )
+    check_equal(
+        errors,
+        "script.MAX_SCRIPT_ELEMENT_SIZE",
+        script.get("MAX_SCRIPT_ELEMENT_SIZE", MISSING),
+        consensus["MAX_SCRIPT_ELEMENT_SIZE"],
+    )
+    check_equal(
+        errors,
+        "script.DILITHIUM_SIGOP_COST",
+        script.get("DILITHIUM_SIGOP_COST", MISSING),
+        consensus["DILITHIUM_SIGOP_COST"],
+    )
+    check_equal(errors, "p2p.MAGIC_BYTES mainnet", magic_bytes.get("mainnet", MISSING), cpp_message_start("CMainParams"))
+    check_equal(errors, "p2p.MAGIC_BYTES testnet3", magic_bytes.get("testnet3", MISSING), cpp_message_start("CTestNetParams"))
+    check_equal(errors, "p2p.MAGIC_BYTES regtest", magic_bytes.get("regtest", MISSING), cpp_message_start("CRegTestParams"))
+    check_equal(errors, "p2p.MAGIC_BYTES signet", magic_bytes.get("signet", MISSING), cpp_default_signet_message_start())
+
+    if errors:
+        print("BTQ consensus constant drift detected:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Brings the PR #57 wallet/Dilithium/P2MR/constants audit hardening up to date with current `master` (PR #56 + #59 "activate Taproot / close second-pass audit gaps"), reconciles the divergences between the two, and closes the remaining concrete audit items. Diff is the PR #57 work + reconciliation + audit fixes only (master's own #59 content is not part of this diff).

## What's in here

**Merge reconciliation (where #57 and #59 overlapped)**
- Encrypted Dilithium key IV standardized on `DeriveDilithiumKeyIV()` with a legacy raw-keyid decrypt fallback (`crypter.cpp`, `scriptpubkeyman.cpp`).
- Dilithium script verification gated via the buried `DEPLOYMENT_DILITHIUM` (master/#59 design, audit-017); `SCRIPT_VERIFY_DILITHIUM` removed from `STANDARD_SCRIPT_VERIFY_FLAGS` and applied explicitly in `ProduceSignature()`'s solution check so Dilithium satisfactions still validate.
- `chainparams`: mainnet `defaultAssumeValid` points at the re-mined genesis (not the stale pre-remine hash).
- `GetTxSigOpCost` expects `SCRIPT_ERR_EQUALVERIFY`, matching the merged `VerifyWitnessProgram` (the superseded `WITNESS_PUBKEYTYPE` expectation was removed).

**Audit fixes**
- **BTQ-AUDIT-021**: `CDilithiumKey::MakeNewKey()` RNG-failure return is now checked by its callers (`DilithiumWalletManager`, `CUnifiedKey`) instead of being silently dropped.
- **BTQ-AUDIT-019**: added P2SH-wrapped Dilithium sigop-count test coverage (bare/multisig were already covered).
- Strengthened `wallet_dilithium_send.py` (issue #41 regression) to prove Dilithium sends are consensus-valid: mined confirmation, the Dilithium UTXO is the input actually spent, plus a `sendmany` case.

## Audit status

All **Critical/High** findings from the internal audit are fixed. Remaining items are Medium/Low and non-blocking (signet placeholder challenge #004 [signet-only], doc/comment drift #003/#005/#024, accepted-with-rationale #025, pre-launch chainwork/assumevalid #027).

## Test plan

- [x] `btqd` + `src/test/test_btq` build clean
- [x] Unit suites touched here pass (`dilithium_basic_tests`, `dilithium_wallet_tests`, `scriptpubkeyman_tests`, `sigopcount_tests`, `feebumper_tests`, `p2mr_tests`)
- [x] `wallet_dilithium_send.py` regression passes (Dilithium spend confirms in a block)
- [ ] Full `test_btq` run is currently blocked by **pre-existing** inherited-test failures (`bloom_tests` hardcoded WIF, `bip324_tests` vectors) tracked in #60 — these are identical to `master` and not introduced here.

## Notes

- Pre-existing test debt filed as #60.
- Mainnet-launch process gates (NIST KAT vectors, fuzz, ASan, perf, docs) are tracked separately and are out of scope for this PR.