### PR TITLE
security: domain-separate Dilithium message signing from transaction signing

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -89,6 +89,7 @@ BTQ_TESTS =\
   test/compress_tests.cpp \
   test/crypto_tests.cpp \
   test/dilithium_key_tests.cpp \
+  test/dilithium_message_tests.cpp \
   test/dilithium_address_script_tests.cpp \
   test/address_all_chains_tests.cpp \
   test/dilithium_descriptor_tests.cpp \

--- a/src/test/dilithium_message_tests.cpp
+++ b/src/test/dilithium_message_tests.cpp
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 The BTQ Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <crypto/dilithium_key.h>
+#include <test/util/setup_common.h>
+#include <uint256.h>
+#include <util/message.h>
+#include <util/strencodings.h>
+
+#include <string>
+#include <vector>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(dilithium_message_tests, BasicTestingSetup)
+
+namespace {
+CDilithiumKey NewKey()
+{
+    CDilithiumKey key;
+    BOOST_REQUIRE(key.MakeNewKey());
+    return key;
+}
+} // namespace
+
+BOOST_AUTO_TEST_CASE(sign_verify_round_trip)
+{
+    const CDilithiumKey key{NewKey()};
+    const CDilithiumPubKey pubkey{key.GetPubKey()};
+    const std::string message{"proof that I control this address"};
+
+    std::string signature;
+    BOOST_REQUIRE(DilithiumMessageSign(key, message, signature));
+    BOOST_CHECK(DilithiumMessageVerify(pubkey, message, signature));
+
+    BOOST_CHECK(!DilithiumMessageVerify(pubkey, message + "!", signature));
+    BOOST_CHECK(!DilithiumMessageVerify(NewKey().GetPubKey(), message, signature));
+    BOOST_CHECK(!DilithiumMessageVerify(pubkey, message, "not base64 $$$"));
+}
+
+/**
+ * The crux of #90. Message signing and transaction signing use the same key and
+ * the same primitive; a transaction signature is made over a bare 32-byte
+ * sighash. So the attack is not hypothetical arithmetic: it is asking the
+ * victim to "sign a message" whose bytes are the sighash of a transaction that
+ * spends their coins.
+ *
+ * The strongest form of the test hands the attacker the win condition for free.
+ * Rather than grinding a transaction until its sighash matches something, take
+ * the exact 32 bytes the message signature commits to and treat those as the
+ * sighash. If the signature still does not verify as a transaction signature
+ * over them, no amount of grinding helps.
+ */
+BOOST_AUTO_TEST_CASE(a_message_signature_cannot_spend)
+{
+    const CDilithiumKey key{NewKey()};
+    const CDilithiumPubKey pubkey{key.GetPubKey()};
+    const std::string message{"harmless looking login challenge"};
+
+    std::string signature;
+    BOOST_REQUIRE(DilithiumMessageSign(key, message, signature));
+    const auto sig_bytes = DecodeBase64(signature);
+    BOOST_REQUIRE(sig_bytes);
+
+    // Grant the attacker the sighash they would otherwise have to grind for.
+    const uint256 sighash{DilithiumMessageHash(message)};
+
+    // This is what the script interpreter and MutableTransactionSignatureCreator
+    // do: verify over the sighash under the empty context.
+    BOOST_CHECK(!pubkey.Verify(sighash, *sig_bytes));
+
+    // And the same key signing that sighash as a transaction would produce a
+    // signature that does verify, so the check above is not passing because the
+    // key or the sighash is somehow unusable.
+    std::vector<unsigned char> tx_sig;
+    BOOST_REQUIRE(key.Sign(sighash, tx_sig));
+    BOOST_CHECK(pubkey.Verify(sighash, tx_sig));
+
+    // The construction that was replaced, kept as the reference the case above
+    // is measured against: signing the caller's bytes under the empty context
+    // is the same call as signing a transaction, so a 32-byte "message" is a
+    // spending signature. Asking for this is what made the RPC an oracle.
+    std::vector<unsigned char> undomained_sig;
+    BOOST_REQUIRE(key.SignMessage(Span<const unsigned char>(sighash.begin(), sighash.size()), undomained_sig));
+    BOOST_CHECK(pubkey.Verify(sighash, undomained_sig));
+}
+
+/** The other direction: a spending signature must not pass as an attestation. */
+BOOST_AUTO_TEST_CASE(a_transaction_signature_is_not_a_message_signature)
+{
+    const CDilithiumKey key{NewKey()};
+    const CDilithiumPubKey pubkey{key.GetPubKey()};
+    const std::string message{"I attest to owning these funds"};
+
+    std::vector<unsigned char> tx_sig;
+    BOOST_REQUIRE(key.Sign(DilithiumMessageHash(message), tx_sig));
+    BOOST_CHECK(!DilithiumMessageVerify(pubkey, message, EncodeBase64(tx_sig)));
+}
+
+/**
+ * Two separations are applied and either would suffice, so check them apart:
+ * a fault that silently drops one must not go unnoticed behind the other.
+ */
+BOOST_AUTO_TEST_CASE(context_and_magic_separate_independently)
+{
+    const CDilithiumKey key{NewKey()};
+    const CDilithiumPubKey pubkey{key.GetPubKey()};
+    const std::string message{"payload"};
+    const uint256 hash{DilithiumMessageHash(message)};
+    const auto span = Span<const unsigned char>(hash.begin(), hash.size());
+
+    // The context alone: same payload, empty context, does not verify under the
+    // message context.
+    std::vector<unsigned char> no_context_sig;
+    BOOST_REQUIRE(key.SignMessage(span, no_context_sig));
+    BOOST_CHECK(!pubkey.VerifyMessage(span, no_context_sig, DilithiumMessageContext()));
+
+    // The magic alone: the hash commits to it, so hashing the raw message
+    // without the prefix lands on a different payload entirely.
+    HashWriter unprefixed{};
+    unprefixed << message;
+    BOOST_CHECK(unprefixed.GetHash() != hash);
+    BOOST_CHECK(DilithiumMessageHash("a") != DilithiumMessageHash("b"));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/util/message.cpp
+++ b/src/util/message.cpp
@@ -3,6 +3,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <crypto/dilithium_key.h>
 #include <hash.h>
 #include <key.h>
 #include <key_io.h>
@@ -22,6 +23,12 @@
  * inadvertently signing a transaction.
  */
 const std::string MESSAGE_MAGIC = "BTQ Signed Message:\n";
+
+/**
+ * As above, for Dilithium. Distinct from MESSAGE_MAGIC so the two schemes'
+ * signatures cannot be presented for one another either.
+ */
+const std::string DILITHIUM_MESSAGE_MAGIC = "BTQ Dilithium Signed Message:\n";
 
 MessageVerificationResult MessageVerify(
     const std::string& address,
@@ -76,6 +83,55 @@ uint256 MessageHash(const std::string& message)
     hasher << MESSAGE_MAGIC << message;
 
     return hasher.GetHash();
+}
+
+const std::vector<unsigned char>& DilithiumMessageContext()
+{
+    static const std::string ctx{"BTQ-DILITHIUM-MSG-V1"};
+    static const std::vector<unsigned char> bytes{ctx.begin(), ctx.end()};
+    return bytes;
+}
+
+uint256 DilithiumMessageHash(const std::string& message)
+{
+    HashWriter hasher{};
+    hasher << DILITHIUM_MESSAGE_MAGIC << message;
+
+    return hasher.GetHash();
+}
+
+bool DilithiumMessageSign(
+    const CDilithiumKey& privkey,
+    const std::string& message,
+    std::string& signature)
+{
+    const uint256 hash{DilithiumMessageHash(message)};
+
+    std::vector<unsigned char> signature_bytes;
+    if (!privkey.SignMessage(Span<const unsigned char>(hash.begin(), hash.size()),
+                             signature_bytes, DilithiumMessageContext())) {
+        return false;
+    }
+
+    signature = EncodeBase64(signature_bytes);
+
+    return true;
+}
+
+bool DilithiumMessageVerify(
+    const CDilithiumPubKey& pubkey,
+    const std::string& message,
+    const std::string& signature)
+{
+    const auto signature_bytes = DecodeBase64(signature);
+    if (!signature_bytes) {
+        return false;
+    }
+
+    const uint256 hash{DilithiumMessageHash(message)};
+
+    return pubkey.VerifyMessage(Span<const unsigned char>(hash.begin(), hash.size()),
+                                *signature_bytes, DilithiumMessageContext());
 }
 
 std::string SigningResultString(const SigningResult res)

--- a/src/util/message.h
+++ b/src/util/message.h
@@ -9,10 +9,14 @@
 #include <uint256.h>
 
 #include <string>
+#include <vector>
 
 class CKey;
+class CDilithiumKey;
+class CDilithiumPubKey;
 
 extern const std::string MESSAGE_MAGIC;
+extern const std::string DILITHIUM_MESSAGE_MAGIC;
 
 /** The result of a signed message verification.
  * Message verification takes as an input:
@@ -71,6 +75,51 @@ bool MessageSign(
  * inadvertently signing a transaction.
  */
 uint256 MessageHash(const std::string& message);
+
+/**
+ * Dilithium context string for message signing.
+ *
+ * Dilithium message signing and transaction signing use the same key and the
+ * same primitive, and a transaction signature is made over a bare 32-byte
+ * sighash under the empty context. Without separation, signing a message is
+ * signing a transaction, and anything offering "sign this to prove you own the
+ * address" becomes a spending oracle for the key behind a P2MR output.
+ *
+ * FIPS 204 prepends (0, len(ctx), ctx) to the message representative, so a
+ * signature made under this context cannot verify under the empty one whatever
+ * the payload -- including a payload an attacker ground to equal a sighash.
+ * The version is part of the string because changing it invalidates every
+ * signature previously made under it.
+ */
+const std::vector<unsigned char>& DilithiumMessageContext();
+
+/**
+ * Hashes a message for Dilithium signing and verification, committing to
+ * DILITHIUM_MESSAGE_MAGIC. Independent of, and redundant with, the context
+ * separation above: neither has to be trusted alone.
+ */
+uint256 DilithiumMessageHash(const std::string& message);
+
+/** Sign a message with a Dilithium key.
+ * @param[in] privkey Dilithium private key to sign with.
+ * @param[in] message The message to sign.
+ * @param[out] signature Signature, base64 encoded, only set if true is returned.
+ * @return true if signing was successful. */
+bool DilithiumMessageSign(
+    const CDilithiumKey& privkey,
+    const std::string& message,
+    std::string& signature);
+
+/** Verify a Dilithium signed message against a known public key.
+ * Paired with DilithiumMessageSign so the two cannot drift apart.
+ * @param[in] pubkey Signer's Dilithium public key.
+ * @param[in] message The message that was signed.
+ * @param[in] signature The signature in base64 format.
+ * @return true if the signature is valid for this key and message. */
+bool DilithiumMessageVerify(
+    const CDilithiumPubKey& pubkey,
+    const std::string& message,
+    const std::string& signature);
 
 std::string SigningResultString(const SigningResult res);
 

--- a/src/wallet/rpc/dilithium.cpp
+++ b/src/wallet/rpc/dilithium.cpp
@@ -18,6 +18,7 @@
 #include <script/interpreter.h>
 #include <core_io.h>
 #include <rpc/rawtransaction_util.h>
+#include <util/message.h>
 #include <util/strencodings.h>
 #include <util/string.h>
 
@@ -148,7 +149,10 @@ RPCHelpMan importdilithiumkey()
 RPCHelpMan signmessagewithdilithium()
 {
     return RPCHelpMan{"signmessagewithdilithium",
-        "\nSign a message with a Dilithium private key.\n",
+        "\nSign a message with a Dilithium private key.\n"
+        "\nThe signature covers a domain-separated hash of the message, not the message\n"
+        "bytes, so it can never be a valid transaction signature for the same key.\n"
+        "Signatures produced before this separation existed no longer verify.\n",
         {
             {"address", RPCArg::Type::STR, RPCArg::Optional::NO, "The Dilithium address to use for signing."},
             {"message", RPCArg::Type::STR, RPCArg::Optional::NO, "The message to create a signature of."},
@@ -216,14 +220,14 @@ RPCHelpMan signmessagewithdilithium()
                 throw JSONRPCError(RPC_WALLET_ERROR, "Dilithium key not found in wallet");
             }
             
-            // Sign the message
-            std::vector<unsigned char> vchSig;
-            std::vector<unsigned char> messageBytes(strMessage.begin(), strMessage.end());
-            if (!dilithium_key.SignMessage(messageBytes, vchSig)) {
+            // Domain-separated: signing a message must not be able to produce a
+            // signature that spends the same key's coins. See util/message.h.
+            std::string signature;
+            if (!DilithiumMessageSign(dilithium_key, strMessage, signature)) {
                 throw JSONRPCError(RPC_WALLET_ERROR, "Failed to sign message");
             }
-            
-            return EncodeBase64(vchSig);
+
+            return signature;
         },
     };
 }
@@ -231,7 +235,9 @@ RPCHelpMan signmessagewithdilithium()
 RPCHelpMan verifydilithiumsignature()
 {
     return RPCHelpMan{"verifydilithiumsignature",
-        "\nVerify a Dilithium signature.\n",
+        "\nVerify a Dilithium signature produced by signmessagewithdilithium.\n"
+        "\nOnly message signatures verify here: a transaction signature made with the\n"
+        "same key belongs to a different domain and is rejected.\n",
         {
             {"message", RPCArg::Type::STR, RPCArg::Optional::NO, "The message that was signed."},
             {"address", RPCArg::Type::STR, RPCArg::Optional::NO, "The Dilithium address that signed the message."},
@@ -309,20 +315,13 @@ RPCHelpMan verifydilithiumsignature()
                 throw JSONRPCError(RPC_WALLET_ERROR, "Invalid Dilithium public key");
             }
 
-            // Decode the signature
-            auto vchSig_opt = DecodeBase64(strSignature);
-            if (!vchSig_opt) {
+            if (!DecodeBase64(strSignature)) {
                 throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid signature encoding");
             }
-            std::vector<unsigned char> vchSig = *vchSig_opt;
 
-            // Convert message to bytes (same as signing)
-            std::vector<unsigned char> messageBytes(strMessage.begin(), strMessage.end());
-
-            // Verify the signature using the Dilithium verification function
-            bool result = dilithium_pubkey.VerifyMessage(messageBytes, vchSig);
-            
-            return result;
+            // Paired with DilithiumMessageSign, so the domain the signature is
+            // checked against is by construction the one it was made in.
+            return DilithiumMessageVerify(dilithium_pubkey, strMessage, strSignature);
         },
     };
 }

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -128,6 +128,7 @@ BASE_SCRIPTS = [
     'wallet_fundrawtransaction.py --legacy-wallet',
     'wallet_fundrawtransaction.py --descriptors',
     'wallet_dilithium_send.py --descriptors',
+    'wallet_dilithium_signmessage.py --descriptors',
     'wallet_dilithium_psbt.py --descriptors',
     'wallet_bumpfee.py --legacy-wallet',
     'wallet_bumpfee.py --descriptors',

--- a/test/functional/wallet_dilithium_signmessage.py
+++ b/test/functional/wallet_dilithium_signmessage.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The BTQ Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Dilithium message signing must not double as transaction signing (issue #90).
+
+signmessagewithdilithium uses the same key and the same primitive as a P2MR
+spend, and a transaction signature is made over a bare 32-byte sighash. Without
+domain separation, "sign this message to prove you own the address" is a request
+to sign a transaction. This checks the separation from the RPC surface: the
+signature is bound to the message, to the key, and to the message domain.
+"""
+
+import base64
+from decimal import Decimal
+
+from test_framework.messages import tx_from_hex
+from test_framework.test_framework import BTQTestFramework
+from test_framework.util import assert_equal, assert_raises_rpc_error
+
+
+class WalletDilithiumSignMessageTest(BTQTestFramework):
+    def add_options(self, parser):
+        self.add_wallet_options(parser, descriptors=True, legacy=False)
+
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def run_test(self):
+        node = self.nodes[0]
+        node.createwallet(wallet_name="signer", descriptors=True)
+        wallet = node.get_wallet_rpc("signer")
+        self.generatetoaddress(node, 101, wallet.getnewaddress())
+
+        address = wallet.getnewdilithiumaddress()["address"]
+        other_address = wallet.getnewdilithiumaddress()["address"]
+        message = "prove you own this address"
+
+        self.log.info("A message signature verifies for its own message, key and nothing else")
+        signature = wallet.signmessagewithdilithium(address, message)
+        assert wallet.verifydilithiumsignature(message, address, signature)
+        assert not wallet.verifydilithiumsignature(message + " ", address, signature)
+        assert not wallet.verifydilithiumsignature(message, other_address, signature)
+
+        self.log.info("The signature is over a hash of the message, not the message bytes")
+        # A Dilithium2 signature is fixed-size, so length says nothing; what says
+        # something is that a 32-byte message and a long one are equally signable
+        # and neither signature transfers to the other.
+        short = wallet.signmessagewithdilithium(address, "x" * 32)
+        long_msg = wallet.signmessagewithdilithium(address, "x" * 4096)
+        assert wallet.verifydilithiumsignature("x" * 32, address, short)
+        assert wallet.verifydilithiumsignature("x" * 4096, address, long_msg)
+        assert not wallet.verifydilithiumsignature("x" * 32, address, long_msg)
+
+        self.log.info("A message signature is not accepted as a P2MR spending signature")
+        # Fund the address, build a spend of it, and substitute the message
+        # signature for the real one. The witness must fail script verification.
+        wallet.sendtoaddress(address, Decimal("1"))
+        self.generate(node, 1)
+        utxo = next(u for u in wallet.listunspent() if u["address"] == address)
+
+        raw = wallet.createrawtransaction(
+            [{"txid": utxo["txid"], "vout": utxo["vout"]}],
+            [{wallet.getnewaddress(): utxo["amount"] - Decimal("0.001")}],
+        )
+        signed = wallet.signrawtransactionwithwallet(raw)
+        assert_equal(signed["complete"], True)
+
+        tx = tx_from_hex(signed["hex"])
+        real_sig = tx.wit.vtxinwit[0].scriptWitness.stack[0]
+        # A Dilithium spending signature carries a trailing sighash byte. Reuse
+        # the genuine one, so the forgery differs from the real witness in the
+        # signature bytes alone.
+        forged_sig = base64.b64decode(signature) + real_sig[-1:]
+        assert_equal(len(forged_sig), len(real_sig))
+        assert forged_sig != real_sig
+        tx.wit.vtxinwit[0].scriptWitness.stack[0] = forged_sig
+
+        result = node.testmempoolaccept([tx.serialize().hex()])[0]
+        assert_equal(result["allowed"], False)
+        self.log.info("  rejected with: %s", result["reject-reason"])
+
+        # The genuine transaction is accepted, so the rejection above is the
+        # substituted signature and not something else about the transaction.
+        assert_equal(node.testmempoolaccept([signed["hex"]])[0]["allowed"], True)
+
+        self.log.info("Errors are reported for unusable inputs")
+        assert_raises_rpc_error(
+            -5, "Address is not a Dilithium key address",
+            wallet.signmessagewithdilithium, wallet.getnewaddress(), message,
+        )
+        assert_raises_rpc_error(
+            -5, "Invalid signature encoding",
+            wallet.verifydilithiumsignature, message, address, "not base64 $$$",
+        )
+
+
+if __name__ == "__main__":
+    WalletDilithiumSignMessageTest().main()


### PR DESCRIPTION
Fixes #90.

`signmessagewithdilithium` signed the caller's message bytes directly, under the empty Dilithium context. Transaction signing uses the same key and the same primitive over a bare 32-byte sighash, and for a P2MR address the key the RPC reaches for via `GetSingleDilithiumKeyIDForP2MR` is precisely the one that authorises the spend.

So the two were not merely similar operations, they were the same one. A "message" of 32 bytes is a spending signature. Anything offering "sign this to prove you own the address" — login flows, attestations, support tooling — was a spending oracle for the key behind the address.

## The fix

Message signing now commits to a magic prefix, `\"BTQ Dilithium Signed Message:\\n\"`, and signs under a distinct Dilithium context, `BTQ-DILITHIUM-MSG-V1`.

Either separation would be enough on its own. Both are applied so that neither has to be trusted alone, and a fault that silently drops one is caught by a test rather than by an incident. The context is the load-bearing one: FIPS 204 prepends `(0, len(ctx), ctx)` to the message representative, so a signature made under the message context cannot verify under the empty one *whatever the payload* — including a payload an attacker ground to equal a sighash.

The sign and verify halves live next to their ECDSA counterparts in `util/message.h`, as a pair, so the domain a signature is checked against is by construction the domain it was made in. The comparison with `MESSAGE_MAGIC` and `MessageHash` is the point: the inherited ECDSA `signmessage` has committed to a magic prefix since 2011 for exactly this reason, and the Dilithium path had no equivalent.

## What is not changed

Transaction signing. The context there stays empty, `MutableTransactionSignatureCreator::CreateDilithiumSig` is untouched, and nothing about script verification or consensus moves. This is a message-side fix and needs no fork.

## Signature format break

Dilithium message signatures made before this do not verify after it. Only `signmessagewithdilithium` output is affected — no funds, no transactions, no stored wallet data. Given testnet is the current target, the break is taken now rather than carried indefinitely as a versioned format. The version is inside the context string, so a future change is expressible without inventing a mechanism for it.

## Testing

New unit suite \`dilithium_message_tests\`, four cases. The central one hands the attacker the win condition for free: rather than grinding a transaction until its sighash matches something, it takes the exact 32 bytes the message signature commits to and treats *those* as the sighash. The signature still does not verify as a spending signature over them, so no amount of grinding helps. The same case asserts that the key and sighash are otherwise perfectly usable (a real transaction signature over them verifies), and reproduces the construction that was replaced — signing those bytes under the empty context — showing it *does* verify as a spend. That is the oracle, kept in the test as the reference point the fix is measured against.

The remaining cases cover the round trip and its negatives, the reverse direction (a transaction signature must not pass as an attestation), and the two separations checked independently.

New functional test \`wallet_dilithium_signmessage.py\` covers the RPC surface, including substituting a message signature into a genuine P2MR witness — same length, same position, same trailing sighash byte, so the forgery differs in the signature bytes alone — and confirming the node rejects it while accepting the genuine transaction.

Full unit suite passes. The Dilithium and P2MR functional suites, which round-trip these two RPCs in five separate tests, all pass.

## Note on overlap

[#84](https://github.com/btq-ag/btq-core/pull/84) touches the same two RPCs to add \`verifymessagewithdilithium\`. Whichever lands second will need a small rebase; the new RPC should call \`DilithiumMessageVerify\` rather than the raw primitive.