### PR TITLE
test: re-encode key_tests key material under BTQ base58 versions

### DIFF
--- a/src/test/key_tests.cpp
+++ b/src/test/key_tests.cpp
@@ -18,16 +18,35 @@
 
 #include <boost/test/unit_test.hpp>
 
-static const std::string strSecret1 = "5HxWvvfubhXpYYpS3tJkw6fq9jE9j18THftkZjHHfmFiWtmAbrj";
-static const std::string strSecret2 = "5KC4ejrDjv152FGwP386VD1i2NYc5KkfSMyv1nGy1VGDxGHqVY3";
-static const std::string strSecret1C = "Kwr371tjA9u2rFSMZjTNun2PXXP3WPZu2afRHTcta6KxEUdm1vEw";
-static const std::string strSecret2C = "L3Hq7a8FEQwJkW1M2GNKDW28546Vp5miewcCzSqUD9kCAXrJdS3g";
-static const std::string addr1 = "1QFqqMUD55ZV3PJEJZtaKCsQmjLT6JkjvJ";
-static const std::string addr2 = "1F5y5E5FMc5YzdJtB9hLaUe43GDxEKXENJ";
-static const std::string addr1C = "1NoJrossxPBKfCHuJXT4HadJrXRE9Fxiqs";
-static const std::string addr2C = "1CRj2HyM1CXWzHAXLQtiGLyggNT9WQqsDs";
+// These were inherited from upstream Bitcoin and encoded under Bitcoin's base58
+// versions, so none of them decoded here: BTQ uses SECRET_KEY 235 (not 128) and
+// PUBKEY_ADDRESS 75 (not 0), see src/kernel/chainparams.cpp. DecodeSecret()
+// returned an invalid CKey, and the GetPubKey() calls below then tripped
+// assert(keydata) in key.cpp and took the whole test binary down with SIGABRT --
+// the same failure mode PR #87 fixed in bloom_tests.
+//
+// Re-encoded under BTQ's versions. Only the version byte changes; the 32 secret
+// bytes and the compression flag are byte-for-byte identical to what the Bitcoin
+// literals encoded, so every downstream expectation in this file (pubkeys,
+// signatures, negation, ellswift) still holds unchanged.
+//
+// Derived with test/functional/test_framework (base58 + ECKey + ripemd160), not
+// by recording what the C++ under test emitted. The same pipeline run with
+// Bitcoin's versions reproduces all eight original literals exactly, which is
+// what makes these trustworthy.
+static const std::string strSecret1 = "8sxAojhKnDu3yKzu3uifzQph8w7zHMJ9V4UGfktD2syDKLTwqiJ";
+static const std::string strSecret2 = "8uBiXYsdvSNJT2TQP4Y1YXAa1aSSdfvMdkZS7ostNbyikjv23Jd";
+static const std::string strSecret1C = "bmtWHHSytbvk7crYjqgw6Q9WA1sqqAagSrKNA4h27Hy7MtuKDJXU";
+static const std::string strSecret2C = "bsLJHqgVxry21sRYCNbsQ89EhYbJ8rnW5DG9s3ubkMPMHxC75WoV";
+static const std::string addr1 = "Xac5gVppKcKCNtkj92sUgcHQyZfCPn9qcJ";
+static const std::string addr2 = "XRSCvNRrc8qGL8mP1cgEwt44F6Yhaz5iN2";
+static const std::string addr1C = "XZ9YhxEVCuw2zhkQ8zRxez3K4MjyRXqsn1";
+static const std::string addr2C = "XNmxsSKxFjHEKnd2AsscdkPgtCmtsyhXqm";
 
-static const std::string strAddressBad = "1HV9Lc3sNHZxwj4Zk6fB38tEmBryq2cBiF";
+// A valid BTQ P2PKH address, which must still not decode as a private key. Kept
+// as an address rather than arbitrary text so this keeps testing what it did
+// upstream: that DecodeSecret rejects a well-formed address of the same chain.
+static const std::string strAddressBad = "XTqPBkQUcpKgHEX4aZe5QYJEy2Bj9QUtff";
 
 
 BOOST_FIXTURE_TEST_SUITE(key_tests, BasicTestingSetup)


### PR DESCRIPTION
## Summary

`key_tests` aborted the whole test binary. This fixes it, and it turns out to be the link in the fatal chain that unblocks most of the suite: with it applied the run goes from 46 executed suites to **118**.

