### PR TITLE
fix: keep testnet legacy Dilithium Base58 addresses valid

### DIFF
--- a/src/addresstype.cpp
+++ b/src/addresstype.cpp
@@ -4,6 +4,7 @@
 
 #include <addresstype.h>
 
+#include <chainparams.h>
 #include <crypto/dilithium_key.h>
 #include <crypto/sha256.h>
 #include <hash.h>
@@ -14,6 +15,7 @@
 #include <util/hash_type.h>
 
 #include <cassert>
+#include <limits>
 #include <vector>
 
 typedef std::vector<unsigned char> valtype;
@@ -229,6 +231,15 @@ public:
     }
 };
 
+/** True while DEPLOYMENT_DILITHIUM_P2MR remains unscheduled (testnet today).
+ *  Legacy Dilithium Base58 P2PKH/P2SH outputs are still consensus-spendable
+ *  there; on chains that activate P2MR-only from genesis/height 1 they are not
+ *  valid payment destinations. */
+bool LegacyDilithiumBase58PaymentsAllowed()
+{
+    return Params().GetConsensus().nDilithiumP2MRHeight == std::numeric_limits<int>::max();
+}
+
 class ValidDestinationVisitor
 {
 public:
@@ -242,11 +253,12 @@ public:
     bool operator()(const WitnessV2P2MR& dest) const { return true; }
     bool operator()(const WitnessUnknown& dest) const { return true; }
     // Dilithium destination operators
-    // Legacy Dilithium destinations remain decodable for display/history, but are
-    // not valid payment destinations: Dilithium opcodes are P2MR-only.
+    // Bare Dilithium P2PK and witness-v0 Dilithium templates are never address
+    // payment destinations. Base58 Dilithium P2PKH/P2SH remain valid only while
+    // P2MR-only is unscheduled (see LegacyDilithiumBase58PaymentsAllowed).
     bool operator()(const DilithiumPubKeyDestination& dest) const { return false; }
-    bool operator()(const DilithiumPKHash& dest) const { return false; }
-    bool operator()(const DilithiumScriptHash& dest) const { return false; }
+    bool operator()(const DilithiumPKHash& dest) const { return LegacyDilithiumBase58PaymentsAllowed(); }
+    bool operator()(const DilithiumScriptHash& dest) const { return LegacyDilithiumBase58PaymentsAllowed(); }
     bool operator()(const DilithiumWitnessV0KeyHash& dest) const { return false; }
     bool operator()(const DilithiumWitnessV0ScriptHash& dest) const { return false; }
 };

--- a/src/rpc/output_script.cpp
+++ b/src/rpc/output_script.cpp
@@ -61,6 +61,21 @@ static RPCHelpMan validateaddress()
             std::vector<int> error_locations;
             CTxDestination dest = DecodeDestination(request.params[0].get_str(), error_msg, &error_locations);
             const bool isValid = IsValidDestination(dest);
+            // DecodeDestination still returns legacy Dilithium witness-v0 (and,
+            // after P2MR-only activation, Base58 Dilithium) destinations for
+            // display/history with an empty error. validateaddress requires an
+            // explanatory error whenever isvalid is false.
+            if (!isValid && error_msg.empty() && !std::holds_alternative<CNoDestination>(dest)) {
+                const bool legacy_dilithium =
+                    std::holds_alternative<DilithiumPubKeyDestination>(dest) ||
+                    std::holds_alternative<DilithiumPKHash>(dest) ||
+                    std::holds_alternative<DilithiumScriptHash>(dest) ||
+                    std::holds_alternative<DilithiumWitnessV0KeyHash>(dest) ||
+                    std::holds_alternative<DilithiumWitnessV0ScriptHash>(dest);
+                error_msg = legacy_dilithium
+                    ? "Legacy Dilithium address: Dilithium is only valid inside P2MR (BIP360) tapscript, so this is not a spendable payment destination. Use getnewdilithiumaddress to obtain a P2MR address."
+                    : "Address is well-formed but is not a valid payment destination.";
+            }
             CHECK_NONFATAL(isValid == error_msg.empty());
 
             UniValue ret(UniValue::VOBJ);

