### PR TITLE
bench: measure Dilithium verification cost against ECDSA

### DIFF
--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -28,6 +28,7 @@ bench_bench_btq_SOURCES = \
   bench/data.cpp \
   bench/data.h \
   bench/descriptors.cpp \
+  bench/dilithium_verify.cpp \
   bench/disconnected_transactions.cpp \
   bench/duplicate_inputs.cpp \
   bench/ellswift.cpp \

--- a/src/bench/dilithium_verify.cpp
+++ b/src/bench/dilithium_verify.cpp
@@ -2,10 +2,17 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <addresstype.h>
 #include <bench/bench.h>
 #include <crypto/dilithium_key.h>
 #include <key.h>
+#include <policy/policy.h>
 #include <pubkey.h>
+#include <script/interpreter.h>
+#include <script/script.h>
+#include <script/signingprovider.h>
+#include <script/solver.h>
+#include <test/util/transaction_utils.h>
 #include <uint256.h>
 
 #include <cassert>
@@ -83,5 +90,183 @@ static void ECDSAVerify(benchmark::Bench& bench)
     ECC_Stop();
 }
 
+// The two benchmarks above measure the signature primitives in isolation. That
+// is not the unit the sigop budget charges.
+//
+// DILITHIUM_SIGOP_COST is applied per signature *opcode inside a script*, by
+// CScript::GetSigOpCount, reached for P2MR through WitnessSigOps ->
+// CountWitnessSigOps -> GetTransactionSigOpCost, and enforced against
+// MAX_BLOCK_SIGOPS_COST in ConnectBlock. So what a node actually pays per
+// charged sigop is a whole input verification: witness parsing, control-block
+// and Merkle-path checking, sighash computation over the transaction, script
+// execution, and only then the signature check.
+//
+// That overhead is substantial and largely algorithm-independent, so it dilutes
+// the primitive ratio. Measuring only the primitive overstates how much dearer a
+// Dilithium input is than an ECDSA one. The two benchmarks below verify complete
+// inputs through VerifyScript, which is the comparison the constant should be
+// derived from:
+//
+//     ./src/bench/bench_btq -filter='(P2MRDilithium|P2WPKHECDSA)Input'
+//
+// Both are built with the same crediting/spending transaction helpers and run
+// through the same VerifyScript entry point, so they differ only in output type
+// and signature algorithm.
+
+static void P2MRDilithiumInput(benchmark::Bench& bench)
+{
+    ECC_Start();
+
+    CDilithiumKey key;
+    const bool made{key.MakeNewKey()};
+    assert(made);
+    const CDilithiumPubKey pubkey{key.GetPubKey()};
+
+    // Single-leaf P2MR tree: <pubkey> OP_CHECKSIGDILITHIUM.
+    const CScript leaf_script{CScript() << ToByteVector(pubkey) << OP_CHECKSIGDILITHIUM};
+    const std::vector<unsigned char> leaf_bytes{leaf_script.begin(), leaf_script.end()};
+
+    P2MRBuilder builder;
+    builder.Add(/*depth=*/0, leaf_bytes, TAPROOT_LEAF_TAPSCRIPT);
+    builder.Finalize();
+    assert(builder.IsComplete());
+    const WitnessV2P2MR output{builder.GetOutput()};
+    const P2MRSpendData spenddata{builder.GetSpendData()};
+
+    const CScript script_pubkey{GetScriptForDestination(output)};
+    const CAmount amount{1};
+
+    const CMutableTransaction tx_credit{BuildCreditingTransaction(script_pubkey, amount)};
+    CMutableTransaction tx_spend{BuildSpendingTransaction(CScript(), CScriptWitness(), CTransaction(tx_credit))};
+
+    const auto script_it{spenddata.scripts.find({leaf_bytes, TAPROOT_LEAF_TAPSCRIPT})};
+    assert(script_it != spenddata.scripts.end());
+    assert(!script_it->second.empty());
+    const std::vector<unsigned char> control{*script_it->second.begin()};
+
+    PrecomputedTransactionData txdata;
+    // force=true: Init otherwise decides which precomputations to build by
+    // inspecting the witness, which is not populated until the signature below
+    // exists -- and the signature needs the sighash this cache feeds.
+    txdata.Init(tx_spend, {CTxOut{tx_credit.vout[0]}}, /*force=*/true);
+
+    ScriptExecutionData execdata;
+    execdata.m_tapleaf_hash_init = true;
+    execdata.m_tapleaf_hash = ComputeTapleafHash(TAPROOT_LEAF_TAPSCRIPT, leaf_bytes);
+    execdata.m_codeseparator_pos_init = true;
+    execdata.m_codeseparator_pos = 0xFFFFFFFF;
+    execdata.m_annex_init = true;
+    execdata.m_annex_present = false;
+
+    uint256 sighash;
+    const bool hashed{SignatureHashSchnorr(sighash, execdata, tx_spend, 0, SIGHASH_ALL,
+                                           SigVersion::P2MR_TAPSCRIPT, txdata,
+                                           MissingDataBehavior::ASSERT_FAIL)};
+    assert(hashed);
+
+    std::vector<unsigned char> sig;
+    const bool signed_ok{key.Sign(sighash, sig)};
+    assert(signed_ok);
+    sig.push_back(static_cast<unsigned char>(SIGHASH_ALL));
+
+    // P2MR witness: [args...] [script] [control block]
+    CScriptWitness& witness{tx_spend.vin[0].scriptWitness};
+    witness.stack.clear();
+    witness.stack.push_back(sig);
+    witness.stack.push_back(leaf_bytes);
+    witness.stack.push_back(control);
+
+    const CTransaction ctx{tx_spend};
+    const uint32_t flags{STANDARD_SCRIPT_VERIFY_FLAGS | SCRIPT_VERIFY_DILITHIUM | SCRIPT_VERIFY_P2MR};
+
+    // Same guard as the primitive benchmarks: a spend that fails to verify can
+    // bail out long before the Dilithium check and would time a rejection path.
+    {
+        ScriptError err{SCRIPT_ERR_OK};
+        const bool ok{VerifyScript(CScript(), script_pubkey, &ctx.vin[0].scriptWitness, flags,
+                                   TransactionSignatureChecker(&ctx, 0, amount, txdata,
+                                                               MissingDataBehavior::ASSERT_FAIL),
+                                   &err)};
+        assert(err == SCRIPT_ERR_OK);
+        assert(ok);
+    }
+
+    bench.run([&] {
+        ScriptError err{SCRIPT_ERR_OK};
+        const bool ok{VerifyScript(CScript(), script_pubkey, &ctx.vin[0].scriptWitness, flags,
+                                   TransactionSignatureChecker(&ctx, 0, amount, txdata,
+                                                               MissingDataBehavior::ASSERT_FAIL),
+                                   &err)};
+        assert(ok);
+    });
+
+    ECC_Stop();
+}
+
+static void P2WPKHECDSAInput(benchmark::Bench& bench)
+{
+    ECC_Start();
+
+    CKey key;
+    key.MakeNewKey(/*fCompressedIn=*/true);
+    assert(key.IsValid());
+    const CPubKey pubkey{key.GetPubKey()};
+
+    uint160 pubkey_hash;
+    CHash160().Write(pubkey).Finalize(pubkey_hash);
+
+    const CScript script_pubkey{CScript() << OP_0 << ToByteVector(pubkey_hash)};
+    const CScript exec_script{CScript() << OP_DUP << OP_HASH160 << ToByteVector(pubkey_hash)
+                                        << OP_EQUALVERIFY << OP_CHECKSIG};
+    const CAmount amount{1};
+
+    const CMutableTransaction tx_credit{BuildCreditingTransaction(script_pubkey, amount)};
+    CMutableTransaction tx_spend{BuildSpendingTransaction(CScript(), CScriptWitness(), CTransaction(tx_credit))};
+
+    PrecomputedTransactionData txdata;
+    // force=true: Init otherwise decides which precomputations to build by
+    // inspecting the witness, which is not populated until the signature below
+    // exists -- and the signature needs the sighash this cache feeds.
+    txdata.Init(tx_spend, {CTxOut{tx_credit.vout[0]}}, /*force=*/true);
+
+    std::vector<unsigned char> sig;
+    const bool signed_ok{key.Sign(SignatureHash(exec_script, tx_spend, 0, SIGHASH_ALL, amount,
+                                                SigVersion::WITNESS_V0),
+                                  sig)};
+    assert(signed_ok);
+    sig.push_back(static_cast<unsigned char>(SIGHASH_ALL));
+
+    CScriptWitness& witness{tx_spend.vin[0].scriptWitness};
+    witness.stack.clear();
+    witness.stack.push_back(sig);
+    witness.stack.push_back(ToByteVector(pubkey));
+
+    const CTransaction ctx{tx_spend};
+    const uint32_t flags{STANDARD_SCRIPT_VERIFY_FLAGS | SCRIPT_VERIFY_DILITHIUM | SCRIPT_VERIFY_P2MR};
+
+    {
+        ScriptError err{SCRIPT_ERR_OK};
+        const bool ok{VerifyScript(CScript(), script_pubkey, &ctx.vin[0].scriptWitness, flags,
+                                   TransactionSignatureChecker(&ctx, 0, amount, txdata,
+                                                               MissingDataBehavior::ASSERT_FAIL),
+                                   &err)};
+        assert(err == SCRIPT_ERR_OK);
+        assert(ok);
+    }
+
+    bench.run([&] {
+        ScriptError err{SCRIPT_ERR_OK};
+        const bool ok{VerifyScript(CScript(), script_pubkey, &ctx.vin[0].scriptWitness, flags,
+                                   TransactionSignatureChecker(&ctx, 0, amount, txdata,
+                                                               MissingDataBehavior::ASSERT_FAIL),
+                                   &err)};
+        assert(ok);
+    });
+
+    ECC_Stop();
+}
+
 BENCHMARK(DilithiumVerify, benchmark::PriorityLevel::HIGH);
 BENCHMARK(ECDSAVerify, benchmark::PriorityLevel::HIGH);
