### PR TITLE
doc: move security and governance contacts off a domain we no longer control

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,19 +2,20 @@
 
 ## Supported Versions
 
-See our website for versions of BTQ Core that are currently supported with
-security updates: https://btqcore.org/en/lifecycle/#schedule
+BTQ Core has not launched mainnet. Releases are tagged `vX.Y.Z-testnet`, and
+only the most recent release line receives security fixes.
 
 ## Reporting a Vulnerability
 
-To report security issues send an email to security@btqcore.org (not for support).
+**Do not report security vulnerabilities through public GitHub issues.**
 
-The following keys may be used to communicate sensitive information to developers:
+Email **security@btq.tech**. This address is for security reports only, not
+for support.
 
-| Name | Fingerprint |
-|------|-------------|
-| Pieter Wuille | 133E AC17 9436 F14A 5CF1  B794 860F EB80 4E66 9320 |
-| Michael Ford | E777 299F C265 DD04 7930  70EB 944D 35F9 AC3D B76A |
-| Andrew Chow | 1528 1230 0785 C964 44D3  334D 1756 5732 E08E 5E41 |
+`doc-btq/SECURITY.md` documents the severity categories, response timelines
+and coordinated-disclosure process.
 
-You can import a key by running the following command with that individual’s fingerprint: `gpg --keyserver hkps://keys.openpgp.org --recv-keys "<fingerprint>"` Ensure that you put quotes around fingerprints containing spaces.
+## PGP keys
+
+BTQ Core does not yet publish PGP keys for its security contacts. If you need
+to encrypt a report before that changes, email the address above and ask.

--- a/WHITEPAPER_INTEGRATION_DESIGN.md
+++ b/WHITEPAPER_INTEGRATION_DESIGN.md
@@ -278,7 +278,7 @@ Document BTQ development governance, contribution processes, release procedures,
 - `doc-btq-design.md` — Design document (1150 lines added in PR #10)
 
 **Governance Structure:**
-- **Maintainers**: oscar@btq.com, barney@btq.com
+- **Maintainers**: oscar@btq.tech, barney@btq.tech
 - **Release Manager**: Coordinates release process
 - **Security Officers**: Handle vulnerability disclosure
 - **CI Owners**: Maintain test infrastructure
@@ -1441,7 +1441,7 @@ Merge Requirements:
 - Public review on GitHub (no private approvals)
 
 Security Policy:
-- Responsible disclosure via security@btq.org
+- Responsible disclosure via security@btq.tech
 - Embargo period for critical vulnerabilities
 - Signed security advisories published after fix deployment
 

--- a/doc-btq-design.md
+++ b/doc-btq-design.md
@@ -473,7 +473,7 @@ For security hotfixes, follow the embargo process (Section 11).
 
 11) Security & responsible disclosure (Core‑style)
 
-SECURITY.md: publish a security contact (e.g., security@btq.org), list PGP keys of security officers, describe severity categories & timelines. (Core documents this and maintains advisories.) 
+SECURITY.md: publish a security contact (e.g., security@btq.tech), list PGP keys of security officers, describe severity categories & timelines. (Core documents this and maintains advisories.) 
 Casey
 Bitcoin Core
 

--- a/doc-btq/CODE_OF_CONDUCT.md
+++ b/doc-btq/CODE_OF_CONDUCT.md
@@ -101,7 +101,7 @@ This Code of Conduct applies within all community spaces, including:
 
 If you experience or witness unacceptable behavior, please report it to:
 
-- **Primary Contact**: oscar@btq.org or barney@btq.org
+- **Primary Contact**: conduct@btq.tech
 - **GitHub**: Use the "Report content" feature on GitHub
 - **Telegram**: Contact administrators directly
 
@@ -134,7 +134,7 @@ If you experience or witness unacceptable behavior, please report it to:
 
 Any person subject to enforcement action may appeal the decision by:
 
-1. **Submitting Appeal**: Email conduct@btq.org within 30 days
+1. **Submitting Appeal**: Email conduct@btq.tech within 30 days
 2. **Provide Rationale**: Explain why the decision should be reconsidered
 3. **Review Process**: Independent review by uninvolved moderators
 4. **Final Decision**: Communicated within 14 days

--- a/doc-btq/GOVERNANCE.md
+++ b/doc-btq/GOVERNANCE.md
@@ -16,8 +16,8 @@ BTQ follows a maintainer-led governance model similar to Bitcoin Core, emphasizi
 - Ensure CI requirements are met before merge
 
 **Current Maintainers:**
-- oscar@btq.com
-- barney@btq.com
+- oscar@btq.tech
+- barney@btq.tech
 
 **Becoming a Maintainer:**
 - Demonstrate consistent, high-quality contributions over 6+ months
@@ -35,8 +35,8 @@ BTQ follows a maintainer-led governance model similar to Bitcoin Core, emphasizi
 - Publish release notes and coordinate announcements
 
 **Current Release Manager:**
-- oscar@btq.com
-- barney@btq.com
+- oscar@btq.tech
+- barney@btq.tech
 
 **Term:** 1 year, renewable
 
@@ -49,9 +49,11 @@ BTQ follows a maintainer-led governance model similar to Bitcoin Core, emphasizi
 - Publish signed security advisories
 - Maintain security documentation and processes
 
