### PR TITLE
security: cleanse Dilithium seed temporaries in ext-key paths

### DIFF
--- a/src/crypto/dilithium_key.cpp
+++ b/src/crypto/dilithium_key.cpp
@@ -289,7 +289,9 @@ void CDilithiumExtKey::Decode(const unsigned char code[DILITHIUM_EXTKEY_SIZE])
 
     // Regenerate the expanded keypair from the seed.
     std::vector<unsigned char> seed_vec(seed.begin(), seed.end());
-    if (!key.GenerateFromEntropy(seed_vec)) {
+    const bool ok = key.GenerateFromEntropy(seed_vec);
+    memory_cleanse(seed_vec.data(), seed_vec.size());
+    if (!ok) {
         key = CDilithiumKey();
     }
 }
@@ -333,7 +335,9 @@ bool CDilithiumExtKey::Derive(CDilithiumExtKey& out, unsigned int child_index) c
 
     // Expand the seed into the full keypair.
     std::vector<unsigned char> child_seed_vec(out.seed.begin(), out.seed.end());
-    if (!out.key.GenerateFromEntropy(child_seed_vec)) {
+    const bool ok = out.key.GenerateFromEntropy(child_seed_vec);
+    memory_cleanse(child_seed_vec.data(), child_seed_vec.size());
+    if (!ok) {
         return false;
     }
     return out.key.IsValid();
@@ -371,7 +375,9 @@ void CDilithiumExtKey::SetSeed(Span<const std::byte> hd_seed)
     nChild = 0;
 
     std::vector<unsigned char> seed_vec(seed.begin(), seed.end());
-    if (!key.GenerateFromEntropy(seed_vec)) {
+    const bool ok = key.GenerateFromEntropy(seed_vec);
+    memory_cleanse(seed_vec.data(), seed_vec.size());
+    if (!ok) {
         key = CDilithiumKey();
     }
 }

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -2470,10 +2470,12 @@ util::Result<CTxDestination> DescriptorScriptPubKeyMan::GetNewDestination(const 
             hmac.Write(&type_byte, 1);
             unsigned char I[64];
             hmac.Finalize(I);
-            const std::vector<unsigned char> seed(I, I + BTQ_DILITHIUM_SEED_SIZE);
+            std::vector<unsigned char> seed(I, I + BTQ_DILITHIUM_SEED_SIZE);
             memory_cleanse(I, sizeof(I));
 
-            if (!dilithium_key.GenerateFromEntropy(seed)) {
+            const bool ok = dilithium_key.GenerateFromEntropy(seed);
+            memory_cleanse(seed.data(), seed.size());
+            if (!ok) {
                 return util::Error{_("Error: Failed to generate Dilithium key")};
             }
 


### PR DESCRIPTION
Decode(), Derive(), and SetSeed() copy the 32-byte Dilithium seed into a heap std::vector before expanding it, and the vector was destroyed without zeroing — leaving seed material in freed memory for anyone with memory read access (core dumps, /proc/pid/mem). Cleanses each temporary after last use, matching the file's existing pattern.

Reworked from the original BTQ-AUDIT-082 fix: the v0.4.0 HD redesign already covered the HMAC buffers and packed sk, so only these three temporaries remained. Passes dilithium_key/wallet/basic suites locally.