--- a/src/test/address_all_chains_tests.cpp
+++ b/src/test/address_all_chains_tests.cpp
@@ -191,7 +191,12 @@ BOOST_AUTO_TEST_CASE(encode_decode_roundtrip_all_chains)
             CTxDestination decoded = DecodeDestination(encoded, err);
             const bool legacy_dilithium =
                 label == "P2DPKH" || label == "P2DSH" || label == "P2DWPKH" || label == "P2DWSH";
-            if (legacy_dilithium) {
+            // Base58 Dilithium P2PKH/P2SH stay valid payment destinations on
+            // testnet while P2MR-only is unscheduled; witness-v0 Dilithium and
+            // post-activation Base58 Dilithium do not.
+            const bool legacy_base58_payments_allowed =
+                (label == "P2DPKH" || label == "P2DSH") && info.chain == ChainType::BTQTEST;
+            if (legacy_dilithium && !legacy_base58_payments_allowed) {
                 // Historical Dilithium destinations remain encodable/decodable for
                 // display, but are no longer valid payment destinations.
                 BOOST_CHECK_MESSAGE(decoded.index() == dest.index(),

--- a/src/test/key_io_tests.cpp
+++ b/src/test/key_io_tests.cpp
@@ -146,4 +146,31 @@ BOOST_AUTO_TEST_CASE(key_io_invalid)
     }
 }
 
+// Mining-pool coinbase address (testnet Dilithium Base58 P2PKH). While
+// DEPLOYMENT_DILITHIUM_P2MR is unscheduled on testnet these remain valid
+// payment destinations so validateaddress / Miningcore keep working.
+BOOST_AUTO_TEST_CASE(key_io_testnet_legacy_dilithium_base58_still_valid)
+{
+    SelectParams(ChainType::BTQTEST);
+
+    // Live Testnet-BTQ-Mining-Pool coinbase address.
+    const std::string pool_addr = "nSUTw4YKuND8kNFad9TyWBXCKouru85oGa";
+    std::string error;
+    const CTxDestination dest = DecodeDestination(pool_addr, error);
+    BOOST_CHECK_MESSAGE(error.empty(), "decode error for pool address: " + error);
+    BOOST_CHECK(std::holds_alternative<DilithiumPKHash>(dest));
+    BOOST_CHECK_MESSAGE(IsValidDestination(dest),
+                        "testnet legacy Dilithium Base58 must remain a valid payment destination");
+    BOOST_CHECK_EQUAL(EncodeDestination(dest), pool_addr);
+
+    // Same form on regtest (P2MR-only from height 1) must not be a payment destination.
+    SelectParams(ChainType::BTQREGTEST);
+    CDilithiumKey key;
+    BOOST_REQUIRE(key.MakeNewKey());
+    const DilithiumPKHash regtest_pkh{key.GetPubKey()};
+    BOOST_CHECK(!IsValidDestination(regtest_pkh));
+
+    SelectParams(ChainType::BTQMAIN);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary
- Restore `DilithiumPKHash` / `DilithiumScriptHash` as valid payment destinations while `DEPLOYMENT_DILITHIUM_P2MR` remains unscheduled (testnet today), so Miningcore `validateaddress` accepts the pool coinbase address again.
- On chains with P2MR-only from genesis/height 1, those destinations stay invalid; `validateaddress` now returns `isvalid: false` with an explanatory error instead of tripping `isValid == error_msg.empty()`.
- Adds a unit test covering the live mining-pool Dilithium Base58 address on testnet.

Supersedes the `isvalid: false` approach in #82 for testnet Base58 Dilithium (still needed there for witness-v0 / post-activation cases). Fixes #81 without breaking Miningcore.

## Test plan
- [x] `test_btq --run_test=key_io_tests/key_io_testnet_legacy_dilithium_base58_still_valid`
- [x] `test_btq --run_test=dilithium_p2mr_only_tests/legacy_dilithium_destinations_not_valid_payments`
- [x] `btq-cli -testnet validateaddress nSUTw4YKuND8kNFad9TyWBXCKouru85oGa` → `isvalid: true`, `isdilithium: true`
- [x] `btq-cli -regtest validateaddress <legacy Dilithium>` → `isvalid: false` with error (no assert)
- [ ] Upgrade mining pool node and confirm Miningcore stays up on :3333