### PR TITLE
test: stop one aborting test from taking the suite with it

### DIFF
--- a/src/test/bloom_tests.cpp
+++ b/src/test/bloom_tests.cpp
@@ -78,8 +78,16 @@ BOOST_AUTO_TEST_CASE(bloom_create_insert_serialize_with_tweak)
 
 BOOST_AUTO_TEST_CASE(bloom_create_insert_key)
 {
-    std::string strSecret = std::string("5Kg1gnAjaLfKiwhhPpGS3QfRg2m6awQvaj98JCZBZQ5SuS2F15C");
-    CKey key = DecodeSecret(strSecret);
+    // Raw secret behind the Bitcoin mainnet WIF this test historically used
+    // ("5Kg1gnAjaLfKiwhhPpGS3QfRg2m6awQvaj98JCZBZQ5SuS2F15C"). Set it directly
+    // instead of via DecodeSecret: BTQ's base58 SECRET_KEY prefix differs, so
+    // that WIF does not decode here, leaving an invalid CKey whose GetPubKey()
+    // trips assert(keydata) and aborts the process. The key material is
+    // unchanged, so the expected filter bytes below still hold.
+    const std::vector<unsigned char> vchSecret{ParseHex("f49addfd726a59abde172c86452f5f73038a02f4415878dc14934175e8418aff")};
+    CKey key;
+    key.Set(vchSecret.begin(), vchSecret.end(), /*fCompressedIn=*/false);
+    BOOST_REQUIRE(key.IsValid());
     CPubKey pubkey = key.GetPubKey();
     std::vector<unsigned char> vchPubKey(pubkey.begin(), pubkey.end());
 

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -93,6 +93,12 @@ BasicTestingSetup::BasicTestingSetup(const ChainType chainType, const std::vecto
       m_args{}
 {
     m_node.args = &gArgs;
+    // gArgs is global and only cleared by ~BasicTestingSetup. If a test aborts
+    // mid-fixture that destructor never runs, and every later fixture then trips
+    // the duplicate-registration assert in SetupServerArgs() below — turning one
+    // failure into hundreds of unrelated ones. Clearing here is idempotent and
+    // keeps a single fatal test from taking the rest of the suite with it.
+    gArgs.ClearArgs();
     std::vector<const char*> arguments = Cat(
         {
             "dummy",


### PR DESCRIPTION
Partial progress on #60. **This does not make the suite green** — it removes the mechanism that was hiding how bad things are.

## The cascade

`bloom_tests/bloom_create_insert_key` decodes a hardcoded Bitcoin mainnet WIF. BTQ's base58 `SECRET_KEY` prefix differs, so `DecodeSecret` returns an invalid `CKey` and `GetPubKey()` trips `assert(keydata)` → SIGABRT.

That abort skips `~BasicTestingSetup`, leaving `gArgs` populated, so every later fixture trips `ArgsManager::AddArg`'s `ret.second` assert and aborts too. One bad line produced hundreds of unrelated failures across `util_tests`, `script_tests`, `wallet_tests`, `crypto_tests`, `net_tests`, `dilithium_key_tests`, `p2mr_tests` and more.

## Change

- Set the key from the raw 32 bytes the WIF encodes rather than via `DecodeSecret`. Key material is unchanged, so the expected filter bytes still hold.
- Clear `gArgs` at the start of `BasicTestingSetup` — idempotent, and stops a fatal test poisoning the fixtures after it.

`bloom_tests` now passes, 12 cases.

## What this does NOT fix

The full run still terminates early. It now dies in `descriptor_tests` with a segfault, from the same root cause class:

```
descriptor_tests.cpp(146): combo(): key L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1 is not valid
fatal error: memory access violation at address: 0x00000000
```

There is a **chain** of these, each masking the next. Worth stating plainly so the numbers are not misread: the run went from 865 reported failures to 283, but that is **not** an improvement — the second run dies *earlier*, so `key_io_tests` (160), `util_tests` (8) and `rpc_tests` (1) never execute at all. The true total is still unknown and will only be measurable once the fatal chain is cleared.

## Verified in isolation on this branch

Passing: `bloom_tests`, `script_tests`, `dilithium_wallet_tests`, `dilithium_key_tests`, `wallet_tests`, `p2mr_tests`, `scriptpubkeyman_tests`, `crypto_tests`, `net_tests`, `netbase_tests`, `pow_tests`, `pow_lwma_tests`.

Still failing: `bip324_tests` (280), `key_io_tests` (160), `util_tests` (8), `coinselector_tests` (4), `descriptor_tests` (2), `rpc_tests` (1), `denialofservice_tests` (1).

Worth noting the Dilithium and wallet suites are all green — that coverage exists, it has just been invisible under the noise.

## Scope for whoever continues

A grep for Bitcoin-format WIFs across `src/test/` and `src/wallet/test/` returns ~318 unique strings over 10+ files including `bip32_tests`, `key_tests`, `miniscript_tests`, `crypto_tests` and several `src/test/data/*.json` fixtures. That count is an upper bound — the pattern also matches non-key base58 — but the spread is real.