### PR TITLE
security: prevent script_flag_exceptions from disabling Dilithium/P2MR

### DIFF
--- a/src/test/validation_tests.cpp
+++ b/src/test/validation_tests.cpp
@@ -9,6 +9,9 @@
 #include <uint256.h>
 #include <util/chaintype.h>
 #include <validation.h>
+#include <deploymentstatus.h>
+#include <chain.h>
+#include <script/interpreter.h>
 
 #include <test/util/setup_common.h>
 
@@ -144,5 +147,43 @@ BOOST_AUTO_TEST_CASE(test_assumeutxo)
     BOOST_CHECK_EQUAL(out110_2.hash_serialized.ToString(), "6657b736d4fe4db0cbc796789e812d5dba7f5c143764b1b6905612f1830609d1");
     BOOST_CHECK_EQUAL(out110_2.nChainTx, 111U);
 }
+
+
+BOOST_AUTO_TEST_CASE(script_flag_exceptions_cannot_clear_dilithium_p2mr)
+{
+    // BTQ currently ships an empty script_flag_exceptions map, but the
+    // override mechanism must not be able to clear Dilithium/P2MR if entries
+    // are ever added (including Bitcoin-lineage hashes).
+    auto& chainman = *Assert(m_node.chainman);
+    Consensus::Params& consensus = const_cast<Consensus::Params&>(chainman.GetConsensus());
+
+    uint256 exception_hash = uint256S("0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");
+    // Exception payload with neither Dilithium nor P2MR bits.
+    consensus.script_flag_exceptions[exception_hash] = SCRIPT_VERIFY_P2SH;
+
+    CBlockIndex index;
+    index.nHeight = 0;
+    index.phashBlock = &exception_hash;
+
+    // Height 0 is before nDilithiumHeight (1) on regtest: P2MR forced, Dilithium not.
+    {
+        const unsigned flags = GetBlockScriptFlags(index, chainman);
+        BOOST_CHECK(flags & SCRIPT_VERIFY_P2MR);
+        BOOST_CHECK(!(flags & SCRIPT_VERIFY_DILITHIUM));
+        BOOST_CHECK(flags & SCRIPT_VERIFY_P2SH); // from exception payload
+    }
+
+    // After Dilithium activation height, Dilithium must also be forced back on.
+    index.nHeight = 1;
+    {
+        const unsigned flags = GetBlockScriptFlags(index, chainman);
+        BOOST_CHECK(flags & SCRIPT_VERIFY_P2MR);
+        BOOST_CHECK(flags & SCRIPT_VERIFY_DILITHIUM);
+    }
+
+    // Cleanup so later tests see the stock empty map.
+    consensus.script_flag_exceptions.erase(exception_hash);
+}
+
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -257,7 +257,7 @@ bool CheckSequenceLocksAtTip(CBlockIndex* tip,
 }
 
 // Returns the script flags which should be checked for a given block
-static unsigned int GetBlockScriptFlags(const CBlockIndex& block_index, const ChainstateManager& chainman);
+unsigned int GetBlockScriptFlags(const CBlockIndex& block_index, const ChainstateManager& chainman);
 
 static void LimitMempoolSize(CTxMemPool& pool, CCoinsViewCache& coins_cache)
     EXCLUSIVE_LOCKS_REQUIRED(::cs_main, pool.cs)
@@ -2096,7 +2096,7 @@ public:
     }
 };
 