Tracked as BTQ-112 under the test-suite umbrella BTQ-90.

## Root cause

Same pattern as #87 (`bloom_tests`) and #91 (`descriptor_tests`): test data inherited from upstream Bitcoin that BTQ's changed constants invalidate.

The WIFs and addresses at the top of the file are encoded under Bitcoin's base58 versions, and BTQ uses different ones (`src/kernel/chainparams.cpp`):

| | Bitcoin | BTQ |
|---|---|---|
| `PUBKEY_ADDRESS` | 0 | 75 |
| `SECRET_KEY` | 128 | 235 |

So `DecodeSecret()` returned an invalid `CKey`, four assertions failed, and the first `GetPubKey()` then tripped `assert(keydata)` at `key.cpp:189` — SIGABRT, taking every suite ordered after `key_tests` with it.

## What changed

**Re-encoded rather than sidestepped.** Only the version byte moves; the 32 secret bytes and the compression flag are byte-for-byte identical to what the Bitcoin literals encoded. Every downstream expectation in the file — pubkeys, signatures, negation, ellswift — still holds with no other edits. Keeping the values flowing through `DecodeSecret()` also means this suite still exercises BTQ's own WIF decode path instead of bypassing it, which matters given that path had a live bug in #81.

**`strAddressBad` re-encoded as a BTQ address**, not left as the Bitcoin one. Worth a reviewer's eye, as it is the one change not strictly forced by the crash: leaving it would still pass, but only by accident — it would be checking that a *foreign-chain* string is not a private key, when the upstream intent was that a well-formed address of *the same chain* is not one. That is a weaker test wearing the same name.

**Derivation is independent.** Values were produced with `test/functional/test_framework` (base58 + `ECKey` + `ripemd160`), not recorded from the C++ under test. The same pipeline run with *Bitcoin's* versions reproduces all eight original literals exactly — that round-trip is what makes the BTQ ones trustworthy rather than merely self-consistent.

## Result

`key_tests`: **6 cases, 0 failures.** Was 4 failures plus SIGABRT.

Measured locally at CI parity (`--disable-bench --disable-fuzz --disable-fuzz-binary --without-gui --with-incompatible-bdb`), stacking the open fixes:

| Applied | Suites executed | Terminates at | Exit |
|---|---|---|---|
| #92 | 36 | `descriptor_tests` segfault | 139 |
| #92 + #91 | 46 | `key_tests` abort | 134 |
| #92 + #91 + **this** | **118** (664 cases) | `psbt_wallet_tests` abort | 134 |

## What this exposes

This does not make the suite green — it makes it *visible*. Most of these suites had never executed, so these counts are new information rather than regressions:

| Suite | Failures | Previously known? |
|---|---|---|
| `key_io_tests` | 160 | yes — regenerate, do not skip |
| `miner_tests` | 112 | **no** |
| `descriptor_tests` | 30 | yes — #91's two open decisions |
| `txpackage_tests` | 21 | **no** |
| `validation_chainstatemanager_tests` | 10 | **no** |
| `util_tests` | 8 | yes |
| `script_standard_tests` | 8 | **no** |
| `miniscript_tests` | 5 | **no** |
| `validation_tests` | 4 | **no** |
| `validation_chainstate_tests` / `script_parse_tests` / `rpc_tests` / `denialofservice_tests` | 1 each | partly |

362 failures total, and that is still a **lower bound** — the run aborts at `psbt_wallet_tests`, so anything sorted after it remains unexecuted.

## Next fatal, for whoever picks up the chain

```
test_btq: wallet/test/psbt_wallet_tests.cpp:24:
    void wallet::psbt_wallet_tests::import_descriptor(wallet::CWallet&, const string&):
    Assertion `desc' failed.
```

A descriptor string fails to parse and the result is dereferenced unchecked — same shape again, and the same `BOOST_REQUIRE`-instead-of-deref lesson #91 applies to `descriptor_tests`.

## Test plan

- [x] `key_tests` passes in isolation under the exact `%.cpp.test` invocation: `test_btq -t key_tests` → 6 cases, `*** No errors detected`, exit 0
- [x] Confirmed the cases actually execute rather than being skipped
- [x] Derivation pipeline validated by reproducing all eight original Bitcoin literals byte-for-byte before emitting BTQ values
- [x] Full-binary run stacked with #91 and #92: 118 suites / 664 cases, no abort until `psbt_wallet_tests`
- [ ] CI will still be red — expected, and not caused by this PR
