### PR TITLE
test: wire address_all_chains_tests for Dilithium destination policy

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -90,6 +90,7 @@ BTQ_TESTS =\
   test/crypto_tests.cpp \
   test/dilithium_key_tests.cpp \
   test/dilithium_address_script_tests.cpp \
+  test/address_all_chains_tests.cpp \
   test/dilithium_descriptor_tests.cpp \
   test/dilithium_basic_tests.cpp \
   test/dilithium_p2mr_only_tests.cpp \

--- a/src/test/address_all_chains_tests.cpp
+++ b/src/test/address_all_chains_tests.cpp
@@ -283,10 +283,26 @@ BOOST_AUTO_TEST_CASE(cross_chain_rejection_all_chains)
 
             if (row.source_chain == target.chain) {
                 ++count_same_chain;
-                BOOST_CHECK_MESSAGE(valid,
-                    "Expected " << row.label << " from " << row.source_name
-                                << " to decode on target " << target.name
-                                << " addr=" << row.address << " err=" << err);
+                // Mirror encode_decode_roundtrip_all_chains: witness-v0 Dilithium
+                // is never a payment destination; Base58 Dilithium only while
+                // testnet keeps P2MR-only unscheduled.
+                const bool legacy_dilithium =
+                    row.label == "P2DPKH" || row.label == "P2DSH" ||
+                    row.label == "P2DWPKH" || row.label == "P2DWSH";
+                const bool legacy_base58_payments_allowed =
+                    (row.label == "P2DPKH" || row.label == "P2DSH") &&
+                    target.chain == ChainType::BTQTEST;
+                if (legacy_dilithium && !legacy_base58_payments_allowed) {
+                    BOOST_CHECK_MESSAGE(!valid,
+                        "Legacy Dilithium destination unexpectedly valid for payments: "
+                            << row.label << " on " << target.name
+                            << " addr=" << row.address);
+                } else {
+                    BOOST_CHECK_MESSAGE(valid,
+                        "Expected " << row.label << " from " << row.source_name
+                                    << " to decode on target " << target.name
+                                    << " addr=" << row.address << " err=" << err);
+                }
                 continue;
             }
 


### PR DESCRIPTION
## Summary
- Wire `src/test/address_all_chains_tests.cpp` into `Makefile.test.include` (it was dead after CI lean address smoke replaced upstream address functionals).
- Update same-chain validity expectations to match P2MR-only / `IsValidDestination`: witness-v0 Dilithium never valid; Base58 Dilithium only on testnet while P2MR-only is unscheduled.

## Test plan
- [x] `./src/test/test_btq --run_test=address_all_chains_tests` → no errors
- [x] Dilithium functionals on master (`820b801`): legacy_spend, send, activation, p2mr_multisig all PASS