### PR TITLE
test: make the unit suite green on master before the audit snapshot

### DIFF
--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -109,7 +109,9 @@ public:
 
         // Pre-launch floor: tied to the remined genesis block (see assert below).
         // Rotate both values at each tagged release (see doc/release-process.md).
-        consensus.nMinimumChainWork = uint256S("0000000000000000000000000000000000000000000000000000000000010002");
+        // 0x49d414 is GetBlockProof(genesis) for nBits 0x1e0377ae; the previous
+        // 0x10002 predated the genesis remine and was below one block's work.
+        consensus.nMinimumChainWork = uint256S("000000000000000000000000000000000000000000000000000000000049d414");
         consensus.defaultAssumeValid = uint256S("0x000003194a90d8d8eff8b39a7ad4e2490729b97a6772b7f4c4cb8887dffd1ae4");
 
         pchMessageStart[0] = 0xf1;

--- a/src/test/sigopcount_tests.cpp
+++ b/src/test/sigopcount_tests.cpp
@@ -194,7 +194,7 @@ BOOST_AUTO_TEST_CASE(GetTxSigOpCost)
         assert(GetTransactionSigOpCost(CTransaction(spendingTx), coins, flags) == 1);
         // No signature operations if we don't verify the witness.
         assert(GetTransactionSigOpCost(CTransaction(spendingTx), coins, flags & ~SCRIPT_VERIFY_WITNESS) == 0);
-        assert(VerifyWithFlag(CTransaction(creationTx), spendingTx, flags) == SCRIPT_ERR_WITNESS_PUBKEYTYPE);
+        assert(VerifyWithFlag(CTransaction(creationTx), spendingTx, flags) == SCRIPT_ERR_EQUALVERIFY);
 
         // The sig op cost for witness version != 0 is zero.
         assert(scriptPubKey[0] == 0x00);
@@ -220,7 +220,7 @@ BOOST_AUTO_TEST_CASE(GetTxSigOpCost)
 
         BuildTxs(spendingTx, coins, creationTx, scriptPubKey, scriptSig, scriptWitness);
         assert(GetTransactionSigOpCost(CTransaction(spendingTx), coins, flags) == 1);
-        assert(VerifyWithFlag(CTransaction(creationTx), spendingTx, flags) == SCRIPT_ERR_WITNESS_PUBKEYTYPE);
+        assert(VerifyWithFlag(CTransaction(creationTx), spendingTx, flags) == SCRIPT_ERR_EQUALVERIFY);
     }
 
     // P2WSH witness program


### PR DESCRIPTION
Two of master's standing unit-test failures, fixed ahead of the external audit (auditors treat test vectors as second in evidential precedence — a red baseline undermines that):

- Cherry-pick of your d99c74b8c from fix/p2mr-merge-master-audit: aligns the stale GetTxSigOpCost witness-pubkeytype assert with the merged interpreter. This was also crashing the two tests after it via the aborted-fixture ArgsManager cascade.
- Rotates nMinimumChainWork from 0x10002 to 0x49d414 (= GetBlockProof(genesis) at nBits 0x1e0377ae). The constant predates the genesis remine and was below one block's work, failing mainnet_minimum_chainwork_at_genesis. Follows the rotate-per-release comment already in chainparams.cpp.

Remaining reds are the issue #60 inherited-vector failures (bloom/bip324) — left out since re-deriving those vectors under BTQ params is a judgment call. chainparams_genesis, sigopcount, pow, and pow_lwma suites all pass locally with this.