### PR TITLE
wallet: sign P2MR inputs in FillPSBT so walletprocesspsbt completes

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2208,6 +2208,41 @@ TransactionError CWallet::FillPSBT(PartiallySignedTransaction& psbtx, bool& comp
         }
     }
 
+    // Tracked P2MR scriptPubKeys are owned via wallet metadata rather than by a
+    // ScriptPubKeyMan, so the loop above never sees them and would leave the
+    // input untouched — complete=false with no indication of which input failed.
+    // GetSolvingProvider() has the same fallback for the raw signing path; this
+    // is what keeps walletprocesspsbt in step with signrawtransactionwithwallet.
+    for (unsigned int i = 0; i < psbtx.tx->vin.size(); ++i) {
+        PSBTInput& input = psbtx.inputs.at(i);
+        if (PSBTInputSigned(input)) continue;
+
+        const CScript* script{nullptr};
+        if (!input.witness_utxo.IsNull()) {
+            script = &input.witness_utxo.scriptPubKey;
+        } else if (input.non_witness_utxo) {
+            const uint32_t n{psbtx.tx->vin[i].prevout.n};
+            if (n >= input.non_witness_utxo->vout.size()) continue;
+            script = &input.non_witness_utxo->vout[n].scriptPubKey;
+        } else {
+            continue;
+        }
+
+        const auto entry{GetP2MRByScript(*this, *script)};
+        if (!entry) continue;
+
+        if (sign && input.sighash_type && *input.sighash_type != sighash_type) {
+            return TransactionError::SIGHASH_MISMATCH;
+        }
+
+        const FlatSigningProvider provider{BuildP2MRSigningProvider(*this, entry->id)};
+        if (SignPSBTInput(HidingSigningProvider(&provider, /*hide_secret=*/!sign, /*hide_origin=*/!bip32derivs),
+                          psbtx, i, &txdata, sighash_type, /*out_sigdata=*/nullptr, finalize) &&
+            n_signed) {
+            (*n_signed)++;
+        }
+    }
+
     RemoveUnnecessaryTransactions(psbtx, sighash_type);
 
     // Complete if every input is now signed

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -128,6 +128,7 @@ BASE_SCRIPTS = [
     'wallet_fundrawtransaction.py --legacy-wallet',
     'wallet_fundrawtransaction.py --descriptors',
     'wallet_dilithium_send.py --descriptors',
+    'wallet_dilithium_psbt.py --descriptors',
     'wallet_bumpfee.py --legacy-wallet',
     'wallet_bumpfee.py --descriptors',
     'wallet_import_rescan.py --legacy-wallet',

--- a/test/functional/wallet_dilithium_psbt.py
+++ b/test/functional/wallet_dilithium_psbt.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The BTQ Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Regression test for signing P2MR (Dilithium) inputs through the PSBT workflow.
+
+Issue #79: walletprocesspsbt silently skipped P2MR inputs and returned
+complete=false with no diagnostic, while signrawtransactionwithwallet signed the
+same outpoint fine. P2MR scriptPubKeys are tracked in wallet metadata rather than
+by a ScriptPubKeyMan, and CWallet::FillPSBT only consulted ScriptPubKeyMans.
+"""
+
+from decimal import Decimal
+
+from test_framework.test_framework import BTQTestFramework
+from test_framework.util import assert_equal
+
+
+class WalletDilithiumPSBTTest(BTQTestFramework):
+    def add_options(self, parser):
+        self.add_wallet_options(parser, descriptors=True, legacy=False)
+
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def dilithium_address(self, wallet):
+        created = wallet.getnewdilithiumaddress()
+        assert isinstance(created, dict), created
+        return created["address"]
+
+    def run_test(self):
+        node = self.nodes[0]
+
+        node.createwallet(wallet_name="funding", descriptors=True)
+        funding = node.get_wallet_rpc("funding")
+        self.generatetoaddress(node, 110, funding.getnewaddress())
+
+        node.createwallet(wallet_name="psbt_w", descriptors=True)
+        wallet = node.get_wallet_rpc("psbt_w")
+
+        p2mr_address = self.dilithium_address(wallet)
+        ordinary_address = wallet.getnewaddress()
+        funding.sendtoaddress(p2mr_address, Decimal("10"))
+        funding.sendtoaddress(ordinary_address, Decimal("10"))
+        self.generate(node, 1)
+
+        utxos = wallet.listunspent()
+        p2mr_utxo = next(u for u in utxos if u["address"] == p2mr_address)
+        ordinary_utxo = next(u for u in utxos if u["address"] == ordinary_address)
+        # Confirm the P2MR outpoint really is witness v2, so a regression that
+        # changed the receive type could not make this test pass vacuously.
+        assert p2mr_utxo["scriptPubKey"].startswith("5220"), p2mr_utxo["scriptPubKey"]
+
+        destination = wallet.getnewaddress()
+
+        self.log.info("walletprocesspsbt signs a P2MR-only PSBT and the result relays")
+        psbt = wallet.walletcreatefundedpsbt(
+            [{"txid": p2mr_utxo["txid"], "vout": p2mr_utxo["vout"]}],
+            [{destination: Decimal("4")}],
+        )["psbt"]
+
+        # Baseline behaviour was complete=false with an empty errors list.
+        processed = wallet.walletprocesspsbt(psbt)
+        assert_equal(processed["complete"], True)
+
+        final = wallet.finalizepsbt(processed["psbt"])
+        assert_equal(final["complete"], True)
+        accept = node.testmempoolaccept([final["hex"]])[0]
+        assert_equal(accept["allowed"], True)
+
+        # Mining it proves the Dilithium witness actually verifies, not merely
+        # that the PSBT reported completion.
+        txid = node.sendrawtransaction(final["hex"])
+        self.generate(node, 1)
+        confirmed = wallet.gettransaction(txid, True, True)
+        assert_equal(confirmed["confirmations"], 1)
+        spent = {(v["txid"], v["vout"]) for v in confirmed["decoded"]["vin"]}
+        assert (p2mr_utxo["txid"], p2mr_utxo["vout"]) in spent
+
+        self.log.info("a PSBT mixing a P2MR input with an ordinary input also completes")
+        p2mr_address2 = self.dilithium_address(wallet)
+        funding.sendtoaddress(p2mr_address2, Decimal("5"))
+        self.generate(node, 1)
+        p2mr_utxo2 = next(u for u in wallet.listunspent() if u["address"] == p2mr_address2)
+
+        mixed = wallet.walletcreatefundedpsbt(
+            [
+                {"txid": p2mr_utxo2["txid"], "vout": p2mr_utxo2["vout"]},
+                {"txid": ordinary_utxo["txid"], "vout": ordinary_utxo["vout"]},
+            ],
+            [{destination: Decimal("6")}],
+        )["psbt"]
+        processed_mixed = wallet.walletprocesspsbt(mixed)
+        assert_equal(processed_mixed["complete"], True)
+        final_mixed = wallet.finalizepsbt(processed_mixed["psbt"])
+        assert_equal(node.testmempoolaccept([final_mixed["hex"]])[0]["allowed"], True)
+
+        self.log.info("sign=false leaves the P2MR input unsigned without erroring")
+        p2mr_address3 = self.dilithium_address(wallet)
+        funding.sendtoaddress(p2mr_address3, Decimal("5"))
+        self.generate(node, 1)
+        p2mr_utxo3 = next(u for u in wallet.listunspent() if u["address"] == p2mr_address3)
+        unsigned_psbt = wallet.walletcreatefundedpsbt(
+            [{"txid": p2mr_utxo3["txid"], "vout": p2mr_utxo3["vout"]}],
+            [{destination: Decimal("1")}],
+        )["psbt"]
+        assert_equal(wallet.walletprocesspsbt(unsigned_psbt, False)["complete"], False)
+        # ...and signing the same PSBT afterwards still works.
+        assert_equal(wallet.walletprocesspsbt(unsigned_psbt, True)["complete"], True)
+
+        self.log.info("ordinary-only PSBTs are unaffected")
+        plain = wallet.walletcreatefundedpsbt([], [{destination: Decimal("0.5")}])["psbt"]
+        assert_equal(wallet.walletprocesspsbt(plain)["complete"], True)
+
+
+if __name__ == "__main__":
+    WalletDilithiumPSBTTest().main()


### PR DESCRIPTION
Fixes #79.

`walletprocesspsbt` left P2MR (Dilithium) inputs untouched and returned `complete: false` with an empty `errors` list, while `signrawtransactionwithwallet` signed the same outpoint fine.

## Root cause

This is narrower than the issue thread concluded, and does **not** require new PSBT fields.

Tracked P2MR scriptPubKeys are owned via wallet metadata, not by any `ScriptPubKeyMan`. `CWallet::GetSolvingProvider` already has an explicit fallback for exactly this (`wallet.cpp:3535-3543` — looks up `GetP2MRByScript`, returns `BuildP2MRSigningProvider`), which is why the raw signing path works.

`CWallet::FillPSBT` has no equivalent. It only loops `GetAllScriptPubKeyMans()`, so no SPKM claims a P2MR script, `DescriptorScriptPubKeyMan::FillPSBT` gets a null provider, falls through to ECDSA/Taproot pubkey scavenging, finds nothing, and leaves the input alone without recording an error.

## Change

Add the P2MR pass to `FillPSBT`, mirroring the fallback that already exists in `GetSolvingProvider`. Because the wallet holds the P2MR spend data locally, the same-wallet workflow signs from metadata exactly as the raw path does.

Carrying P2MR spend data *across devices* in a PSBT — hardware wallets, air-gapped signers — is a genuinely separate problem that does need new key types, and is still unsolved. This PR does not address that, and I would not want it to look like it does.

Respects `sign` and `bip32derivs` via `HidingSigningProvider`, and returns `SIGHASH_MISMATCH` on a conflicting per-input sighash type, consistent with the SPKM path.

## Tests

New `wallet_dilithium_psbt.py`:

- P2MR-only PSBT through `walletprocesspsbt` → `finalizepsbt` → `testmempoolaccept` → broadcast → confirmed, asserting the P2MR outpoint was the input actually spent. Mining it proves the Dilithium witness verifies, not just that the PSBT reported completion.
- Mixed P2MR + ordinary input PSBT.
- `sign=false` leaves it unsigned without erroring, and signing the same PSBT afterwards still works.
- Ordinary-only PSBT control.
- Asserts the P2MR scriptPubKey really is witness v2 (`5220…`), so a change to the receive type could not make the test pass vacuously.

**Verified to fail on baseline** at `assert_equal(processed["complete"], True)` → `not(False == True)`, and pass with the fix.

`wallet_dilithium_send.py` passes. `wallet_basic.py` and `rpc_psbt.py` fail identically with and without this change (pre-existing inherited-vector failures), so no new failures.

## Note on analyzepsbt

`analyzepsbt` on an unsigned P2MR PSBT still reports `next: "updater"` rather than naming what is missing. That is now cosmetic — signing works — but it is the remaining half of the "fail loudly" request in the issue, and is worth a follow-up.