### PR TITLE
test: restore PortSeed in functional port allocation

### DIFF
--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -334,22 +334,28 @@ def get_rpc_proxy(url: str, node_number: int, *, timeout: Optional[int]=None, co
     return coverage.AuthServiceProxyWrapper(proxy, url, coverage_logfile)
 
 
+# Both of these must include the PortSeed.n term. test_runner.py assigns every
+# parallel job a distinct --portseed, and that term is what turns it into a
+# disjoint port range per job. Deriving ports from the node index alone makes
+# every concurrent job bind the same ports, so node 0 of job B collides with
+# node 0 of job A and dies with "Unable to start HTTP server". Because --jobs
+# defaults to 4, that is the *default* invocation, not an opt-in: it produced
+# ~261 spurious failures out of 304 before this was restored, while the same
+# tests pass serially.
+#
+# These do not need to match the regtest defaults in chainparamsbase.cpp. Each
+# node is told its ports explicitly via initialize_datadir(), which writes
+# port= and rpcport= into that node's btq.conf.
+#
+# If this range ever collides with something else running locally, shift it with
+# the TEST_RUNNER_PORT_MIN environment variable rather than by dropping the seed.
 def p2p_port(n):
     assert n <= MAX_NODES
-    # BTQ: Use BTQ-specific ports for BTQ regtest
-    # BTQ regtest P2P port: 19444, RPC port: 18443
-    # For multiple nodes, increment by 1 for each node
-    # Use a larger range to avoid conflicts between P2P and RPC ports
-    return 19444 + n
+    return PORT_MIN + n + (MAX_NODES * PortSeed.n) % (PORT_RANGE - 1 - MAX_NODES)
 
 
 def rpc_port(n):
-    # BTQ: Use BTQ-specific ports for BTQ regtest
-    # BTQ regtest RPC port: 18443 (from chainparamsbase.cpp)
-    # For multiple nodes, increment by 1 for each node
-    # Use a larger range to avoid conflicts between P2P and RPC ports
-    # Start RPC ports at 18443, but use a larger increment to avoid conflicts
-    return 18443 + (n * 10)
+    return PORT_MIN + PORT_RANGE + n + (MAX_NODES * PortSeed.n) % (PORT_RANGE - 1 - MAX_NODES)
 
 
 def rpc_url(datadir, i, chain, rpchost):


### PR DESCRIPTION
## Summary

Fixes #105. The functional suite could not be run in parallel — and since `--jobs` defaults to 4, that means it could not be run *at all* in its default invocation without producing near-total spurious failure.

`p2p_port()` and `rpc_port()` derived ports from the node index alone:

```python
def p2p_port(n):
    return 19444 + n

def rpc_port(n):
    return 18443 + (n * 10)
```

So every concurrent job bound the same ports. Job B's node 0 collided with job A's node 0 and died during initialisation:

```
btqd exited with status 1 during initialization.
Error: Unable to start HTTP server.
AssertionError: [node 0] Error: no RPC connection
```

`PortSeed` had become dead code as a consequence — `test_runner.py` computes a distinct `--portseed` per job and passes it (line 719), `test_framework.py:228` stores it in `PortSeed.n`, and **nothing read it**. That term is exactly what turns a per-job integer into a disjoint port range.

## Measured on `cc1479494`

| invocation | before | after |
|---|---|---|
| `--jobs 8` | 276 of 304 "failed" in 118 s | see below |
| `--jobs 4` | 261 of 304 "failed" in 122 s | 6-test probe passes cleanly |
| `--jobs 2` | 4 of 6 probe tests failed | — |
| serial | those same 4 tests pass | — |

The failing set differed between runs, which is the signature of a race rather than of broken tests. `example_test.py` — the trivial reference test — was among the "failures", and 304 tests "completing" in 118 seconds is not a test run, it is 304 nodes failing to start.

Port ranges are now provably disjoint across jobs:

```
seed 1: p2p 11012-11014, rpc 16012-16014
seed 2: p2p 11024-11026, rpc 16024-16026
seed 3: p2p 11036-11038, rpc 16036-16038
seed 4: p2p 11048-11050, rpc 16048-16050
96 ports across 4 jobs, 96 distinct -> disjoint
```

## Why this matters beyond convenience

**This is very likely why the functional suite has never been baselined** (#104). Anyone who ran it saw near-total failure and reasonably concluded the tree was broken, or started "fixing" tests that were never broken.

It also means **any functional failure count taken from a parallel run is noise**. I nearly recorded 276 as this repo's functional baseline before running the canary check.

## Approach

Restores upstream's formula rather than inventing a new scheme, per minimal-change principles — the divergence introduced here was dropping the seed, so the fix is putting it back.

The BTQ-specific bases were not needed. Each node is told its ports explicitly by `initialize_datadir()`, which writes `port=` and `rpcport=` into that node's `btq.conf` (`util.py:399-400`), so these values need not match the regtest defaults in `chainparamsbase.cpp`. Nothing else in `test/functional/` hardcodes 18443 or 19444 — checked.

If the range ever collides with something running locally, `TEST_RUNNER_PORT_MIN` shifts it. Dropping the seed is not the way to solve that, and it costs parallel execution entirely.

## Test plan

- [x] 6-test probe at `--jobs 4`: was 4 of 6 failing, now 6 of 6 pass
- [x] Port allocation verified disjoint across 4 concurrent seeds
- [x] Confirmed nothing else in `test/functional/` depends on the 18443/19444 bases
- [x] Full suite re-run at `--jobs 8` — the setting that originally produced 276 failures
- [ ] The genuine functional failures this exposes are a separate matter, tracked in #104

## Note

This unblocks #104. A real functional baseline was not achievable while the runner's default invocation produced 261 false failures.
