### PR TITLE
test: skip inherited BIP324 vectors that cannot pass under BTQ params

### DIFF
--- a/src/test/bip324_tests.cpp
+++ b/src/test/bip324_tests.cpp
@@ -158,7 +158,44 @@ void TestBIP324PacketVector(
 
 }  // namespace
 
-BOOST_FIXTURE_TEST_SUITE(bip324_tests, BasicTestingSetup)
+// The vectors below are inherited verbatim from upstream Bitcoin and cannot pass
+// on BTQ, so this suite is skipped rather than asserted. In full:
+//
+//  1. The feature is off. v2 transport is opt-in and disabled by default on BTQ
+//     (DEFAULT_V2_TRANSPORT{false}, src/net.h:111) where upstream ships it
+//     enabled. The code under test is inert in every configuration we ship.
+//  2. The vectors mismatch by construction, not by defect. BIP324Cipher salts
+//     the session KDF with "btq_v2_shared_secret" plus the network magic
+//     (src/bip324.cpp:38). BTQ changed both, so every hardcoded upstream packet
+//     vector must diverge even if this implementation is byte-perfect. These
+//     failures are evidence of deliberately changed parameters, not of broken
+//     crypto.
+//  3. Parity is deferred, not abandoned. Regenerating them against BTQ transport
+//     params requires an independent reference generator, and BIP324 is in any
+//     case the wrong foundation for a post-quantum transport -- its handshake is
+//     ElligatorSwift over secp256k1 ECDH. That work risks being thrown away
+//     against a design that would be replaced rather than extended.
+//
+// This skips the test vectors ONLY. It does not remove or disable BIP324 itself,
+// which still compiles and still carries real value against classical adversaries
+// -- transaction-origin linkage and DPI censorship -- whenever BTQ enables it.
+// "Not post-quantum" is deliberately not the argument here; by that standard we
+// would also drop the ECDSA compatibility paths.
+//
+// Tracked in BTQ-113. Revisit if BTQ enables v2 transport or commits to parity.
+//
+// NB: this uses precondition() and not the more obvious disabled(). The
+// %.cpp.test rule in src/Makefile.test.include greps the suite name out of this
+// file and passes it to test_btq as an explicit `-t bip324_tests` filter, and an
+// explicit filter overrides disabled() -- the suite would run and fail anyway.
+// A precondition is evaluated at runtime and survives the filter. Measured on
+// Boost 1.74: disabled() under `-t` exits 201, precondition under `-t` exits 0.
+static bool upstream_vectors_apply_to_btq(boost::unit_test::test_unit_id)
+{
+    return false;
+}
+
+BOOST_FIXTURE_TEST_SUITE(bip324_tests, BasicTestingSetup, *boost::unit_test::precondition(upstream_vectors_apply_to_btq))
 
 BOOST_AUTO_TEST_CASE(packet_test_vectors) {
     // BIP324 key derivation uses network magic in the HKDF process. We use mainnet params here


### PR DESCRIPTION
## Summary

`bip324_tests` is the first failing file in the unit run, and it is currently the only thing CI ever gets to. Skipping its inherited vectors lets the merge gate advance for the first time in weeks.

Tracked as BTQ-113, under the test-suite umbrella BTQ-90.

## Why this is the head of the queue

`check-local` invokes `test_btq` once per test file, and `make check` stops at the first failing file. Measured on master `731c7efc5`:

- the failing step reports **280 failures, and every failure line is `test/bip324_tests.cpp`** — nothing else contributes
- `bip324_tests` sorts early, so **no test file after it executes in CI at all**

So `build-and-address-tests` being red is not a weak signal, it is an absent one. Every other suite — including the work in #91 — is invisible to CI until this lands. That also means red CI is currently meaningless as a review signal on any BTQ PR, which is a bad habit to carry into an audit.

## Why skipping is defensible here

Two facts, both verified against master rather than assumed:

1. **The feature is off.** `DEFAULT_V2_TRANSPORT{false}` (`src/net.h:111`). Upstream Bitcoin ships this `true`; BTQ does not enable it. The code under test is inert in every configuration we ship.
2. **The vectors mismatch by construction, not by defect.** `BIP324Cipher::Initialize` salts the session KDF with `"btq_v2_shared_secret"` plus the network magic (`src/bip324.cpp:38`). BTQ changed both, so every hardcoded upstream packet vector must diverge *even if this implementation is byte-perfect*.

This removes the vectors **only**. BIP324 itself is untouched and still compiles.

Worth stating explicitly, because the short version gets misremembered as "BIP324 isn't quantum-safe so we don't need it" — that argument proves far too much, and by the same standard we would drop the ECDSA compatibility paths. BIP324 was never a post-quantum feature. It defends against classical adversaries that exist today: transaction-origin linkage (which node announced first ties a tx to an IP) and DPI censorship, the latter mattering disproportionately for a small chain still bootstrapping its peer graph. The argument for skipping is the maintenance cost of the vectors against a transport we have not enabled — not the feature being pointless.

Parity is deferred, not abandoned. Regenerating them needs an independent reference generator, and BIP324 is in any case the wrong foundation for a PQ transport (its handshake is ElligatorSwift over secp256k1 ECDH), so that work risks being thrown away against a design that would be replaced rather than extended.

## Implementation note — `precondition()`, not `disabled()`

This is the part worth reviewing carefully, because the obvious approach silently does nothing.

`disabled()` is what you would reach for. It does not work here. The `%.cpp.test` rule in `src/Makefile.test.include` greps the suite name out of the source and passes it to `test_btq` as an explicit `-t bip324_tests` filter — and **an explicit filter overrides `disabled()`**, so the suite runs and fails exactly as before. A `precondition` is evaluated at runtime and survives the filter.

Measured on Boost 1.74, matching CI's ubuntu-22.04, under the exact `-t` invocation the Makefile uses:

| Mechanism | Result under `-t bip324_tests` | Exit |
| -- | -- | -- |
| `*boost::unit_test::disabled()` | suite runs, vectors fail | 201 |
| `*boost::unit_test::precondition(...)` | `skipped because precondition failed` | 0 |

The rationale and this gotcha are both recorded in the file so the next person does not rediscover it by shipping a no-op.

## What this does not do

**It does not turn CI green.** It lets CI advance to the next failing file — most likely `key_io_tests` (160 failures, which must be *regenerated*, not skipped, since they cover BTQ's own address encode/decode). That is the intended outcome: the first honest, ordered account of what is actually broken.

## Test plan

- [x] Suite-name extraction still yields `bip324_tests` after the edit — the added comment block could have corrupted the `-t` filter and does not
- [x] Declaration form (fixture + precondition decorator) compiles clean under `-Wall -Wextra` against `<boost/test/unit_test.hpp>`
- [x] Mechanism verified on Boost 1.74 under the exact Makefile invocation (table above)
- [ ] **Full `make check` not run locally** — `libboost_unit_test_framework` is not installed on my machine, so `test_btq` cannot link. CI on this PR is the end-to-end check; expect it to advance past `bip324_tests` and fail on the next file rather than go green.

## Review note

Needs the confirmation BTQ-113 already calls for: that BTQ does not intend to maintain BIP324 v2 vector parity. If parity is wanted, this re-scopes to "regenerate 280 vectors against BTQ transport params" — real work needing a reference generator — and should be re-scoped rather than skipped.
