### PR TITLE
consensus: activate LWMA from block 1 on mainnet

### DIFF
--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -90,7 +90,12 @@ public:
         consensus.powLimit = uint256S("00000377ae000000000000000000000000000000000000000000000000000000");
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks (legacy, pre-LWMA)
         consensus.nPowTargetSpacing = 1 * 60;
-        consensus.nLWMAHeight = 300000;
+        // BTQ-AUDIT-103: LWMA from block 1 so mainnet never has a pre-LWMA
+        // legacy-retarget window that can be manipulated. Mainnet only: the
+        // live testnet keeps its scheduled height (changing it retroactively
+        // would invalidate existing history — see the height-gate pattern in
+        // nDilithiumP2MRHeight).
+        consensus.nLWMAHeight = 1;
         consensus.nDilithiumHeight = 1;
         consensus.fPowAllowMinDifficultyBlocks = false;
         consensus.fPowNoRetargeting = false;

--- a/src/test/pow_lwma_tests.cpp
+++ b/src/test/pow_lwma_tests.cpp
@@ -97,7 +97,11 @@ BOOST_FIXTURE_TEST_SUITE(pow_lwma_tests, BasicTestingSetup)
 BOOST_AUTO_TEST_CASE(lwma_activation_height_configured)
 {
     const auto params = CreateChainParams(*m_node.args, ChainType::BTQMAIN);
-    BOOST_CHECK_EQUAL(params->GetConsensus().nLWMAHeight, 300000);
+    // Mainnet activates LWMA from block 1 (BTQ-AUDIT-103); the live testnet
+    // keeps its scheduled height so existing history stays valid.
+    BOOST_CHECK_EQUAL(params->GetConsensus().nLWMAHeight, 1);
+    const auto testnet_params = CreateChainParams(*m_node.args, ChainType::BTQTEST);
+    BOOST_CHECK_EQUAL(testnet_params->GetConsensus().nLWMAHeight, 300000);
     BOOST_CHECK(params->GetConsensus().nDilithiumHeight > 0);
     BOOST_CHECK_EQUAL(Consensus::Params::LWMA_WINDOW, 45);
 }

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -48,11 +48,14 @@ BOOST_AUTO_TEST_CASE(get_next_work_pow_limit)
     BOOST_CHECK(PermittedDifficultyTransition(consensus, pindexLast.nHeight+1, pindexLast.nBits, expected_nbits));
 }
 
-/* Test the constraint on the lower bound for actual time taken */
+/* Test the constraint on the lower bound for actual time taken.
+ * Mainnet activates LWMA from block 1, so restore a legacy window locally:
+ * the ±4x transition bounds only apply to heights below nLWMAHeight. */
 BOOST_AUTO_TEST_CASE(get_next_work_lower_limit_actual)
 {
     const auto chainParams = CreateChainParams(*m_node.args, ChainType::BTQMAIN);
-    const auto& consensus = chainParams->GetConsensus();
+    Consensus::Params consensus = chainParams->GetConsensus();
+    consensus.nLWMAHeight = 300000;
     int64_t nLastRetargetTime = 1279008237; // Block #66528
     CBlockIndex pindexLast;
     pindexLast.nHeight = consensus.DifficultyAdjustmentInterval() - 1;
@@ -66,11 +69,13 @@ BOOST_AUTO_TEST_CASE(get_next_work_lower_limit_actual)
     BOOST_CHECK(!PermittedDifficultyTransition(consensus, pindexLast.nHeight+1, pindexLast.nBits, invalid_nbits));
 }
 
-/* Test the constraint on the upper bound for actual time taken */
+/* Test the constraint on the upper bound for actual time taken.
+ * Local legacy window for the same reason as the lower-limit case above. */
 BOOST_AUTO_TEST_CASE(get_next_work_upper_limit_actual)
 {
     const auto chainParams = CreateChainParams(*m_node.args, ChainType::BTQMAIN);
-    const auto& consensus = chainParams->GetConsensus();
+    Consensus::Params consensus = chainParams->GetConsensus();
+    consensus.nLWMAHeight = 300000;
     int64_t nLastRetargetTime = 1263163443; // NOTE: Not an actual block time
     CBlockIndex pindexLast;
     pindexLast.nHeight = consensus.DifficultyAdjustmentInterval() - 1;


### PR DESCRIPTION
Mainnet had a 300000-block legacy-retarget window before LWMA activation — manipulable exactly when the chain is weakest (low hashrate at launch). Mainnet is pre-launch, so activating from block 1 is free (BTQ-AUDIT-103).

Mainnet only, following the nDilithiumP2MRHeight height-gate pattern: testnet/signet/regtest keep the scheduled height, so no live-chain impact and no reset. The activation test now locks in both values; the two legacy-bounds pow_tests construct their legacy window explicitly since mainnet no longer has one. pow_lwma_tests and pow_tests pass locally.

Should land before the external audit snapshot — the auditors need to review the difficulty design as it will ship.