### PR TITLE
p2p: reduce MAX_PROTOCOL_MESSAGE_LENGTH from 70 MB to 9 MB

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -63,8 +63,8 @@ static constexpr std::chrono::minutes TIMEOUT_INTERVAL{20};
 static constexpr auto FEELER_INTERVAL = 2min;
 /** Run the extra block-relay-only connection loop once every 5 minutes. **/
 static constexpr auto EXTRA_BLOCK_RELAY_ONLY_PEER_INTERVAL = 5min;
-/** Maximum length of incoming protocol messages (raised to carry ≥64 MB blocks). */
-static const unsigned int MAX_PROTOCOL_MESSAGE_LENGTH = 70 * 1000 * 1000; // 70 MB
+/** Maximum length of incoming protocol messages (block size + overhead). */
+static const unsigned int MAX_PROTOCOL_MESSAGE_LENGTH = 9 * 1000 * 1000; // 9 MB
 /** Maximum length of the user agent string in `version` message */
 static const unsigned int MAX_SUBVERSION_LENGTH = 256;
 /** Maximum number of automatic outgoing nodes over which we'll relay everything (blocks, tx, addrs, etc) */

--- a/src/net.h
+++ b/src/net.h
@@ -68,11 +68,13 @@ static constexpr auto EXTRA_BLOCK_RELAY_ONLY_PEER_INTERVAL = 5min;
  *
  * Derived from MAX_BLOCK_SERIALIZED_SIZE so a future block-size change cannot
  * silently make valid blocks unrelayable. The largest legitimate message is a
