### PR TITLE
rpc: report an error for legacy Dilithium addresses instead of tripping an assert

### DIFF
--- a/src/key_io.cpp
+++ b/src/key_io.cpp
@@ -122,7 +122,7 @@ public:
     std::string operator()(const DilithiumPubKeyDestination& pk) const { return {}; }
 };
 
-CTxDestination DecodeDestination(const std::string& str, const CChainParams& params, std::string& error_str, std::vector<int>* error_locations)
+CTxDestination DecodeDestinationInner(const std::string& str, const CChainParams& params, std::string& error_str, std::vector<int>* error_locations)
 {
     std::vector<unsigned char> data;
     uint160 hash;
@@ -327,6 +327,38 @@ CTxDestination DecodeDestination(const std::string& str, const CChainParams& par
     error_str = res.first;
     if (error_locations) *error_locations = std::move(res.second);
     return CNoDestination();
+}
+
+/**
+ * Whether a well-formed address decoded to a legacy (pre-BIP360) Dilithium
+ * destination. These stay decodable so historical addresses and wallet history
+ * still render, but IsValidDestination() rejects them: Dilithium opcodes are
+ * consensus-valid only inside P2MR tapscript leaves.
+ */
+bool IsLegacyDilithiumDestination(const CTxDestination& dest)
+{
+    return std::holds_alternative<DilithiumPubKeyDestination>(dest) ||
+           std::holds_alternative<DilithiumPKHash>(dest) ||
+           std::holds_alternative<DilithiumScriptHash>(dest) ||
+           std::holds_alternative<DilithiumWitnessV0KeyHash>(dest) ||
+           std::holds_alternative<DilithiumWitnessV0ScriptHash>(dest);
+}
+
+CTxDestination DecodeDestination(const std::string& str, const CChainParams& params, std::string& error_str, std::vector<int>* error_locations)
+{
+    const CTxDestination dest = DecodeDestinationInner(str, params, error_str, error_locations);
+
+    // Callers rely on "not a valid destination" implying a non-empty error —
+    // validateaddress asserts exactly that. A legacy Dilithium address decodes
+    // cleanly yet is invalid, so without this it would report failure with no
+    // reason and trip the assertion.
+    if (error_str.empty() && !IsValidDestination(dest)) {
+        error_str = IsLegacyDilithiumDestination(dest)
+            ? "Legacy Dilithium address: Dilithium is only valid inside P2MR (BIP360) tapscript, so this is not a spendable payment destination. Use getnewdilithiumaddress to obtain a P2MR address."
+            : "Address is well-formed but is not a valid payment destination.";
+    }
+
+    return dest;
 }
 } // namespace
 

--- a/src/test/key_io_tests.cpp
+++ b/src/test/key_io_tests.cpp
@@ -146,4 +146,32 @@ BOOST_AUTO_TEST_CASE(key_io_invalid)
     }
 }
 
+// Goal: legacy (pre-BIP360) Dilithium addresses still decode, but are not valid
+// payment destinations. validateaddress asserts that an invalid destination always
+// carries an explanatory error, so DecodeDestination must never return one silently.
+BOOST_AUTO_TEST_CASE(key_io_legacy_dilithium_reports_error)
+{
+    SelectParams(ChainType::BTQREGTEST);
+
+    const std::string legacy_dilithium[] = {
+        "nEw8yjgSEg5hqRB6bgkbuQaajkzLc76BN4",           // base58 DilithiumPKHash
+        "2NSfQfy1vb1UBMG2TgM4h84iTEdtX1rD6xR",           // base58 DilithiumScriptHash
+        "rdbt1qd68s67kvaasd2d6ktevsr2t4gep8cg87tqye8c",  // bech32 DilithiumWitnessV0KeyHash
+    };
+
+    for (const auto& addr : legacy_dilithium) {
+        std::string error;
+        const CTxDestination dest = DecodeDestination(addr, error);
+        BOOST_CHECK_MESSAGE(!IsValidDestination(dest), "unexpectedly a valid destination: " + addr);
+        BOOST_CHECK_MESSAGE(!error.empty(), "invalid destination reported without an error: " + addr);
+    }
+
+    // Control: a P2MR address is the supported Dilithium destination and stays valid
+    // with no error, so the check above cannot pass by rejecting everything.
+    std::string error;
+    const CTxDestination p2mr = DecodeDestination("qcrt1zm9jhnxr4cuqen07hqplknfhp7q9rl26m4q6ez4gpjny0dxukx6eqnfj93l", error);
+    BOOST_CHECK(IsValidDestination(p2mr));
+    BOOST_CHECK(error.empty());
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Fixes #81.

`validateaddress` asserts `isValid == error_msg.empty()` (`rpc/output_script.cpp:64`). Making Dilithium P2MR-only turned every legacy Dilithium destination invalid, but `DecodeDestination` still decodes them and left `error_str` empty, so the assert fired:

```
$ btq-cli validateaddress nEw8yjgSEg5hqRB6bgkbuQaajkzLc76BN4
error code: -1
Internal bug detected: isValid == error_msg.empty()
```

## Change

`DecodeDestination` now sets an error whenever a well-formed address decodes to something `IsValidDestination()` rejects. Legacy Dilithium addresses get a message naming P2MR as the replacement; anything else gets a generic one, so the invariant holds regardless of which destination types are added later.

Done as a wrapper around the existing decoder rather than at the four return sites, so it cannot drift.

Behaviour after:

```
$ btq-cli validateaddress nEw8yjgSEg5hqRB6bgkbuQaajkzLc76BN4
{
  "isvalid": false,
  "error_locations": [],
  "error": "Legacy Dilithium address: Dilithium is only valid inside P2MR (BIP360) tapscript, so this is not a spendable payment destination. Use getnewdilithiumaddress to obtain a P2MR address."
}
```

No consensus, policy, wallet, or encoding changes. Legacy addresses stay decodable, so history and display are unaffected.

## Tests

New `key_io_tests/key_io_legacy_dilithium_reports_error` locks the invariant across all three decodable legacy forms (base58 pubkey-hash, base58 script-hash, bech32 witness-v0 key-hash), plus a P2MR control asserting it still decodes valid with no error — so the test cannot pass by rejecting everything.

Verified manually on regtest for all four legacy forms, a garbage address, a valid bech32 ECDSA address, and a P2MR address.

`key_io_tests` reports 160 failures both with and without this change — the pre-existing inherited-vector failures tracked in #60. No new failures. `dilithium_address_script_tests` passes clean.