### PR TITLE
consensus: count Dilithium sigops for P2MR (witness v2)

### DIFF
--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -2403,28 +2403,17 @@ size_t static WitnessSigOps(int witversion, const std::vector<unsigned char>& wi
 
     if (witversion == 2 && witprogram.size() == WITNESS_V2_P2MR_SIZE && witness.stack.size() >= 2) {
         // P2MR witness: [args...] [script] [control_block] [optional annex]
-        // Determine if annex is present (last element starts with ANNEX_TAG)
-        size_t last = witness.stack.size() - 1;
-        bool has_annex = (witness.stack.size() >= 2 &&
-                          !witness.stack[last].empty() &&
-                          witness.stack[last][0] == ANNEX_TAG);
-        size_t control_idx = has_annex ? last - 1 : last;
+        // Mirror VerifyWitnessProgram's annex / control / script indexing, then
+        // reuse GetSigOpCount(true) so Dilithium (and any ECDSA) opcodes get the
+        // same weighting as legacy / P2WSH — including accurate multisig key counts.
+        const size_t last = witness.stack.size() - 1;
+        const bool has_annex = !witness.stack[last].empty() && witness.stack[last][0] == ANNEX_TAG;
+        const size_t control_idx = has_annex ? last - 1 : last;
         if (control_idx < 1) return 0;
-        size_t script_idx = control_idx - 1;
+        const size_t script_idx = control_idx - 1;
 
-        const auto& script_data = witness.stack[script_idx];
-        CScript subscript(script_data.begin(), script_data.end());
-        unsigned int n = 0;
-        CScript::const_iterator pc = subscript.begin();
-        opcodetype opcode;
-        while (pc < subscript.end()) {
-            if (!subscript.GetOp(pc, opcode)) break;
-            if (opcode == OP_CHECKSIGDILITHIUM || opcode == OP_CHECKSIGDILITHIUMVERIFY)
-                n++;
-            else if (opcode == OP_CHECKMULTISIGDILITHIUM || opcode == OP_CHECKMULTISIGDILITHIUMVERIFY)
-                n += MAX_PUBKEYS_PER_MULTISIG;
-        }
-        return n * DILITHIUM_SIGOP_COST;
+        CScript subscript(witness.stack[script_idx].begin(), witness.stack[script_idx].end());
+        return subscript.GetSigOpCount(true);
     }
 
     // Future flags may be implemented here.

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -2401,6 +2401,32 @@ size_t static WitnessSigOps(int witversion, const std::vector<unsigned char>& wi
         }
     }
 
+    if (witversion == 2 && witprogram.size() == WITNESS_V2_P2MR_SIZE && witness.stack.size() >= 2) {
+        // P2MR witness: [args...] [script] [control_block] [optional annex]
+        // Determine if annex is present (last element starts with ANNEX_TAG)
+        size_t last = witness.stack.size() - 1;
+        bool has_annex = (witness.stack.size() >= 2 &&
+                          !witness.stack[last].empty() &&
+                          witness.stack[last][0] == ANNEX_TAG);
+        size_t control_idx = has_annex ? last - 1 : last;
+        if (control_idx < 1) return 0;
+        size_t script_idx = control_idx - 1;
+
+        const auto& script_data = witness.stack[script_idx];
+        CScript subscript(script_data.begin(), script_data.end());
+        unsigned int n = 0;
+        CScript::const_iterator pc = subscript.begin();
+        opcodetype opcode;
+        while (pc < subscript.end()) {
+            if (!subscript.GetOp(pc, opcode)) break;
+            if (opcode == OP_CHECKSIGDILITHIUM || opcode == OP_CHECKSIGDILITHIUMVERIFY)
+                n++;
+            else if (opcode == OP_CHECKMULTISIGDILITHIUM || opcode == OP_CHECKMULTISIGDILITHIUMVERIFY)
+                n += MAX_PUBKEYS_PER_MULTISIG;
+        }
+        return n * DILITHIUM_SIGOP_COST;
+    }
+
     // Future flags may be implemented here.
     return 0;
 }

--- a/src/test/sigopcount_tests.cpp
+++ b/src/test/sigopcount_tests.cpp
@@ -290,4 +290,145 @@ BOOST_AUTO_TEST_CASE(dilithium_witness_v0_sigop_weighting)
     BOOST_CHECK_EQUAL(GetTransactionSigOpCost(CTransaction(spendingTx), coins, flags), 1);
 }
 