- * `block`: block weight (stripped_size * (WITNESS_SCALE_FACTOR - 1) + total_size
- * <= MAX_BLOCK_WEIGHT) caps the serialized size of any valid block - including
- * one stuffed with Dilithium witness data - strictly below
- * MAX_BLOCK_SERIALIZED_SIZE. The extra 1 MB covers message framing and any
- * non-block message. Mirrored in test_framework/messages.py.
+ * `block` (or near-full `blocktxn`): block weight
+ * (stripped_size * (WITNESS_SCALE_FACTOR - 1) + total_size <= MAX_BLOCK_WEIGHT)
+ * caps the with-witness serialized size of any valid block — including one
+ * stuffed with Dilithium witness data — strictly below MAX_BLOCK_SERIALIZED_SIZE.
+ * The extra 1 MB is headroom above that consensus buffer for non-block messages
+ * (inv/getdata peak ~1.8 MB). Payload size only; V1 headers are not counted.
+ * Mirrored in test_framework/messages.py.
  */
 static const unsigned int MAX_PROTOCOL_MESSAGE_LENGTH = MAX_BLOCK_SERIALIZED_SIZE + 1 * 1000 * 1000; // 9 MB
 static_assert(MAX_PROTOCOL_MESSAGE_LENGTH <= MAX_SIZE,

--- a/src/net.h
+++ b/src/net.h
@@ -10,6 +10,7 @@
 #include <chainparams.h>
 #include <common/bloom.h>
 #include <compat/compat.h>
+#include <consensus/consensus.h>
 #include <consensus/amount.h>
 #include <crypto/siphash.h>
 #include <hash.h>
@@ -63,8 +64,19 @@ static constexpr std::chrono::minutes TIMEOUT_INTERVAL{20};
 static constexpr auto FEELER_INTERVAL = 2min;
 /** Run the extra block-relay-only connection loop once every 5 minutes. **/
 static constexpr auto EXTRA_BLOCK_RELAY_ONLY_PEER_INTERVAL = 5min;
-/** Maximum length of incoming protocol messages (block size + overhead). */
-static const unsigned int MAX_PROTOCOL_MESSAGE_LENGTH = 9 * 1000 * 1000; // 9 MB
+/** Maximum length of incoming protocol messages (block size + overhead).
+ *
+ * Derived from MAX_BLOCK_SERIALIZED_SIZE so a future block-size change cannot
+ * silently make valid blocks unrelayable. The largest legitimate message is a
+ * `block`: block weight (stripped_size * (WITNESS_SCALE_FACTOR - 1) + total_size
+ * <= MAX_BLOCK_WEIGHT) caps the serialized size of any valid block - including
+ * one stuffed with Dilithium witness data - strictly below
+ * MAX_BLOCK_SERIALIZED_SIZE. The extra 1 MB covers message framing and any
+ * non-block message. Mirrored in test_framework/messages.py.
+ */
+static const unsigned int MAX_PROTOCOL_MESSAGE_LENGTH = MAX_BLOCK_SERIALIZED_SIZE + 1 * 1000 * 1000; // 9 MB
+static_assert(MAX_PROTOCOL_MESSAGE_LENGTH <= MAX_SIZE,
+              "message length cap above MAX_SIZE would be ineffective (see V1Transport header checks)");
 /** Maximum length of the user agent string in `version` message */
 static const unsigned int MAX_SUBVERSION_LENGTH = 256;
 /** Maximum number of automatic outgoing nodes over which we'll relay everything (blocks, tx, addrs, etc) */

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -36,6 +36,21 @@ using namespace std::literals;
 
 BOOST_FIXTURE_TEST_SUITE(net_tests, RegTestingSetup)
 
+BOOST_AUTO_TEST_CASE(max_protocol_message_length)
+{
+    // Transport cap must clear the largest legitimate payload (a serialized
+    // block, bounded by MAX_BLOCK_SERIALIZED_SIZE / weight) with the documented
+    // 1 MB headroom, and must not exceed CompactSize MAX_SIZE — otherwise the
+    // V1Transport hdr.nMessageSize > MAX_SIZE check would make the cap a no-op.
+    BOOST_CHECK_EQUAL(MAX_PROTOCOL_MESSAGE_LENGTH, MAX_BLOCK_SERIALIZED_SIZE + 1 * 1000 * 1000);
+    BOOST_CHECK_LE(MAX_PROTOCOL_MESSAGE_LENGTH, MAX_SIZE);
+    BOOST_CHECK_GT(MAX_PROTOCOL_MESSAGE_LENGTH, MAX_BLOCK_SERIALIZED_SIZE);
+    // Largest common non-block inventory message stays well under the cap.
+    constexpr size_t MAX_INV_ENTRIES = 50000;
+    constexpr size_t INV_ENTRY_BYTES = 36; // type (4) + hash (32)
+    BOOST_CHECK_LT(MAX_INV_ENTRIES * INV_ENTRY_BYTES, MAX_PROTOCOL_MESSAGE_LENGTH);
+}
+
 BOOST_AUTO_TEST_CASE(cnode_listen_port)
 {
     // test default

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -1413,8 +1413,8 @@ BOOST_AUTO_TEST_CASE(v2transport_test)
         BOOST_CHECK((*ret)[0] && (*ret)[0]->m_type == "inv" && Span{(*ret)[0]->m_recv} == MakeByteSpan(msg_data_1));
         BOOST_CHECK((*ret)[1] && (*ret)[1]->m_type == "pong" && Span{(*ret)[1]->m_recv} == MakeByteSpan(msg_data_2));
 
-        // Then send a too-large message.
-        auto msg_data_3 = g_insecure_rand_ctx.randbytes<uint8_t>(4005000);
+        // Then send a too-large message (beyond MAX_PROTOCOL_MESSAGE_LENGTH plus framing slack).
+        auto msg_data_3 = g_insecure_rand_ctx.randbytes<uint8_t>(MAX_PROTOCOL_MESSAGE_LENGTH + 5000);
         tester.SendMessage(uint8_t(11), msg_data_3); // getdata short id
         ret = tester.Interact();
         BOOST_CHECK(!ret);

--- a/test/functional/p2p_invalid_messages.py
+++ b/test/functional/p2p_invalid_messages.py
@@ -136,6 +136,19 @@ class InvalidMessagesTest(BTQTestFramework):
         self.nodes[0].disconnect_p2ps()
 
     def test_size(self):
+        self.log.info("Test message at maximum payload size is accepted")
+        # Boundary check: a message exactly at MAX_PROTOCOL_MESSAGE_LENGTH must
+        # not be rejected. This keeps the cap honest against the 8 MB consensus
+        # block size (a full block, e.g. one stuffed with Dilithium witness
+        # data, must always fit).
+        conn = self.nodes[0].add_p2p_connection(P2PDataStore())
+        msg_limit = msg_unrecognized(str_data="d" * VALID_DATA_LIMIT)
+        assert_equal(len(conn.build_message(msg_limit)) - 24, MAX_PROTOCOL_MESSAGE_LENGTH)  # minus header
+        conn.send_message(msg_limit)
+        conn.sync_with_ping(timeout=60)
+        assert conn.is_connected
+        self.nodes[0].disconnect_p2ps()
+
         self.log.info("Test message with oversized payload disconnects peer")
         conn = self.nodes[0].add_p2p_connection(P2PDataStore())
         with self.nodes[0].assert_debug_log([

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -43,7 +43,7 @@ MAX_MONEY = 21000000 * COIN
 MAX_BIP125_RBF_SEQUENCE = 0xfffffffd  # Sequence number that is rbf-opt-in (BIP 125) and csv-opt-out (BIP 68)
 SEQUENCE_FINAL = 0xffffffff  # Sequence number that disables nLockTime if set for every input of a tx
 
-MAX_PROTOCOL_MESSAGE_LENGTH = 70000000  # Maximum length of incoming protocol messages
+MAX_PROTOCOL_MESSAGE_LENGTH = 9000000  # Maximum length of incoming protocol messages (MAX_BLOCK_SERIALIZED_SIZE + 1 MB, mirrors src/net.h)
 MAX_HEADERS_RESULTS = 2000  # Number of headers sent in one getheaders result
 MAX_INV_SIZE = 50000  # Maximum number of entries in an 'inv' protocol message
 

--- a/test/lint/lint-btq-consensus-constants.py
+++ b/test/lint/lint-btq-consensus-constants.py
@@ -55,7 +55,12 @@ def eval_int_expr(node, names):
     raise ValueError(f"unsupported integer expression: {node!r}")
 
 
-def cpp_constant(path, name):
+def cpp_constant(path, name, names=None):
+    """Evaluate a C++ integer constant initializer.
+
+    `names` supplies identifiers referenced by the expression (e.g. when
+    MAX_PROTOCOL_MESSAGE_LENGTH is defined in terms of MAX_BLOCK_SERIALIZED_SIZE).
+    """
     text = (REPO_ROOT / path).read_text(encoding="utf8")
     match = re.search(
         rf"\b{name}\b\s*=\s*(?P<expr>[^;]+);",
@@ -65,7 +70,7 @@ def cpp_constant(path, name):
         raise ValueError(f"could not find {name} in {path}")
     expr = match.group("expr").split("//", 1)[0].strip()
     tree = parse(expr, mode="eval")
-    return eval_int_expr(tree.body, {})
+    return eval_int_expr(tree.body, dict(names or {}))
 
 
 def cpp_regex_int(path, pattern):
@@ -162,7 +167,9 @@ def check_equal(errors, label, actual, expected):
 def main():
     errors = []
 
+    max_block_serialized_size = cpp_constant("src/consensus/consensus.h", "MAX_BLOCK_SERIALIZED_SIZE")
     consensus = {
+        "MAX_BLOCK_SERIALIZED_SIZE": max_block_serialized_size,
         "MAX_BLOCK_WEIGHT": cpp_constant("src/consensus/consensus.h", "MAX_BLOCK_WEIGHT"),
         "MAX_BLOCK_SIGOPS_COST": cpp_constant("src/consensus/consensus.h", "MAX_BLOCK_SIGOPS_COST"),
         "WITNESS_SCALE_FACTOR": cpp_constant("src/consensus/consensus.h", "WITNESS_SCALE_FACTOR"),
@@ -170,11 +177,23 @@ def main():
         "MAX_SCRIPT_ELEMENT_SIZE": cpp_constant("src/script/script.h", "MAX_SCRIPT_ELEMENT_SIZE"),
         "DILITHIUM_SIGOP_COST": cpp_constant("src/script/script.h", "DILITHIUM_SIGOP_COST"),
         "MAX_FUTURE_BLOCK_TIME": cpp_constant("src/chain.h", "MAX_FUTURE_BLOCK_TIME"),
-        "MAX_PROTOCOL_MESSAGE_LENGTH": cpp_constant("src/net.h", "MAX_PROTOCOL_MESSAGE_LENGTH"),
+        # Derived as MAX_BLOCK_SERIALIZED_SIZE + 1 MB in src/net.h.
+        "MAX_PROTOCOL_MESSAGE_LENGTH": cpp_constant(
+            "src/net.h",
+            "MAX_PROTOCOL_MESSAGE_LENGTH",
+            {"MAX_BLOCK_SERIALIZED_SIZE": max_block_serialized_size},
+        ),
         "INITIAL_SUBSIDY_BTQ": cpp_regex_int("src/validation.cpp", r"CAmount nSubsidy = (\d+) \* COIN;"),
         "REGTEST_HALVING_INTERVAL": cpp_regex_int("src/kernel/chainparams.cpp", r"class CRegTestParams[\s\S]*?consensus\.nSubsidyHalvingInterval = (\d+);"),
         "REGTEST_GENESIS_TIME": cpp_regex_int("src/kernel/chainparams.cpp", r"class CRegTestParams[\s\S]*?genesis = CreateGenesisBlock\([^;]*?,\s*(\d+),\s*3,\s*0x"),
     }
+
+    check_equal(
+        errors,
+        "net.h MAX_PROTOCOL_MESSAGE_LENGTH",
+        consensus["MAX_PROTOCOL_MESSAGE_LENGTH"],
+        consensus["MAX_BLOCK_SERIALIZED_SIZE"] + 1_000_000,
+    )
 
     messages = python_constants("test/functional/test_framework/messages.py")
     blocktools = python_constants("test/functional/test_framework/blocktools.py")


### PR DESCRIPTION
The inherited 70 MB cap let a single peer force allocation of very large message buffers. 9 MB still clears the largest legitimate message (8 MB serialized block, MAX_BLOCK_SERIALIZED_SIZE) with headroom.

Safe for mixed-version P2P on the running testnet: no legitimate message exceeds 8 MB today, so old and new nodes interoperate through the upgrade.