-static unsigned int GetBlockScriptFlags(const CBlockIndex& block_index, const ChainstateManager& chainman)
+unsigned int GetBlockScriptFlags(const CBlockIndex& block_index, const ChainstateManager& chainman)
 {
     const Consensus::Params& consensusparams = chainman.GetConsensus();
 
@@ -2109,31 +2109,23 @@ static unsigned int GetBlockScriptFlags(const CBlockIndex& block_index, const Ch
     // For simplicity, always leave P2SH on, but conditionally enable WITNESS and TAPROOT
     // BTQ: Modified to conditionally include WITNESS and TAPROOT based on deployment status
     uint32_t flags{SCRIPT_VERIFY_P2SH};
-    
+
     // BTQ: Only enable Witness (SegWit) if the deployment is active
     if (DeploymentActiveAt(block_index, chainman, Consensus::DEPLOYMENT_SEGWIT)) {
         flags |= SCRIPT_VERIFY_WITNESS;
     }
-    
+
     // BTQ: Only enable Taproot if the deployment is active
     if (DeploymentActiveAt(block_index, chainman, Consensus::DEPLOYMENT_TAPROOT)) {
         flags |= SCRIPT_VERIFY_TAPROOT;
     }
-    
-    // BTQ: Enable Dilithium signature validation after activation height
-    if (DeploymentActiveAt(block_index, chainman, Consensus::DEPLOYMENT_DILITHIUM)) {
-        flags |= SCRIPT_VERIFY_DILITHIUM;
-    }
 
-    // BTQ: Enable BIP360 P2MR (Pay-to-Merkle-Root) validation
-    flags |= SCRIPT_VERIFY_P2MR;
-    
+    // Exception entries completely replace the flags computed above. Any rule that
+    // must remain enforceable has to be applied *after* this override — the same
+    // pattern Bitcoin uses for DERSIG/CLTV/CSV/NULLDUMMY below.
     const auto it{consensusparams.script_flag_exceptions.find(*Assert(block_index.phashBlock))};
     if (it != consensusparams.script_flag_exceptions.end()) {
         flags = it->second;
-        // Dilithium and P2MR verification must never be disabled by exceptions
-        flags |= SCRIPT_VERIFY_DILITHIUM;
-        flags |= SCRIPT_VERIFY_P2MR;
     }
 
     // Enforce the DERSIG (BIP66) rule
@@ -2155,6 +2147,13 @@ static unsigned int GetBlockScriptFlags(const CBlockIndex& block_index, const Ch
     if (DeploymentActiveAt(block_index, chainman, Consensus::DEPLOYMENT_SEGWIT)) {
         flags |= SCRIPT_VERIFY_NULLDUMMY;
     }
+
+    // BTQ: Dilithium and P2MR must never be clearable via script_flag_exceptions.
+    // Keep Dilithium deployment-gated (do not force it on pre-activation heights).
+    if (DeploymentActiveAt(block_index, chainman, Consensus::DEPLOYMENT_DILITHIUM)) {
+        flags |= SCRIPT_VERIFY_DILITHIUM;
+    }
+    flags |= SCRIPT_VERIFY_P2MR;
 
     return flags;
 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2131,6 +2131,9 @@ static unsigned int GetBlockScriptFlags(const CBlockIndex& block_index, const Ch
     const auto it{consensusparams.script_flag_exceptions.find(*Assert(block_index.phashBlock))};
     if (it != consensusparams.script_flag_exceptions.end()) {
         flags = it->second;
+        // Dilithium and P2MR verification must never be disabled by exceptions
+        flags |= SCRIPT_VERIFY_DILITHIUM;
+        flags |= SCRIPT_VERIFY_P2MR;
     }
 
     // Enforce the DERSIG (BIP66) rule

--- a/src/validation.h
+++ b/src/validation.h
@@ -105,6 +105,9 @@ void StopScriptCheckWorkerThreads();
 
 CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams);
 
+/** Script verification flags that apply to a given block. */
+unsigned int GetBlockScriptFlags(const CBlockIndex& block_index, const ChainstateManager& chainman);
+
 bool FatalError(kernel::Notifications& notifications, BlockValidationState& state, const std::string& strMessage, const bilingual_str& userMessage = {});
 
 /** Guess verification progress (as a fraction between 0.0=genesis and 1.0=current tip). */


### PR DESCRIPTION
The inherited script_flag_exceptions mechanism could clear SCRIPT_VERIFY_DILITHIUM and P2MR flags for blocks matching an exception hash. The exception entries are Bitcoin block hashes that can't occur on the BTQ chain, so the practical window is nearly theoretical — but the invariant that no mechanism can disable PQ signature verification should hold structurally. One commit, belt-and-suspenders before the external audit.