+/** Dummy P2MR scriptPubKey: WitnessSigOps only checks version + 32-byte program. */
+static CScript MakeP2MRScriptPubKey()
+{
+    return GetScriptForDestination(WitnessV2P2MR(uint256{}));
+}
+
+/**
+ * Build a P2MR-shaped witness: [args...] [leaf_script] [control] [optional annex].
+ * Control/merkle validity is irrelevant for sigop counting.
+ */
+static CScriptWitness MakeP2MRWitness(const CScript& leaf_script,
+                                      const std::vector<std::vector<unsigned char>>& args = {},
+                                      bool with_annex = false)
+{
+    CScriptWitness witness;
+    for (const auto& arg : args) {
+        witness.stack.push_back(arg);
+    }
+    witness.stack.emplace_back(leaf_script.begin(), leaf_script.end());
+    // P2MR control base: leaf version | parity bit 1 (required by VerifyWitnessProgram).
+    witness.stack.push_back(std::vector<unsigned char>{static_cast<unsigned char>(TAPROOT_LEAF_TAPSCRIPT | 0x01)});
+    if (with_annex) {
+        witness.stack.push_back(std::vector<unsigned char>{static_cast<unsigned char>(ANNEX_TAG), 0x00});
+    }
+    return witness;
+}
+
+BOOST_AUTO_TEST_CASE(p2mr_witness_v2_sigop_weighting)
+{
+    // P2MR Dilithium leaves must count toward MAX_BLOCK_SIGOPS_COST via WitnessSigOps.
+    CMutableTransaction creationTx;
+    CMutableTransaction spendingTx;
+    CCoinsView coinsDummy;
+    CCoinsViewCache coins(&coinsDummy);
+    const uint32_t flags{SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH};
+    const CScript scriptPubKey = MakeP2MRScriptPubKey();
+
+    CDilithiumKey dilithium_key;
+    BOOST_REQUIRE(dilithium_key.MakeNewKey());
+    const auto dilithium_pubkey = ToByteVector(dilithium_key.GetPubKey());
+
+    // Single-sig Dilithium leaf.
+    {
+        const CScript leaf = CScript() << dilithium_pubkey << OP_CHECKSIGDILITHIUM;
+        const CScriptWitness witness = MakeP2MRWitness(leaf, {/*args=*/{std::vector<unsigned char>{0x01}}});
+        BuildTxs(spendingTx, coins, creationTx, scriptPubKey, CScript{}, witness);
+        BOOST_CHECK_EQUAL(GetTransactionSigOpCost(CTransaction(spendingTx), coins, flags),
+                          static_cast<int64_t>(DILITHIUM_SIGOP_COST));
+        BOOST_CHECK_EQUAL(GetTransactionSigOpCost(CTransaction(spendingTx), coins, flags & ~SCRIPT_VERIFY_WITNESS), 0);
+    }
+
+    // OP_CHECKSIGDILITHIUMVERIFY counts the same as OP_CHECKSIGDILITHIUM.
+    {
+        const CScript leaf = CScript() << dilithium_pubkey << OP_CHECKSIGDILITHIUMVERIFY;
+        BuildTxs(spendingTx, coins, creationTx, scriptPubKey, CScript{}, MakeP2MRWitness(leaf));
+        BOOST_CHECK_EQUAL(GetTransactionSigOpCost(CTransaction(spendingTx), coins, flags),
+                          static_cast<int64_t>(DILITHIUM_SIGOP_COST));
+    }
+
+    // Accurate Dilithium multisig: OP_2 ... OP_2 OP_CHECKMULTISIGDILITHIUM → 2 * cost.
+    {
+        const CScript leaf = CScript() << OP_2 << dilithium_pubkey << dilithium_pubkey << OP_2
+                                       << OP_CHECKMULTISIGDILITHIUM;
+        BuildTxs(spendingTx, coins, creationTx, scriptPubKey, CScript{}, MakeP2MRWitness(leaf));
+        BOOST_CHECK_EQUAL(GetTransactionSigOpCost(CTransaction(spendingTx), coins, flags),
+                          static_cast<int64_t>(2U * DILITHIUM_SIGOP_COST));
+        BOOST_CHECK_EQUAL(leaf.GetSigOpCount(true), 2U * DILITHIUM_SIGOP_COST);
+        // Inaccurate path would charge MAX_PUBKEYS_PER_MULTISIG * cost — must not match that.
+        BOOST_CHECK(GetTransactionSigOpCost(CTransaction(spendingTx), coins, flags) !=
+                    static_cast<int64_t>(MAX_PUBKEYS_PER_MULTISIG * DILITHIUM_SIGOP_COST));
+    }
+
+    // Annex present: still locate leaf at control_idx - 1 and count the same.
+    {
+        const CScript leaf = CScript() << dilithium_pubkey << OP_CHECKSIGDILITHIUM;
+        BuildTxs(spendingTx, coins, creationTx, scriptPubKey, CScript{},
+                 MakeP2MRWitness(leaf, {/*args=*/{std::vector<unsigned char>{0x01}}}, /*with_annex=*/true));
+        BOOST_CHECK_EQUAL(GetTransactionSigOpCost(CTransaction(spendingTx), coins, flags),
+                          static_cast<int64_t>(DILITHIUM_SIGOP_COST));
+    }
+
+    // ECDSA OP_CHECKSIG in a P2MR leaf counts via GetSigOpCount (1), matching P2WSH.
+    {
+        CKey ecdsa_key;
+        ecdsa_key.MakeNewKey(true);
+        const CScript leaf = CScript() << ToByteVector(ecdsa_key.GetPubKey()) << OP_CHECKSIG;
+        BuildTxs(spendingTx, coins, creationTx, scriptPubKey, CScript{}, MakeP2MRWitness(leaf));
+        BOOST_CHECK_EQUAL(GetTransactionSigOpCost(CTransaction(spendingTx), coins, flags), 1);
+    }
+
+    // Mixed leaf: one Dilithium + one ECDSA.
+    {
+        CKey ecdsa_key;
+        ecdsa_key.MakeNewKey(true);
+        const CScript leaf = CScript() << dilithium_pubkey << OP_CHECKSIGDILITHIUM
+                                       << ToByteVector(ecdsa_key.GetPubKey()) << OP_CHECKSIG;
+        BuildTxs(spendingTx, coins, creationTx, scriptPubKey, CScript{}, MakeP2MRWitness(leaf));
+        BOOST_CHECK_EQUAL(GetTransactionSigOpCost(CTransaction(spendingTx), coins, flags),
+                          static_cast<int64_t>(DILITHIUM_SIGOP_COST + 1));
+    }
+
+    // Too few witness elements: no script+control pair → 0.
+    {
+        CScriptWitness witness;
+        witness.stack.push_back(std::vector<unsigned char>{0x01});
+        BuildTxs(spendingTx, coins, creationTx, scriptPubKey, CScript{}, witness);
+        BOOST_CHECK_EQUAL(GetTransactionSigOpCost(CTransaction(spendingTx), coins, flags), 0);
+    }
+
+    // [control][annex] only: annex strips to a single control element → 0.
+    {
+        CScriptWitness witness;
+        witness.stack.push_back(std::vector<unsigned char>{static_cast<unsigned char>(TAPROOT_LEAF_TAPSCRIPT | 0x01)});
+        witness.stack.push_back(std::vector<unsigned char>{static_cast<unsigned char>(ANNEX_TAG)});
+        BuildTxs(spendingTx, coins, creationTx, scriptPubKey, CScript{}, witness);
+        BOOST_CHECK_EQUAL(GetTransactionSigOpCost(CTransaction(spendingTx), coins, flags), 0);
+    }
+
+    // Empty leaf script → 0.
+    {
+        BuildTxs(spendingTx, coins, creationTx, scriptPubKey, CScript{}, MakeP2MRWitness(CScript{}));
+        BOOST_CHECK_EQUAL(GetTransactionSigOpCost(CTransaction(spendingTx), coins, flags), 0);
+    }
+
+    // Wrong program length is not P2MR; WitnessSigOps returns 0 for non-v0/non-P2MR.
+    {
+        CScript bad = CScript() << OP_2 << std::vector<unsigned char>(20, 0x00);
+        const CScript leaf = CScript() << dilithium_pubkey << OP_CHECKSIGDILITHIUM;
+        BuildTxs(spendingTx, coins, creationTx, bad, CScript{}, MakeP2MRWitness(leaf));
+        BOOST_CHECK_EQUAL(GetTransactionSigOpCost(CTransaction(spendingTx), coins, flags), 0);
+    }
+
+    // Coinbase witness is ignored by GetTransactionSigOpCost.
+    {
+        const CScript leaf = CScript() << dilithium_pubkey << OP_CHECKSIGDILITHIUM;
+        BuildTxs(spendingTx, coins, creationTx, scriptPubKey, CScript{}, MakeP2MRWitness(leaf));
+        spendingTx.vin[0].prevout.SetNull();
+        BOOST_CHECK_EQUAL(GetTransactionSigOpCost(CTransaction(spendingTx), coins, flags), 0);
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
WitnessSigOps() returned 0 for witness versions other than v0, so P2MR Dilithium signature operations were never counted toward MAX_BLOCK_SIGOPS_COST. A block full of P2MR inputs could be disproportionately expensive to validate.

This parses the P2MR leaf script and counts OP_CHECKSIGDILITHIUM* / OP_CHECKMULTISIGDILITHIUM* using the existing DILITHIUM_SIGOP_COST constant from script.h (50).

One open question for maintainers: 50 caps a block at 1600 Dilithium sigops (80000/50), which binds before the 8 MB block size does (~2100 single-sig P2MR inputs). If the intended multiplier is closer to the ~10x verification-cost ratio vs ECDSA, that's a one-line change to script.h — but it should be a deliberate decision since it sets Dilithium throughput per block. Follows up on #24.