### PR TITLE
p2p: add NODE_BTQ_DILITHIUM service bit

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -787,7 +787,7 @@ namespace { // Variables internal to initialization process only
 int nMaxConnections;
 int nUserMaxConnections;
 int nFD;
-ServiceFlags nLocalServices = ServiceFlags(NODE_NETWORK_LIMITED | NODE_WITNESS);
+ServiceFlags nLocalServices = ServiceFlags(NODE_NETWORK_LIMITED | NODE_WITNESS | NODE_BTQ_DILITHIUM);
 int64_t peer_connect_timeout;
 std::set<BlockFilterType> g_enabled_filter_types;
 

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -200,6 +200,7 @@ static std::string serviceFlagToStr(size_t bit)
     case NODE_COMPACT_FILTERS: return "COMPACT_FILTERS";
     case NODE_NETWORK_LIMITED: return "NETWORK_LIMITED";
     case NODE_P2P_V2:          return "P2P_V2";
+    case NODE_BTQ_DILITHIUM:   return "BTQ_DILITHIUM";
     // Not using default, so we get warned when a case is missing
     }
 

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -294,6 +294,10 @@ enum ServiceFlags : uint64_t {
     // NODE_P2P_V2 means the node supports BIP324 transport
     NODE_P2P_V2 = (1 << 11),
 
+    // NODE_BTQ_DILITHIUM indicates a BTQ node that validates Dilithium
+    // signatures and P2MR (BIP360) witness v2 transactions.
+    NODE_BTQ_DILITHIUM = (1 << 26),
+
     // Bits 24-31 are reserved for temporary experiments. Just pick a bit that
     // isn't getting used, or one not being used much, and notify the
     // btq-development mailing list. Remember that service bits are just

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -294,10 +294,6 @@ enum ServiceFlags : uint64_t {
     // NODE_P2P_V2 means the node supports BIP324 transport
     NODE_P2P_V2 = (1 << 11),
 
-    // NODE_BTQ_DILITHIUM indicates a BTQ node that validates Dilithium
-    // signatures and P2MR (BIP360) witness v2 transactions.
-    NODE_BTQ_DILITHIUM = (1 << 26),
-
     // Bits 24-31 are reserved for temporary experiments. Just pick a bit that
     // isn't getting used, or one not being used much, and notify the
     // btq-development mailing list. Remember that service bits are just
@@ -305,6 +301,14 @@ enum ServiceFlags : uint64_t {
     // collisions and other cases where nodes may be advertising a service they
     // do not actually support. Other service bits should be allocated via the
     // BIP process.
+
+    // NODE_BTQ_DILITHIUM indicates a BTQ node that validates Dilithium
+    // signatures and P2MR (BIP360) witness v2 transactions. Advertised for
+    // chain identification / crawlers only; not required by
+    // GetDesirableServiceFlags. Bit 25 avoids the experimental full-RBF /
+    // NODE_REPLACE_BY_FEE (NODE_FULL_RBF) allocation on bit 26 used by
+    // Bitcoin Core lineage tooling.
+    NODE_BTQ_DILITHIUM = (1 << 25),
 };
 
 /**

--- a/src/test/netbase_tests.cpp
+++ b/src/test/netbase_tests.cpp
@@ -611,4 +611,27 @@ BOOST_AUTO_TEST_CASE(isbadport)
     BOOST_CHECK_EQUAL(total_bad_ports, 80);
 }
 
+BOOST_AUTO_TEST_CASE(node_btq_dilithium_service_bit)
+{
+    // Identification-only flag: value, stringification, and peer-selection
+    // must not require it from remote peers (including pre-bit testnet nodes).
+    BOOST_CHECK_EQUAL(static_cast<uint64_t>(NODE_BTQ_DILITHIUM), 1ULL << 25);
+
+    const auto names = serviceFlagsToStr(NODE_BTQ_DILITHIUM);
+    BOOST_REQUIRE_EQUAL(names.size(), 1U);
+    BOOST_CHECK_EQUAL(names.at(0), "BTQ_DILITHIUM");
+
+    SetServiceFlagsIBDCache(/*state=*/false);
+    BOOST_CHECK_EQUAL(GetDesirableServiceFlags(NODE_NONE), ServiceFlags(NODE_NETWORK | NODE_WITNESS));
+    BOOST_CHECK(!(GetDesirableServiceFlags(NODE_NONE) & NODE_BTQ_DILITHIUM));
+    BOOST_CHECK(HasAllDesirableServiceFlags(ServiceFlags(NODE_NETWORK | NODE_WITNESS)));
+    BOOST_CHECK(HasAllDesirableServiceFlags(ServiceFlags(NODE_NETWORK | NODE_WITNESS | NODE_BTQ_DILITHIUM)));
+
+    SetServiceFlagsIBDCache(/*state=*/true);
+    BOOST_CHECK_EQUAL(GetDesirableServiceFlags(NODE_NETWORK_LIMITED), ServiceFlags(NODE_NETWORK_LIMITED | NODE_WITNESS));
+    BOOST_CHECK(!(GetDesirableServiceFlags(NODE_NETWORK_LIMITED) & NODE_BTQ_DILITHIUM));
+    BOOST_CHECK(HasAllDesirableServiceFlags(ServiceFlags(NODE_NETWORK_LIMITED | NODE_WITNESS)));
+    SetServiceFlagsIBDCache(/*state=*/false);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -53,6 +53,7 @@ NODE_WITNESS = (1 << 3)
 NODE_COMPACT_FILTERS = (1 << 6)
 NODE_NETWORK_LIMITED = (1 << 10)
 NODE_P2P_V2 = (1 << 11)
+NODE_BTQ_DILITHIUM = (1 << 25)  # mirrors src/protocol.h; identification only
 
 MSG_TX = 1
 MSG_BLOCK = 2


### PR DESCRIPTION
Advertises bit 26 in local services so BTQ nodes are identifiable in addr gossip and crawler/seed tooling can distinguish them from other Bitcoin-lineage nodes.

Scope note: this is identification only — GetDesirableServiceFlags does not require the bit from peers, and cross-chain handshakes are already blocked by BTQ's message-start bytes. Requiring the bit for peer selection could be a follow-up once most of the network advertises it.