+BENCHMARK(P2MRDilithiumInput, benchmark::PriorityLevel::HIGH);
+BENCHMARK(P2WPKHECDSAInput, benchmark::PriorityLevel::HIGH);

--- a/src/bench/dilithium_verify.cpp
+++ b/src/bench/dilithium_verify.cpp
@@ -1,0 +1,87 @@
+// Copyright (c) 2026 The BTQ Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <bench/bench.h>
+#include <crypto/dilithium_key.h>
+#include <key.h>
+#include <pubkey.h>
+#include <uint256.h>
+
+#include <cassert>
+#include <vector>
+
+// Signature verification cost, Dilithium against ECDSA, measured on the same
+// hardware over the same input.
+//
+// This exists because two consensus constants encode a ratio between the two
+// that has never been measured. DILITHIUM_SIGOP_COST (src/script/script.h)
+// charges a Dilithium check 50 sigops, asserting that one Dilithium
+// verification costs about fifty ECDSA verifications. The reasoning recorded
+// when that was chosen cited a figure closer to 10. Both cannot be right, and
+// the constant bounds how many post-quantum signatures a block can carry:
+// MAX_BLOCK_SIGOPS_COST / WITNESS_SCALE_FACTOR legacy sigops, divided by
+// whatever a Dilithium op is charged.
+//
+// Run both and divide the reported ns/op:
+//
+//     ./src/bench/bench_btq -filter='(Dilithium|ECDSA)Verify'
+//
+// The ratio is what DILITHIUM_SIGOP_COST should approximate. Verification is
+// the operation to measure rather than signing, because validation cost is what
+// the sigop budget exists to bound -- every node verifies every signature in
+// every block, while signing happens once on the spending wallet.
+//
+// Both benchmarks verify a *valid* signature and assert as much. An invalid one
+// can be rejected early on a size or format check without the verification
+// maths ever running, which would time a rejection path and understate the true
+// cost by an arbitrary margin.
+
+static void DilithiumVerify(benchmark::Bench& bench)
+{
+    CDilithiumKey key;
+    const bool made{key.MakeNewKey()};
+    assert(made);
+
+    const CDilithiumPubKey pubkey{key.GetPubKey()};
+    const uint256 hash{uint256S("0x1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f708192a3b4c5d6e7f809")};
+
+    std::vector<unsigned char> vchSig;
+    const bool signed_ok{key.Sign(hash, vchSig)};
+    assert(signed_ok);
+    // Guard against timing a rejection path rather than a verification.
+    assert(pubkey.Verify(hash, vchSig));
+
+    bench.run([&] {
+        const bool ok{pubkey.Verify(hash, vchSig)};
+        assert(ok);
+    });
+}
+
+static void ECDSAVerify(benchmark::Bench& bench)
+{
+    ECC_Start();
+
+    CKey key;
+    key.MakeNewKey(/*fCompressedIn=*/true);
+    assert(key.IsValid());
+
+    const CPubKey pubkey{key.GetPubKey()};
+    const uint256 hash{uint256S("0x1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f708192a3b4c5d6e7f809")};
+
+    std::vector<unsigned char> vchSig;
+    const bool signed_ok{key.Sign(hash, vchSig)};
+    assert(signed_ok);
+    // Same guard as above.
+    assert(pubkey.Verify(hash, vchSig));
+
+    bench.run([&] {
+        const bool ok{pubkey.Verify(hash, vchSig)};
+        assert(ok);
+    });
+
+    ECC_Stop();
+}
+
+BENCHMARK(DilithiumVerify, benchmark::PriorityLevel::HIGH);
+BENCHMARK(ECDSAVerify, benchmark::PriorityLevel::HIGH);


