### PR TITLE
cleanup: low-risk fixes from change-focused audit

### DIFF
--- a/src/crypto/dilithium_wrapper.c
+++ b/src/crypto/dilithium_wrapper.c
@@ -54,13 +54,3 @@ int btq_dilithium_verify(const uint8_t *sig, size_t siglen,
     
     return pqcrystals_dilithium2_ref_verify(sig, siglen, m, mlen, ctx_ptr, ctx_len, pk);
 }
-
-int btq_dilithium_sk_to_pk(uint8_t *pk, const uint8_t *sk)
-{
-    // Extract public key from secret key
-    // In Dilithium, the secret key contains the public key at the beginning
-    // For Dilithium2: sk = (rho, K, tr, s1, s2, t0) and pk = (rho, K, tr)
-    // The public key is the first 1312 bytes of the secret key
-    memcpy(pk, sk, pqcrystals_dilithium2_ref_PUBLICKEYBYTES);
-    return 0;
-}

--- a/src/crypto/dilithium_wrapper.h
+++ b/src/crypto/dilithium_wrapper.h
@@ -73,14 +73,6 @@ int btq_dilithium_verify(const uint8_t *sig, size_t siglen,
                          const uint8_t *ctx, size_t ctxlen,
                          const uint8_t *pk);
 
-/**
- * Extract public key from secret key.
- * @param pk Output buffer for public key (must be BTQ_DILITHIUM_PUBLIC_KEY_SIZE bytes)
- * @param sk Secret key (must be BTQ_DILITHIUM_SECRET_KEY_SIZE bytes)
- * @return 0 on success, non-zero on failure
- */
-int btq_dilithium_sk_to_pk(uint8_t *pk, const uint8_t *sk);
-
 #ifdef __cplusplus
 }
 #endif

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -8,7 +8,6 @@
 
 #include <consensus/amount.h>
 #include <consensus/consensus.h>
-#include <consensus/consensus.h>
 #include <primitives/transaction.h>
 #include <script/interpreter.h>
 #include <script/solver.h>

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -23,7 +23,9 @@
 #include <vector>
 
 // Maximum number of bytes pushable to the stack
-// Increased to 15000 to support post-quantum signatures and keys (Dilithium5 sig ~4627 bytes + key ~2592 bytes + overhead)
+// Increased to 15000 to support post-quantum signatures and keys. The active
+// parameter set is Dilithium2 (signature 2420 bytes, public key 1312 bytes);
+// 15000 also leaves headroom for higher Dilithium levels and script overhead.
 static const unsigned int MAX_SCRIPT_ELEMENT_SIZE = 15000;
 
 // Maximum number of non-push operations per script
@@ -36,7 +38,8 @@ static const int MAX_PUBKEYS_PER_MULTISIG = 20;
 static constexpr unsigned int MAX_PUBKEYS_PER_MULTI_A = 999;
 
 // Maximum script length in bytes
-// Increased to 100000 to support complex post-quantum multisig (3x Dilithium5: ~21KB crypto + overhead)
+// Increased to 100000 to support complex post-quantum multisig scripts
+// (multiple Dilithium2 signatures/keys plus script overhead).
 static const int MAX_SCRIPT_SIZE = 100000;
 
 // Maximum number of values on script interpreter stack


### PR DESCRIPTION
## Summary

Three small, **behavior-preserving** cleanups found while auditing the BTQ changes against Bitcoin Core 26.0. No functional or consensus behavior changes.

- **`src/policy/policy.h`** — remove a duplicated `#include <consensus/consensus.h>`.
- **`src/script/script.h`** — correct the `MAX_SCRIPT_ELEMENT_SIZE` (15000) and `MAX_SCRIPT_SIZE` (100000) comments to reference the parameter set that is actually compiled (**Dilithium2**: 2420-byte signature, 1312-byte public key) rather than Dilithium5. The constant values are unchanged.
- **`src/crypto/dilithium_wrapper.{c,h}`** — remove the unused `btq_dilithium_sk_to_pk()`. Its comment/`memcpy` assumed a Dilithium secret key begins with the public key (it does not: `sk = rho‖K‖tr‖s1‖s2‖t0`), so the function would have returned incorrect bytes. It has **no callers** (`rg btq_dilithium_sk_to_pk src/ test/` returns only the removed def/decl).

## Test plan

- [ ] `make` / CI build is green (pure comment + dead-code/duplicate-include removal; no codegen impact)
- [ ] No new references to `btq_dilithium_sk_to_pk` anywhere in the tree

## Notes

These are the lowest-risk items from a broader change-focused audit; larger findings are tracked separately.