### PR TITLE
doc: annotate two unreachable code paths and list dilithium_p2mr in help

### DIFF
--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -16,7 +16,7 @@ void SetupChainParamsBaseOptions(ArgsManager& argsman)
     argsman.AddArg("-chain=<chain>", "Use the chain <chain> (default: main). Allowed values: main, test, signet, regtest", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
     argsman.AddArg("-regtest", "Enter regression test mode, which uses a special chain in which blocks can be solved instantly. "
                  "This is intended for regression testing tools and app development. Equivalent to -chain=regtest.", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
-    argsman.AddArg("-testactivationheight=name@height.", "Set the activation height of 'name' (segwit, bip34, dersig, cltv, csv, lwma, dilithium). (regtest-only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::DEBUG_TEST);
+    argsman.AddArg("-testactivationheight=name@height.", "Set the activation height of 'name' (segwit, bip34, dersig, cltv, csv, lwma, dilithium, dilithium_p2mr). (regtest-only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::DEBUG_TEST);
     argsman.AddArg("-testnet", "Use the test chain. Equivalent to -chain=test.", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
     argsman.AddArg("-vbparams=deployment:start:end[:min_activation_height]", "Use given start/end times and min_activation_height for specified version bits deployment (regtest-only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
     argsman.AddArg("-signet", "Use the signet chain. Equivalent to -chain=signet. Note that the network is defined by the -signetchallenge parameter", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -23,8 +23,8 @@ namespace Consensus {
 enum class SignatureAlgorithm {
     NONE,      // No specific algorithm enforced (legacy mode)
     DILITHIUM, // CRYSTALS-Dilithium post-quantum signature scheme
-    FALCON,    // Falcon post-quantum signature scheme  
-    SPHINCS    // SPHINCS+ post-quantum signature scheme
+    FALCON,    // Falcon post-quantum signature scheme (reserved, not implemented)
+    SPHINCS    // SPHINCS+ post-quantum signature scheme (reserved, not implemented)
 };
 
 /**
@@ -89,9 +89,16 @@ struct BIP9Deployment {
 struct Params {
     uint256 hashGenesisBlock;
     int nSubsidyHalvingInterval;
-    /** 
-     * Defines which post-quantum signature algorithm is enforced for transactions.
-     * Set to NONE initially to maintain compatibility while transitioning to PQ signatures.
+    /**
+     * Reserved. Never read.
+     *
+     * Every network sets this to NONE (kernel/chainparams.cpp) and nothing
+     * consumes it, so changing it has no effect on validation. No Falcon or
+     * SPHINCS+ implementation exists in the tree either -- the enum values are
+     * the only occurrences outside vendored directories.
+     *
+     * Dilithium is selected by script opcode and activation height
+     * (nDilithiumHeight / nDilithiumP2MRHeight), not by this field. See #116.
      */
     SignatureAlgorithm signature_algorithm{SignatureAlgorithm::NONE};
     /**

--- a/src/script/solver.h
+++ b/src/script/solver.h
@@ -35,6 +35,14 @@ enum class TxoutType {
     // Dilithium transaction types:
     DILITHIUM_PUBKEY,
     DILITHIUM_PUBKEYHASH,
+    //! Never produced by Solver(). A Dilithium script-hash output compiles to
+    //! OP_HASH160 <20> OP_EQUAL, which is byte-identical to P2SH, so
+    //! IsPayToScriptHash() matches first and SCRIPTHASH is returned instead
+    //! (solver.cpp, "it is always OP_HASH160 20 [20 byte hash] OP_EQUAL").
+    //! Unlike DILITHIUM_PUBKEYHASH there is no distinguishing opcode to key
+    //! off, because P2SH commits only to a hash. Consumers of this value in
+    //! policy.cpp, sign.cpp, descriptor.cpp and scriptpubkeyman.cpp are
+    //! therefore unreachable. See issue #112.
     DILITHIUM_SCRIPTHASH,
     DILITHIUM_MULTISIG,
     DILITHIUM_WITNESS_V0_KEYHASH,


### PR DESCRIPTION
Three small corrections taken off @BarneyChambers's queue. **No behaviour change** — one string literal and two comment blocks. Grouped into one PR because they are a single review context.

## `-testactivationheight` omits `dilithium_p2mr` — closes #109

`deploymentinfo.cpp:62` accepts `dilithium_p2mr`; the help string did not list it. So the one BTQ deployment whose height differs per network (1 on mainnet/signet/regtest, `INT_MAX` on testnet) was the one you could not discover from `-help`.

`argsman_tests/testactivationheight_help_lists_lwma` only asserts the presence of `-testactivationheight=name@height`, so this does not disturb it — checked before changing.

## `TxoutType::DILITHIUM_SCRIPTHASH` is never produced — #112

A Dilithium script-hash output compiles to `OP_HASH160 <20> OP_EQUAL`, **byte-identical to P2SH**, so `IsPayToScriptHash()` matches first and `Solver()` returns `SCRIPTHASH`. Unlike `DILITHIUM_PUBKEYHASH` there is no trailing opcode to key off, because P2SH commits only to a hash — the asymmetry is inherent, not an oversight.

Its consumers in `policy.cpp`, `sign.cpp`, `descriptor.cpp` and `scriptpubkeyman.cpp` are consequently dead. Harmless — the P2MR-only cutover made those paths deliberately unspendable anyway — but a reviewer tracing the standardness branch in `policy.cpp:91` has no way to know that without deriving reachability themselves.

## `signature_algorithm` is never read — #116

Every network sets it to `NONE`, nothing consumes it, and neither Falcon nor SPHINCS+ is implemented — the enum values are their only occurrences outside vendored directories. Dilithium is selected by script opcode and activation height, not by this field.

The comment went **on the field** rather than on the enum, since the field is what misleads. The enum values got a short `(reserved, not implemented)` marker.

## Why now

An external audit starts shortly. Dead code that reads as reachable consensus logic is billable time spent proving a negative, and an auditor who trips over one of these starts checking the others — correctly, and expensively.

Both issues offer removal as an alternative. This takes the minimal option each records: annotate now, decide on removal later, since neither warrants touching a consensus header immediately before an audit.

## Test plan

- [x] `g++ -fsyntax-only -std=c++20` clean on both modified headers
- [x] Verified `argsman_tests` does not assert the full option list
- [x] Confirmed `Solver()` has no branch returning `DILITHIUM_SCRIPTHASH` (grep across the tree)
- [x] Confirmed `signature_algorithm` has no readers — only the 4 chainparams writes and the declaration
- [ ] No behaviour change; comments and one help string only