### PR DESCRIPTION
## Summary

`DILITHIUM_SIGOP_COST = 50` (`src/script/script.h:68`) asserts that a Dilithium signature check costs about fifty ECDSA checks. BTQ-82's recorded reasoning cited a figure closer to 10. Neither was measured, and no benchmark existed that could settle it.

That constant is load-bearing. Witness sigops reach the block budget through `CountWitnessSigOps`, and for P2MR `WitnessSigOps` extracts the tapscript and calls `GetSigOpCount(true)`, charging every `OP_CHECKSIGDILITHIUM` at `DILITHIUM_SIGOP_COST`. `ConnectBlock` enforces the total against `MAX_BLOCK_SIGOPS_COST`. **It sets the ceiling on post-quantum signatures per block directly: 80000/50 = 1600.**

This adds the missing benchmark. **It does not propose changing the constant** — see the analysis below, which is the opposite of what I expected to write.

## What is measured

Four benchmarks. Two for the signature primitives, two for whole-input verification through `VerifyScript` — because the primitive is not the unit the rule charges. What a node pays per charged sigop is a complete input: witness parsing, control-block and Merkle-path checking, sighash computation, script execution, and only then the signature check.

| | ns/op | ratio |
|---|---|---|
| `DilithiumVerify` (primitive) | 133,273 | — |
| `ECDSAVerify` (primitive) | 44,523 | 2.99× |
| `P2MRDilithiumInput` | 141,838–146,412 | — |
| `P2WPKHECDSAInput` | 46,160–47,076 | **3.11×** |