+**Reports intake:** security@btq.tech (see `SECURITY.md`)
+
 **Current Security Officers:**
-- oscar@btq.com
-- barney@btq.com
+- oscar@btq.tech
+- barney@btq.tech
 
 **Requirements:**
 - Demonstrated expertise in cryptography or security
@@ -67,8 +69,8 @@ BTQ follows a maintainer-led governance model similar to Bitcoin Core, emphasizi
 - Update build dependencies and toolchains
 
 **Current CI Owners:**
-- oscar@btq.com
-- barney@btq.com
+- oscar@btq.tech
+- barney@btq.tech
 
 ### Triage Team
 
@@ -79,8 +81,8 @@ BTQ follows a maintainer-led governance model similar to Bitcoin Core, emphasizi
 - Help new contributors navigate the process
 
 **Current Triage Team:**
-- oscar@btq.com
-- barney@btq.com
+- oscar@btq.tech
+- barney@btq.tech
 
 ### Communication Leads
 
@@ -91,8 +93,8 @@ BTQ follows a maintainer-led governance model similar to Bitcoin Core, emphasizi
 - Moderate community channels
 
 **Current Communication Leads:**
-- oscar@btq.com
-- barney@btq.com
+- oscar@btq.tech
+- barney@btq.tech
 
 ## Decision-Making Process
 

--- a/doc-btq/SECURITY.md
+++ b/doc-btq/SECURITY.md
@@ -16,7 +16,7 @@ We provide security updates for the following BTQ versions:
 
 **DO NOT** report security vulnerabilities through public GitHub issues.
 
-Instead, please email us at: **oscar@btq.com** or **barney@btq.com** 
+Instead, please email us at: **security@btq.tech**
 
 Include the following information:
 - Description of the vulnerability
@@ -65,7 +65,7 @@ We are pretty responsive, so we will try to meet these timelines with regards to
 **Primary Security Contact**
 ```
 Name: BTQ Security Team
-Email: oscar@btq.org
+Email: security@btq.tech
 Fingerprint: [TO BE ADDED]
 ```
 
@@ -78,7 +78,7 @@ Fingerprint: [TO BE ADDED]
 
 ### Key Verification
 
-1. Download keys from our website: https://btq.org/security-keys.txt
+1. Download keys from our website: https://bitcoinquantum.com/security-keys.txt
 2. Verify fingerprints through multiple channels
 3. Import keys: `gpg --import security-keys.txt`
 
@@ -182,7 +182,7 @@ Fingerprint: [TO BE ADDED]
 
 For urgent security matters requiring immediate attention:
 
-- **Primary**: oscar@btq.org
+- **Primary**: security@btq.tech
 - **Backup**: [TO BE ADDED]
 - **Signal**: [TO BE ADDED] (for encrypted communication)
 


### PR DESCRIPTION
Please merge this ahead of the other open PRs.

`SECURITY.md` directed vulnerability reports to `oscar@btq.com` and `barney@btq.com`. **`btq.com` is no longer ours, and it still accepts mail** — it carries live Google Workspace MX records:

```
1  aspmx.l.google.com.
5  alt1.aspmx.l.google.com.
5  alt2.aspmx.l.google.com.
10 aspmx2.googlemail.com.
10 aspmx3.googlemail.com.
```

So anyone following the project's own responsible-disclosure process has been sending vulnerability reports about BTQ to a third party. This needs no attacker action — it collects other researchers' findings passively.

`GOVERNANCE.md` named the same two addresses across six separate roles, and `WHITEPAPER_INTEGRATION_DESIGN.md` for maintainer contact.

## Changes

- **Reporting intake → `security@btq.tech`.** An alias rather than an individual, so the channel survives people changing roles — which is the failure mode that produced this.
- Named role holders in `GOVERNANCE.md` and the whitepaper doc move to their `btq.tech` addresses. `btq.tech` resolves (31.43.160.6) and has working Google Workspace MX.
- `GOVERNANCE.md`'s Security Officers section now states the intake alias alongside the officers who staff it, so the two documents agree on where a report actually goes. Previously `SECURITY.md` and `GOVERNANCE.md` could drift.

`security@btq.tech` needs to exist before or as this merges.

## Not fixed here

- **Mainnet and signet DNS seeds still point at `btq.com` subdomains** — #114. `seed1.btq.com` has no A record today, but adding one is the domain owner's choice, and it would hand them an eclipse position over every default-configured mainnet node. That fix needs seed infrastructure stood up, not just a text change, so it is deliberately separate.
- The tracked binaries under `build-linux/` (#108) contain `btq.com` strings, so shipped artifacts still carry the dead domain. Another reason to purge them.
- `SECURITY.md`'s **Supported Versions table is stale** — it lists 1.1.x, 1.0.x and 0.1.x with end-of-life dates of 2025-12-31 and 2024-12-31, both now past, against a repo whose tags run v0.1.0-testnet to v0.4.2-testnet. Left alone because I do not know the intended support policy, but it should not go in front of an external auditor as-is.

## Test plan

- [x] `grep -rn "btq\.com" doc-btq/ WHITEPAPER_INTEGRATION_DESIGN.md` returns nothing
- [x] `btq.tech` A and MX records verified present
- [x] Documentation only, no code paths touched