### PR TITLE
security: constant-time comparison for Dilithium key material

### DIFF
--- a/src/crypto/dilithium/avx2/sign.c
+++ b/src/crypto/dilithium/avx2/sign.c
@@ -451,9 +451,15 @@ int crypto_sign_verify_internal(const uint8_t *sig, size_t siglen, const uint8_t
   shake256_absorb(&state, buf.coeffs, K*POLYW1_PACKEDBYTES);
   shake256_finalize(&state);
   shake256_squeeze(buf.coeffs, CTILDEBYTES, &state);
-  for(i = 0; i < CTILDEBYTES; ++i)
-    if(buf.coeffs[i] != sig[i])
+  {
+    /* Constant-time challenge comparison: no early exit on first mismatch.
+     * Not linked today (Makefile builds ref/), but keep avx2 in sync. */
+    volatile uint8_t result = 0;
+    for(i = 0; i < CTILDEBYTES; ++i)
+      result |= buf.coeffs[i] ^ sig[i];
+    if(result)
       return -1;
+  }
 
   return 0;
 }

--- a/src/crypto/dilithium/ref/sign.c
+++ b/src/crypto/dilithium/ref/sign.c
@@ -383,8 +383,10 @@ int crypto_sign_verify_internal(const uint8_t *sig,
   shake256_finalize(&state);
   shake256_squeeze(c2, CTILDEBYTES, &state);
   {
-    /* Constant-time challenge comparison: no early exit on first mismatch. */
-    uint8_t result = 0;
+    /* Constant-time challenge comparison: no early exit on first mismatch.
+     * volatile keeps compilers from rewriting this into a short-circuiting
+     * byte loop (same rationale as TimingSafeEqual in dilithium_key.h). */
+    volatile uint8_t result = 0;
     for(i = 0; i < CTILDEBYTES; ++i)
       result |= c[i] ^ c2[i];
     if(result)

--- a/src/crypto/dilithium/ref/sign.c
+++ b/src/crypto/dilithium/ref/sign.c
@@ -382,9 +382,14 @@ int crypto_sign_verify_internal(const uint8_t *sig,
   shake256_absorb(&state, buf, K*POLYW1_PACKEDBYTES);
   shake256_finalize(&state);
   shake256_squeeze(c2, CTILDEBYTES, &state);
-  for(i = 0; i < CTILDEBYTES; ++i)
-    if(c[i] != c2[i])
+  {
+    /* Constant-time challenge comparison: no early exit on first mismatch. */
+    uint8_t result = 0;
+    for(i = 0; i < CTILDEBYTES; ++i)
+      result |= c[i] ^ c2[i];
+    if(result)
       return -1;
+  }
 
   return 0;
 }

--- a/src/crypto/dilithium_key.h
+++ b/src/crypto/dilithium_key.h
@@ -12,8 +12,22 @@
 #include <key.h>
 
 #include <array>
+#include <cstddef>
 #include <memory>
 #include <vector>
+
+namespace dilithium_internal {
+/** Constant-time equality: no early exit, so timing does not reveal how many
+ *  leading bytes of two keys match. volatile prevents the compiler from
+ *  optimizing the loop back into a short-circuiting compare. */
+inline bool TimingSafeEqual(const unsigned char* a, const unsigned char* b, size_t n) noexcept
+{
+    volatile unsigned char result = 0;
+    for (size_t i = 0; i < n; i++)
+        result |= a[i] ^ b[i];
+    return result == 0;
+}
+} // namespace dilithium_internal
 
 // Dilithium extended key serialization size.
 //
@@ -119,7 +133,7 @@ public:
     friend bool operator==(const CDilithiumKey& a, const CDilithiumKey& b)
     {
         return a.size() == b.size() &&
-               (a.size() == 0 || memcmp(a.data(), b.data(), a.size()) == 0);
+               (a.size() == 0 || dilithium_internal::TimingSafeEqual(a.begin(), b.begin(), a.size()));
     }
 
     /** Inequality operator */
@@ -276,7 +290,7 @@ public:
     //! Comparator implementations.
     friend bool operator==(const CDilithiumPubKey& a, const CDilithiumPubKey& b)
     {
-        return memcmp(a.vch.data(), b.vch.data(), SIZE) == 0;
+        return dilithium_internal::TimingSafeEqual(a.vch.data(), b.vch.data(), SIZE);
     }
     
     friend bool operator!=(const CDilithiumPubKey& a, const CDilithiumPubKey& b)
@@ -373,10 +387,12 @@ public:
     friend bool operator==(const CDilithiumExtKey& a, const CDilithiumExtKey& b)
     {
         return a.nDepth == b.nDepth &&
-            memcmp(a.vchFingerprint, b.vchFingerprint, sizeof(vchFingerprint)) == 0 &&
+            dilithium_internal::TimingSafeEqual(a.vchFingerprint, b.vchFingerprint, sizeof(vchFingerprint)) &&
             a.nChild == b.nChild &&
             a.chaincode == b.chaincode &&
-            a.seed == b.seed;
+            // The seed is the master secret; std::array's operator== would
+            // short-circuit on the first differing byte.
+            dilithium_internal::TimingSafeEqual(a.seed.data(), b.seed.data(), a.seed.size());
     }
 
     void Encode(unsigned char code[DILITHIUM_EXTKEY_SIZE]) const;
@@ -410,7 +426,7 @@ public:
     friend bool operator==(const CDilithiumExtPubKey& a, const CDilithiumExtPubKey& b)
     {
         return a.nDepth == b.nDepth &&
-            memcmp(a.vchFingerprint, b.vchFingerprint, sizeof(vchFingerprint)) == 0 &&
+            dilithium_internal::TimingSafeEqual(a.vchFingerprint, b.vchFingerprint, sizeof(vchFingerprint)) &&
             a.nChild == b.nChild &&
             a.chaincode == b.chaincode &&
             a.pubkey == b.pubkey;

--- a/src/crypto/dilithium_key.h
+++ b/src/crypto/dilithium_key.h
@@ -18,13 +18,17 @@
 
 namespace dilithium_internal {
 /** Constant-time equality: no early exit, so timing does not reveal how many
- *  leading bytes of two keys match. volatile prevents the compiler from
- *  optimizing the loop back into a short-circuiting compare. */
+ *  leading bytes of two buffers match. The accumulator is volatile so the
+ *  compiler cannot collapse the loop into a short-circuiting memcmp-style
+ *  compare. Callers that combine multiple checks must use bitwise & (not &&)
+ *  if every secret buffer must always be scanned. Length mismatches should be
+ *  handled before calling this (do not pass unequal lengths). */
 inline bool TimingSafeEqual(const unsigned char* a, const unsigned char* b, size_t n) noexcept
 {
     volatile unsigned char result = 0;
-    for (size_t i = 0; i < n; i++)
-        result |= a[i] ^ b[i];
+    for (size_t i = 0; i < n; i++) {
+        result |= static_cast<unsigned char>(a[i] ^ b[i]);
+    }
     return result == 0;
 }
 } // namespace dilithium_internal
@@ -386,13 +390,17 @@ public:
 
     friend bool operator==(const CDilithiumExtKey& a, const CDilithiumExtKey& b)
     {
-        return a.nDepth == b.nDepth &&
-            dilithium_internal::TimingSafeEqual(a.vchFingerprint, b.vchFingerprint, sizeof(vchFingerprint)) &&
-            a.nChild == b.nChild &&
-            a.chaincode == b.chaincode &&
-            // The seed is the master secret; std::array's operator== would
-            // short-circuit on the first differing byte.
-            dilithium_internal::TimingSafeEqual(a.seed.data(), b.seed.data(), a.seed.size());
+        // Seed and chaincode are secret HD material. Evaluate both
+        // TimingSafeEqual calls into locals first so && short-circuit cannot
+        // skip a secret scan. Do not use ChainCode/uint256 operator== — it
+        // short-circuits via memcmp.
+        const bool seed_equal = dilithium_internal::TimingSafeEqual(a.seed.data(), b.seed.data(), a.seed.size());
+        const bool chaincode_equal = dilithium_internal::TimingSafeEqual(
+            a.chaincode.begin(), b.chaincode.begin(), a.chaincode.size());
+        const bool fingerprint_equal = dilithium_internal::TimingSafeEqual(
+            a.vchFingerprint, b.vchFingerprint, sizeof(vchFingerprint));
+        return seed_equal && chaincode_equal && fingerprint_equal &&
+               a.nDepth == b.nDepth && a.nChild == b.nChild;
     }
 
     void Encode(unsigned char code[DILITHIUM_EXTKEY_SIZE]) const;
@@ -425,11 +433,15 @@ public:
 
     friend bool operator==(const CDilithiumExtPubKey& a, const CDilithiumExtPubKey& b)
     {
-        return a.nDepth == b.nDepth &&
-            dilithium_internal::TimingSafeEqual(a.vchFingerprint, b.vchFingerprint, sizeof(vchFingerprint)) &&
-            a.nChild == b.nChild &&
-            a.chaincode == b.chaincode &&
-            a.pubkey == b.pubkey;
+        // Chaincode is HD secret material; always CT-compare it (local first
+        // so short-circuit cannot skip the scan). Pubkey == uses TimingSafeEqual.
+        const bool chaincode_equal = dilithium_internal::TimingSafeEqual(
+            a.chaincode.begin(), b.chaincode.begin(), a.chaincode.size());
+        const bool fingerprint_equal = dilithium_internal::TimingSafeEqual(
+            a.vchFingerprint, b.vchFingerprint, sizeof(vchFingerprint));
+        const bool pubkey_equal = (a.pubkey == b.pubkey);
+        return chaincode_equal && fingerprint_equal && pubkey_equal &&
+               a.nDepth == b.nDepth && a.nChild == b.nChild;
     }
 
     void Encode(unsigned char code[DILITHIUM_EXTPUBKEY_SIZE]) const;

--- a/src/test/dilithium_key_tests.cpp
+++ b/src/test/dilithium_key_tests.cpp
@@ -279,6 +279,80 @@ BOOST_AUTO_TEST_CASE(dilithium_pubkey_equality)
     BOOST_CHECK((pubkey1 < pubkey2) != (pubkey2 < pubkey1));
 }
 
+
+BOOST_AUTO_TEST_CASE(dilithium_timingsafe_equal_functional)
+{
+    // Functional coverage for TimingSafeEqual: equal buffers, mismatch at
+    // first byte, and mismatch only at the last byte (the case short-circuit
+    // memcmp would still reject — but after scanning every byte).
+    unsigned char a[32]{}, b[32]{};
+    for (size_t i = 0; i < sizeof(a); ++i) {
+        a[i] = static_cast<unsigned char>(i * 7 + 3);
+        b[i] = a[i];
+    }
+    BOOST_CHECK(dilithium_internal::TimingSafeEqual(a, b, sizeof(a)));
+
+    b[0] ^= 0x01;
+    BOOST_CHECK(!dilithium_internal::TimingSafeEqual(a, b, sizeof(a)));
+    b[0] = a[0];
+
+    b[sizeof(b) - 1] ^= 0x80;
+    BOOST_CHECK(!dilithium_internal::TimingSafeEqual(a, b, sizeof(a)));
+    BOOST_CHECK(dilithium_internal::TimingSafeEqual(a, b, sizeof(a) - 1));
+}
+
+BOOST_AUTO_TEST_CASE(dilithium_key_equality_last_byte_differs)
+{
+    CDilithiumKey key1;
+    BOOST_REQUIRE(key1.MakeNewKey());
+    std::vector<unsigned char> bytes = key1.Serialize();
+    BOOST_REQUIRE_EQUAL(bytes.size(), CDilithiumKey::GetKeySize());
+
+    CDilithiumKey key_same;
+    BOOST_REQUIRE(key_same.Load(Span<const unsigned char>(bytes)));
+    BOOST_CHECK(key1 == key_same);
+
+    // Flip the final secret-key byte. Load/Set may reject inconsistent
+    // key material via self-checks, so compare via TimingSafeEqual on the
+    // serialized buffers and via operator== only when both keys remain valid.
+    std::vector<unsigned char> mutated = bytes;
+    mutated.back() ^= 0x01;
+    BOOST_CHECK(!dilithium_internal::TimingSafeEqual(bytes.data(), mutated.data(), bytes.size()));
+
+    // PubKey: last-byte mismatch must yield inequality.
+    CDilithiumPubKey pub = key1.GetPubKey();
+    std::vector<unsigned char> pub_bytes(pub.begin(), pub.end());
+    std::vector<unsigned char> pub_mut = pub_bytes;
+    pub_mut.back() ^= 0x01;
+    CDilithiumPubKey pub_other(pub_mut.begin(), pub_mut.end());
+    BOOST_CHECK(pub != pub_other);
+    BOOST_CHECK(!(pub == pub_other));
+}
+
+BOOST_AUTO_TEST_CASE(dilithium_extkey_equality_secret_fields)
+{
+    const auto raw_seed = std::vector<std::byte>(32, std::byte{0x42});
+    CDilithiumExtKey a;
+    a.SetSeed(Span<const std::byte>(raw_seed.data(), raw_seed.size()));
+    CDilithiumExtKey b = a;
+    BOOST_CHECK(a == b);
+
+    // Differ only in the last seed byte; metadata left identical.
+    b.seed.back() ^= 0x01;
+    BOOST_CHECK(!(a == b));
+
+    // Restore seed; differ only in last chaincode byte (secret HD material
+    // previously compared via short-circuiting uint256 operator==).
+    b = a;
+    b.chaincode.begin()[CDilithiumExtKey::SEED_SIZE - 1] ^= 0x01;
+    BOOST_CHECK(!(a == b));
+
+    // Differ only in fingerprint with identical seed/chaincode.
+    b = a;
+    b.vchFingerprint[3] ^= 0x01;
+    BOOST_CHECK(!(a == b));
+}
+
 BOOST_AUTO_TEST_CASE(dilithium_sanity_check)
 {
     // Test the global sanity check function


### PR DESCRIPTION
memcmp and std::array::operator== short-circuit on the first differing byte, leaking through timing how many leading bytes of two secrets match. Adds a TimingSafeEqual helper (volatile accumulator, XOR) for CDilithiumKey/PubKey equality, ext-key fingerprints, and the challenge-hash check in the reference implementation's crypto_sign_verify_internal().

One site is new relative to the original BTQ-AUDIT-016/-173 finding: the v0.4.0 ext-key operator== compares the 32-byte master seed via std::array's short-circuiting compare — that's the most sensitive equality in the file and is now constant-time. Ordering comparisons (operator<) are unchanged; they're not equality oracles. Passes dilithium_key/wallet/basic suites locally.