Both input benchmarks use the same crediting/spending helpers and the same `VerifyScript` entry point, differing only in output type and algorithm.

Overhead is not symmetric, which surprised me: P2MR adds ~10,800 ns per input for control-block and Merkle-path work where P2WPKH adds ~2,550 ns, so moving to the correct unit *raises* the ratio slightly rather than diluting it.

## Why this does not mean "lower the constant to 3"

A measured cost ratio of ~3 against a constant of 50 looks like a 16x over-charge. Taken alone it is. But the sigop budget does not exist to price CPU — it exists to bound **worst-case block validation time relative to the block interval**, and BTQ's interval is 60 seconds against Bitcoin's 600.

Worst-case signature verification per block, at the measured input cost:

| `DILITHIUM_SIGOP_COST` | Dilithium sigs/block | worst-case verify | % of 60 s interval |
|---|---|---|---|
| **50 (current)** | 1,600 | 0.23 s | 0.38% |
| 25 | 3,200 | 0.45 s | 0.76% |
| 13 | 6,153 | 0.87 s | 1.45% |
| 10 | 8,000 | 1.13 s | 1.89% |
| 3 (measured ratio) | 26,666 | 3.78 s | 6.30% |
| 1 | 80,000 | 11.35 s | 18.91% |

Bitcoin's own budget on the same measurement basis: 20,000 ECDSA checks × 46.7 µs = **0.93 s worst case, 0.156% of a 600 s interval**.

