### PR TITLE
crypto: principled IsFullyValid() for Dilithium public keys

### DIFF
--- a/src/crypto/dilithium_key.h
+++ b/src/crypto/dilithium_key.h
@@ -315,8 +315,8 @@ public:
     bool IsValid() const;
 
     /**
-     * Fully validate whether this is a valid Dilithium public key.
-     * This performs more extensive validation than IsValid().
+     * Structural Dilithium pubkey check beyond IsValid(): reject all-zero
+     * rho or all-zero t1. Not a cryptographic membership proof.
      */
     bool IsFullyValid() const;
 

--- a/src/crypto/dilithium_pubkey.cpp
+++ b/src/crypto/dilithium_pubkey.cpp
@@ -35,29 +35,25 @@ bool CDilithiumPubKey::IsValid() const
 
 bool CDilithiumPubKey::IsFullyValid() const
 {
-    // BTQ-AUDIT-022: structural validation of an ML-DSA-44 public key.
+    // BTQ-AUDIT-022: cheap structural checks for an ML-DSA-44 / Dilithium2
+    // public key (rho(32) || t1(1280) == SIZE).
     //
-    // Layout is rho(32) || t1(1280 bytes). Unlike a secret key, there is NO
-    // coefficient-range check to perform: t1 is stored as a 10-bit packed field
-    // (POLYT1_PACKEDBYTES), so every correctly-sized byte string unpacks to
-    // coefficients already in [0, 2^10) and unpack_pk cannot read out of bounds.
-    // Structural validity therefore reduces to (a) correct length and (b)
-    // rejection of degenerate keys that key generation never produces. We
-    // deliberately do NOT call the verifier on a dummy signature as a "does it
-    // crash" probe: it validates nothing (a well-formed key returns "invalid"
-    // just like a malformed one) and only adds a heavy NTT to every check.
+    // t1 is 10-bit packed, so any SIZE-byte string unpacks in-bounds; there is
+    // no coefficient-range check analogous to secp256k1 curve membership.
+    // Random non-degenerate blobs still pass — this rejects only empty /
+    // all-zero and the all-zero-rho / all-zero-t1 encodings that keygen does
+    // not produce. We deliberately do NOT probe with a dummy verify() call.
     if (!IsValid()) {
-        return false;   // wrong length or all-zero blob
+        return false;   // all-zero blob (wrong-length Set() also clears to this)
     }
-    // Reject an all-zero rho (the public seed): never emitted by keygen, and a
-    // cheap DoS/confusion input.
+    // Reject all-zero rho (public seed): not produced by keygen.
     bool rho_nonzero = false;
     for (size_t i = 0; i < 32; ++i) {
         if (vch[i] != 0) { rho_nonzero = true; break; }
     }
     if (!rho_nonzero) return false;
-    // Reject an all-zero t1: a real keypair's t1 = Power2Round(A*s1 + s2) is
-    // never identically zero, so this catches structurally degenerate keys.
+    // Reject all-zero t1: Power2Round(A*s1+s2) is not expected to be identically
+    // zero for a keygen output; treat that encoding as degenerate.
     for (size_t i = 32; i < SIZE; ++i) {
         if (vch[i] != 0) return true;
     }

--- a/src/crypto/dilithium_pubkey.cpp
+++ b/src/crypto/dilithium_pubkey.cpp
@@ -35,14 +35,31 @@ bool CDilithiumPubKey::IsValid() const
 
 bool CDilithiumPubKey::IsFullyValid() const
 {
+    // BTQ-AUDIT-022: structural validation of an ML-DSA-44 public key.
+    //
+    // Layout is rho(32) || t1(1280 bytes). Unlike a secret key, there is NO
+    // coefficient-range check to perform: t1 is stored as a 10-bit packed field
+    // (POLYT1_PACKEDBYTES), so every correctly-sized byte string unpacks to
+    // coefficients already in [0, 2^10) and unpack_pk cannot read out of bounds.
+    // Structural validity therefore reduces to (a) correct length and (b)
+    // rejection of degenerate keys that key generation never produces. We
+    // deliberately do NOT call the verifier on a dummy signature as a "does it
+    // crash" probe: it validates nothing (a well-formed key returns "invalid"
+    // just like a malformed one) and only adds a heavy NTT to every check.
     if (!IsValid()) {
-        return false;
+        return false;   // wrong length or all-zero blob
     }
-    // Reject pubkeys whose rho prefix is all-zero (malformed / cheap DoS bait).
+    // Reject an all-zero rho (the public seed): never emitted by keygen, and a
+    // cheap DoS/confusion input.
+    bool rho_nonzero = false;
     for (size_t i = 0; i < 32; ++i) {
-        if (vch[i] != 0) {
-            return true;
-        }
+        if (vch[i] != 0) { rho_nonzero = true; break; }
+    }
+    if (!rho_nonzero) return false;
+    // Reject an all-zero t1: a real keypair's t1 = Power2Round(A*s1 + s2) is
+    // never identically zero, so this catches structurally degenerate keys.
+    for (size_t i = 32; i < SIZE; ++i) {
+        if (vch[i] != 0) return true;
     }
     return false;
 }

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -101,8 +101,9 @@ bool static IsValidDilithiumPubKey(const valtype &vchPubKey) {
     if (vchPubKey.size() != CDilithiumPubKey::SIZE) {
         return false;
     }
-    CDilithiumPubKey pubkey(vchPubKey);
-    return pubkey.IsValid();
+    // Size + structural checks (nonzero rho and nonzero t1). Used by
+    // OP_CHECKSIGDILITHIUM* (via EvalChecksigDilithium) and OP_DILITHIUM_PUBKEY.
+    return CDilithiumPubKey(vchPubKey).IsFullyValid();
 }
 
 /** Helper for OP_CHECKSIGDILITHIUM and OP_CHECKSIGDILITHIUMVERIFY.
@@ -116,11 +117,8 @@ static bool EvalChecksigDilithium(const valtype& sig, const valtype& pubkey, CSc
         return set_error(serror, SCRIPT_ERR_SIG_DER);
     }
 
-    // Check public key encoding
+    // Check public key encoding / structural validity (size, rho, t1).
     if (!IsValidDilithiumPubKey(pubkey)) {
-        return set_error(serror, SCRIPT_ERR_PUBKEYTYPE);
-    }
-    if (!CDilithiumPubKey(pubkey).IsFullyValid()) {
         return set_error(serror, SCRIPT_ERR_PUBKEYTYPE);
     }
 

--- a/src/test/dilithium_key_tests.cpp
+++ b/src/test/dilithium_key_tests.cpp
@@ -36,10 +36,55 @@ BOOST_AUTO_TEST_CASE(dilithium_pubkey_derivation)
     // Get public key
     CDilithiumPubKey pubkey = key.GetPubKey();
     BOOST_CHECK(pubkey.IsValid());
+    BOOST_CHECK(pubkey.IsFullyValid());
     BOOST_CHECK(pubkey.size() == CDilithiumPubKey::SIZE);
     
     // Verify the private key corresponds to the public key
     BOOST_CHECK(key.VerifyPubKey(pubkey));
+}
+
+
+BOOST_AUTO_TEST_CASE(dilithium_pubkey_isfullvalid_rejects_malformed)
+{
+    // Dilithium2 / ML-DSA-44 layout: rho(32) || t1(1280) == 1312.
+    BOOST_STATIC_ASSERT(CDilithiumPubKey::SIZE == 1312);
+    constexpr size_t RHO_SIZE = 32;
+
+    CDilithiumPubKey empty;
+    BOOST_CHECK(!empty.IsValid());
+    BOOST_CHECK(!empty.IsFullyValid());
+
+    std::vector<unsigned char> wrong_len(64, 0xab);
+    CDilithiumPubKey wrong_size(wrong_len.begin(), wrong_len.end());
+    BOOST_CHECK(!wrong_size.IsValid());
+    BOOST_CHECK(!wrong_size.IsFullyValid());
+
+    // Nonzero t1, all-zero rho.
+    std::array<unsigned char, CDilithiumPubKey::SIZE> zero_rho{};
+    zero_rho[RHO_SIZE] = 0x01;
+    CDilithiumPubKey pk_zero_rho(zero_rho.begin(), zero_rho.end());
+    BOOST_CHECK(pk_zero_rho.IsValid());
+    BOOST_CHECK(!pk_zero_rho.IsFullyValid());
+
+    // Nonzero rho, all-zero t1 (accepted by master's rho-only IsFullyValid).
+    std::array<unsigned char, CDilithiumPubKey::SIZE> zero_t1{};
+    zero_t1[0] = 0x01;
+    CDilithiumPubKey pk_zero_t1(zero_t1.begin(), zero_t1.end());
+    BOOST_CHECK(pk_zero_t1.IsValid());
+    BOOST_CHECK(!pk_zero_t1.IsFullyValid());
+
+    // Nonzero rho and t1: structural pass only.
+    std::array<unsigned char, CDilithiumPubKey::SIZE> structural{};
+    structural[0] = 0x01;
+    structural[RHO_SIZE] = 0x01;
+    CDilithiumPubKey pk_structural(structural.begin(), structural.end());
+    BOOST_CHECK(pk_structural.IsValid());
+    BOOST_CHECK(pk_structural.IsFullyValid());
+
+    // Real keygen output must remain fully valid.
+    CDilithiumKey key;
+    BOOST_REQUIRE(key.MakeNewKey());
+    BOOST_CHECK(key.GetPubKey().IsFullyValid());
 }
 
 BOOST_AUTO_TEST_CASE(dilithium_raw_secret_key_to_public_key_fails_closed)


### PR DESCRIPTION
IsFullyValid() previously reduced to a size check. This validates the key's structure so malformed Dilithium pubkeys are rejected at the wallet/mempool boundary instead of surfacing later (BTQ-AUDIT-022). Dead-center of the external audit's scope — better landed than rediscovered.