So:

- the BTQ constant giving the **same absolute** worst-case verification time as Bitcoin is **≈12**
- the BTQ constant giving the **same proportion of block interval** as Bitcoin is **≈121**

`50` sits between those two, and is already **2.4× less conservative than Bitcoin proportionally** while remaining 4× more conservative in absolute terms. It is a defensible number. The measurement's value is that it is now a *justified* number rather than an arbitrary one.

Dropping to 3 would put worst-case verification at 6.3% of the block interval — roughly **40× less conservative than Bitcoin** — which is not a trade a 60-second chain should make for throughput.

## Worst case if the ratio is wrong

The measurement could understate Dilithium's relative cost in at least five ways, and they stack:

1. **Batch ECDSA verification.** libsecp256k1 supports it; the Dilithium path does not appear to. If batching is ever adopted, per-signature ECDSA cost falls and the ratio rises to perhaps 6–9×.
2. **Weaker hardware.** Dilithium verification is NTT- and memory-bandwidth-heavy; ECDSA is arithmetic-heavy. On a small-cache ARM node the ratio can be materially worse than on this x86 machine. This matters for whoever can afford to run a full node.
3. **Dilithium5.** The constants for it are already in `dilithium_key.h` (pubkey 2592, sig 4627). Raising the parameter set roughly doubles verification cost.
4. **Multisig amplification.** `OP_CHECKMULTISIGDILITHIUM` charges `keys * DILITHIUM_SIGOP_COST`; at 20 keys any error in the per-key model is amplified twentyfold.
5. **Adversarial inputs.** These benchmarks verify well-formed signatures. Worst-case malformed-but-parseable inputs were not explored.

If the constant were set to 3 and the effective worst case turned out ~10× the measured ratio through some combination of the above, block verification would consume tens of seconds of a 60-second interval. The failure mode is not slowness — it is **fast validators staying on the tip while slow ones fall behind**, raising orphan rates and risking a split along hardware lines. That is the worst class of failure a chain has.

The error is asymmetric in cost, too: raising the constant later is a tightening (soft fork, deployable but under duress), while lowering it is a loosening (hard fork). **Both are cheap now and expensive after mainnet**, which is the argument for settling it deliberately before launch rather than shipping an unexamined number.

## Recommendation

Keep `DILITHIUM_SIGOP_COST = 50`, and record *why* — it now has a derivation instead of an assumption. If throughput pressure justifies revisiting, **25 is the floor I would defend** (0.76% of interval, still under half of Bitcoin's proportional budget once the 10× faster blocks are accounted for). The measured 3× is a CPU floor, not a target.

The decision remains BTQ-82 and BTQ-118 owners'. The margin between 3 and 50 is a risk judgement, not a measurement, and this PR deliberately does not make it.

## Notes

- Measured against `crypto/dilithium/ref`. An `avx2` implementation ships in-tree and is never compiled — worth its own look, independent of this constant, if Dilithium verification is on the validation hot path.
- All four benchmarks verify a *valid* signature and assert success. An invalid one can be rejected on a size or format check before the verification maths runs, which would time a rejection path.
- On noise: one run came in 71% slower in absolute terms than another on this frequency-scaled `powersave` machine. The ratio moved 4.5% across that spread. Absolute timings here should not be quoted; the ratio is sound because both sides are measured in the same process under identical conditions.

## Test plan

- [x] `bench_btq -filter='(Dilithium|ECDSA)Verify'` — primitives, 4 runs, ratio 2.99–3.05
- [x] `bench_btq -filter='(P2MRDilithium|P2WPKHECDSA)Input'` — inputs, 4 runs, ratio 3.03–3.17
- [x] ECDSA figure cross-checked against the pre-existing `VerifyScriptBench` (89,039 ns for a full P2WPKH verify vs 44,523 ns bare) — the right order
- [x] `assert()` confirmed live in this build (no `-DNDEBUG` on the compile line), so the valid-signature guards are real
- [x] P2MR spend verified end-to-end through `VerifyScript` with `SCRIPT_ERR_OK` before timing
