### PR TITLE
consensus: exercise the P2MR-only activation, and make testnet's height settable

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -21,6 +21,28 @@
 #include <stdexcept>
 #include <vector>
 
+void ReadTestNetArgs(const ArgsManager& args, CChainParams::TestNetOptions& options)
+{
+    if (!args.IsArgSet("-testnetdilithiump2mrheight")) return;
+
+    const int64_t height{args.GetIntArg("-testnetdilithiump2mrheight", 0)};
+    if (height < 1 || height > std::numeric_limits<int>::max()) {
+        throw std::runtime_error(strprintf(
+            "-testnetdilithiump2mrheight=%d is out of range, expected 1..%d.",
+            height, std::numeric_limits<int>::max()));
+    }
+    options.dilithium_p2mr_height = int{static_cast<int>(height)};
+
+    // Loud on purpose. This changes consensus, so a node running it will fork
+    // away from one that is not, and every legacy Dilithium coin still unspent
+    // at that height stops being spendable for good.
+    LogPrintf("Warning: -testnetdilithiump2mrheight=%d overrides a consensus rule. "
+              "Nodes with a different value will fork from this one, and legacy "
+              "Dilithium outputs unspent at that height become permanently "
+              "unspendable. Only use this with a coordinated height, and scan "
+              "first (contrib/devtools/scan-legacy-dilithium-utxos.py).\n", height);
+}
+
 void ReadSigNetArgs(const ArgsManager& args, CChainParams::SigNetOptions& options)
 {
     if (args.IsArgSet("-signetseednode")) {
@@ -111,8 +133,11 @@ std::unique_ptr<const CChainParams> CreateChainParams(const ArgsManager& args, c
     switch (chain) {
     case ChainType::BTQMAIN:
         return CChainParams::Main();
-    case ChainType::BTQTEST:
-        return CChainParams::TestNet();
+    case ChainType::BTQTEST: {
+        auto opts = CChainParams::TestNetOptions{};
+        ReadTestNetArgs(args, opts);
+        return CChainParams::TestNet(opts);
+    }
     case ChainType::BTQSIGNET: {
         auto opts = CChainParams::SigNetOptions{};
         ReadSigNetArgs(args, opts);

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -18,6 +18,9 @@ void SetupChainParamsBaseOptions(ArgsManager& argsman)
                  "This is intended for regression testing tools and app development. Equivalent to -chain=regtest.", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
     argsman.AddArg("-testactivationheight=name@height.", "Set the activation height of 'name' (segwit, bip34, dersig, cltv, csv, lwma, dilithium). (regtest-only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::DEBUG_TEST);
     argsman.AddArg("-testnet", "Use the test chain. Equivalent to -chain=test.", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
+    argsman.AddArg("-testnetdilithiump2mrheight=<n>", "Activate the P2MR-only Dilithium rule at height <n> on testnet, where it is unscheduled by default (testnet-only). "
+                 "This is a consensus change: nodes running different values will fork from each other, and legacy Dilithium outputs still unspent at <n> become permanently unspendable. "
+                 "Only use it with a coordinated height, and scan the chain for such outputs first.", ArgsManager::ALLOW_ANY | ArgsManager::DISALLOW_NEGATION, OptionsCategory::CHAINPARAMS);
     argsman.AddArg("-vbparams=deployment:start:end[:min_activation_height]", "Use given start/end times and min_activation_height for specified version bits deployment (regtest-only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
     argsman.AddArg("-signet", "Use the signet chain. Equivalent to -chain=signet. Note that the network is defined by the -signetchallenge parameter", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
     argsman.AddArg("-signetchallenge", "Blocks must satisfy the given script to be considered valid (only for signet networks; defaults to the global default signet test network challenge)", ArgsManager::ALLOW_ANY | ArgsManager::DISALLOW_NEGATION, OptionsCategory::CHAINPARAMS);

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -175,7 +175,7 @@ public:
  */
 class CTestNetParams : public CChainParams {
 public:
-    CTestNetParams() {
+    explicit CTestNetParams(const TestNetOptions& opts) {
         m_chain_type = ChainType::BTQTEST;
         consensus.signet_blocks = false;
         consensus.signet_challenge.clear();
@@ -196,17 +196,24 @@ public:
         consensus.nPowTargetSpacing = 1 * 60;
         consensus.nLWMAHeight = 300000;
         consensus.nDilithiumHeight = 1;
-        // TODO(release): schedule DEPLOYMENT_DILITHIUM_P2MR on testnet. The running
-        // testnet has legacy BASE/witness-v0 Dilithium UTXOs that this restriction
-        // makes unspendable; activating without a coordinated height (or a chain
-        // reset) would fork upgraded nodes away from non-upgraded ones. Until a
-        // height is chosen the restriction is policy-only on testnet (non-standard
-        // to relay, refused by the wallet) but not yet enforced in blocks.
-        // Soft-reject classification relies on SCRIPT_VERIFY_DILITHIUM being
-        // mandatory while SCRIPT_VERIFY_DILITHIUM_P2MR_ONLY stays non-mandatory
-        // — otherwise CheckInputScripts would Misbehave peers that relay still-
-        // consensus-valid legacy Dilithium spends (see policy.h).
-        consensus.nDilithiumP2MRHeight = std::numeric_limits<int>::max();
+        // DEPLOYMENT_DILITHIUM_P2MR is deliberately unscheduled here, so the
+        // restriction is policy-only on testnet (non-standard to relay, refused
+        // by the wallet) rather than enforced in blocks. Mainnet ships it at 1,
+        // so testnet is not validating the rules mainnet launches with; that
+        // gap is issue #102, and it is not closed by picking a height on this
+        // chain. Scanning the running testnet (issue #111) found ~719,045 BTQ
+        // across ~141,888 legacy Dilithium outputs, about three quarters of the
+        // chain's value, spread evenly over its whole history rather than
+        // concentrated in a few sweepable addresses. Activating here would
+        // destroy all of it, so closing #102 means a chain that never had them.
+        //
+        // -testnetdilithiump2mrheight overrides this for a rehearsal or a
+        // coordinated activation. Soft-reject classification relies on
+        // SCRIPT_VERIFY_DILITHIUM being mandatory while
+        // SCRIPT_VERIFY_DILITHIUM_P2MR_ONLY stays non-mandatory — otherwise
+        // CheckInputScripts would Misbehave peers that relay still-consensus-
+        // valid legacy Dilithium spends (see policy.h).
+        consensus.nDilithiumP2MRHeight = opts.dilithium_p2mr_height.value_or(std::numeric_limits<int>::max());
         consensus.fPowAllowMinDifficultyBlocks = true;
         consensus.fPowNoRetargeting = false;
         consensus.nRuleChangeActivationThreshold = 15120; // 75% of 20160 for testchains
@@ -559,9 +566,9 @@ std::unique_ptr<const CChainParams> CChainParams::Main()
     return std::make_unique<const CMainParams>();
 }
 
-std::unique_ptr<const CChainParams> CChainParams::TestNet()
+std::unique_ptr<const CChainParams> CChainParams::TestNet(const TestNetOptions& options)
 {
-    return std::make_unique<const CTestNetParams>();
+    return std::make_unique<const CTestNetParams>(options);
 }
 
 void MineGenesisBlock(CBlock &genesis)

--- a/src/kernel/chainparams.h
+++ b/src/kernel/chainparams.h
@@ -162,10 +162,23 @@ public:
         bool fastprune{false};
     };
 
+    /**
+     * TestNetOptions holds configurations for creating a testnet CChainParams.
+     */
+    struct TestNetOptions {
+        /** Height at which DEPLOYMENT_DILITHIUM_P2MR activates.
+         *
+         * Unset means unscheduled, which is the shipped default. Setting it is
+         * a consensus change: nodes running different values will fork from
+         * each other, so it is only useful with a coordinated height, or on a
+         * private chain rehearsing one. See issue #102. */
+        std::optional<int> dilithium_p2mr_height{};
+    };
+
     static std::unique_ptr<const CChainParams> RegTest(const RegTestOptions& options);
     static std::unique_ptr<const CChainParams> SigNet(const SigNetOptions& options);
     static std::unique_ptr<const CChainParams> Main();
-    static std::unique_ptr<const CChainParams> TestNet();
+    static std::unique_ptr<const CChainParams> TestNet(const TestNetOptions& options);
 
 protected:
     CChainParams() {}

--- a/src/test/dilithium_p2mr_only_tests.cpp
+++ b/src/test/dilithium_p2mr_only_tests.cpp
@@ -60,6 +60,43 @@ BOOST_AUTO_TEST_CASE(chainparams_dilithium_p2mr_heights)
                       std::numeric_limits<int>::max());
 }
 
+BOOST_AUTO_TEST_CASE(testnet_dilithium_p2mr_height_is_settable)
+{
+    // Testnet ships unscheduled, which is what leaves the rule mainnet launches
+    // with unvalidated by any live chain (issue #102). Scheduling it is a
+    // coordinated decision rather than a release, so the height is a config
+    // option; the default must stay unscheduled.
+    // A local ArgsManager, because m_node.args is shared and a leaked override
+    // here would silently reconfigure testnet for every later test.
+    ArgsManager args;
+    auto params_with = [&](const char* value, ChainType chain) {
+        args.ForceSetArg("-testnetdilithiump2mrheight", value);
+        return CreateChainParams(args, chain);
+    };
+
+    BOOST_CHECK_EQUAL(CreateChainParams(args, ChainType::BTQTEST)->GetConsensus().nDilithiumP2MRHeight,
+                      std::numeric_limits<int>::max());
+
+    BOOST_CHECK_EQUAL(params_with("250", ChainType::BTQTEST)->GetConsensus().nDilithiumP2MRHeight, 250);
+    BOOST_CHECK_EQUAL(params_with("1", ChainType::BTQTEST)->GetConsensus().nDilithiumP2MRHeight, 1);
+    BOOST_CHECK_EQUAL(params_with("2147483647", ChainType::BTQTEST)->GetConsensus().nDilithiumP2MRHeight,
+                      std::numeric_limits<int>::max());
+
+    for (const char* rejected : {"0", "-1", "2147483648"}) {
+        args.ForceSetArg("-testnetdilithiump2mrheight", rejected);
+        BOOST_CHECK_THROW(CreateChainParams(args, ChainType::BTQTEST), std::runtime_error);
+    }
+
+    // The option is testnet-shaped and must not disturb the chains that
+    // already ship the rule at height 1.
+    BOOST_CHECK_EQUAL(params_with("250", ChainType::BTQMAIN)->GetConsensus().nDilithiumP2MRHeight, 1);
+    BOOST_CHECK_EQUAL(params_with("250", ChainType::BTQREGTEST)->GetConsensus().nDilithiumP2MRHeight, 1);
+
+    // And it must not have leaked into the shared manager.
+    BOOST_CHECK_EQUAL(CreateChainParams(*m_node.args, ChainType::BTQTEST)->GetConsensus().nDilithiumP2MRHeight,
+                      std::numeric_limits<int>::max());
+}
+
 BOOST_AUTO_TEST_CASE(dilithium_opcodes_rejected_outside_p2mr_when_flag_set)
 {
     CDilithiumKey key;

--- a/test/functional/feature_dilithium_p2mr_activation.py
+++ b/test/functional/feature_dilithium_p2mr_activation.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The BTQ Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Mine across a DEPLOYMENT_DILITHIUM_P2MR activation.
+
+Mainnet ships nDilithiumP2MRHeight = 1, so P2MR-only is active from the first
+block and no mainnet node ever crosses the boundary. Testnet leaves it
+unscheduled, so no live chain has ever crossed it either. Issue #102 is that
+the rule mainnet launches with has therefore never been observed switching on.
+
+A chain reset is what actually closes that, and the scan in issue #111 shows why
+it cannot be closed by activating on the running testnet: about three quarters
+of that chain's value sits on legacy Dilithium outputs that the activation would
+freeze. What can be done here is to exercise the transition itself, which no
+existing test does -- coverage today either has P2MR-only on from height 1
+(regtest, feature_p2mr.py) or off forever (tool_scan_legacy_dilithium.py), and
+the unit tests in dilithium_p2mr_only_tests.cpp toggle the flag directly without
+a chain.
+
+What is checked here:
+
+  - a legacy witness-v0 Dilithium spend is accepted in a block below the height
+  - the same spend is rejected in a block at the height
+  - activation is not retroactive: the pre-activation block survives a reindex
+  - a reorg cannot launder a legacy spend across the boundary
+  - P2MR spends work on both sides, so the restriction is narrow
+
+Legacy spends go in via submitblock rather than the mempool. P2MR-only sits in
+STANDARD_SCRIPT_VERIFY_FLAGS unconditionally, so the mempool refuses these
+spends on every chain regardless of activation; that is deliberate (see
+policy.h) and it means only block validation can show the consensus rule
+changing.
+"""
+
+from test_framework.blocktools import (
+    COINBASE_MATURITY,
+    add_witness_commitment,
+    create_block,
+    create_coinbase,
+)
+from test_framework.messages import (
+    COutPoint,
+    CTransaction,
+    CTxIn,
+    CTxInWitness,
+    CTxOut,
+    SEQUENCE_FINAL,
+)
+from test_framework.script import (
+    CScript,
+    OP_0,
+    OP_CHECKSIGDILITHIUM,
+    OP_DUP,
+    OP_EQUALVERIFY,
+    OP_HASH160,
+    SIGHASH_ALL,
+    SegwitV0SignatureHash,
+    TaprootSignatureHash,
+    hash160,
+    p2mr_construct,
+)
+from test_framework.dilithium import DilithiumKey, dilithium_available
+from test_framework.test_framework import BTQTestFramework, SkipTest
+from test_framework.util import assert_equal
+from test_framework.wallet import MiniWallet
+
+ACTIVATION_HEIGHT = 250
+FUND_SATOSHIS = 200_000
+SPEND_SATOSHIS = 180_000
+
+
+class DilithiumP2MRActivationTest(BTQTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+        self.extra_args = [[
+            f"-testactivationheight=dilithium_p2mr@{ACTIVATION_HEIGHT}",
+            "-acceptnonstdtxn=1",
+        ]]
+
+    def skip_test_if_missing_module(self):
+        if not dilithium_available():
+            raise SkipTest("could not build the Dilithium reference library (needs a C compiler)")
+
+    # ------------------------------------------------------------------ helpers
+    def fund(self, script_pubkey):
+        funded = self.wallet.send_to(from_node=self.node, scriptPubKey=script_pubkey,
+                                     amount=FUND_SATOSHIS)
+        self.generate(self.node, 1)
+        return COutPoint(int(funded["txid"], 16), funded["sent_vout"])
+
+    def legacy_witness_v0_spend(self, outpoint):
+        """A witness-v0 keyhash spend satisfied by a Dilithium key.
+
+        This is the shape the activation removes. Pre-activation the
+        interpreter routes a 1312-byte witness key to OP_CHECKSIGDILITHIUM;
+        afterwards the same witness falls through to the ECDSA path, where a
+        1312-byte pubkey is not valid.
+        """
+        tx = CTransaction()
+        tx.nVersion = 2
+        tx.vin = [CTxIn(outpoint, b"", SEQUENCE_FINAL)]
+        tx.vout = [CTxOut(SPEND_SATOSHIS, self.wallet.get_scriptPubKey())]
+
+        # The scriptCode the interpreter builds for a v0 keyhash program held
+        # by a Dilithium key, mirroring VerifyWitnessProgram.
+        script_code = CScript([OP_DUP, OP_HASH160, self.program,
+                               OP_EQUALVERIFY, OP_CHECKSIGDILITHIUM])
+        sighash = SegwitV0SignatureHash(script_code, tx, 0, SIGHASH_ALL, FUND_SATOSHIS)
+
+        witness = CTxInWitness()
+        witness.scriptWitness.stack = [
+            self.key.sign(sighash) + bytes([SIGHASH_ALL]),
+            self.key.pubkey,
+        ]
+        tx.wit.vtxinwit = [witness]
+        tx.rehash()
+        return tx
+
+    def p2mr_spend(self, outpoint):
+        """A Dilithium spend through P2MR, which activation is meant to keep."""
+        tx = CTransaction()
+        tx.nVersion = 2
+        tx.vin = [CTxIn(outpoint, b"", SEQUENCE_FINAL)]
+        tx.vout = [CTxOut(SPEND_SATOSHIS, self.wallet.get_scriptPubKey())]
+
+        leaf = self.p2mr.leaves["only"]
+        sighash = TaprootSignatureHash(
+            tx, [CTxOut(FUND_SATOSHIS, self.p2mr.scriptPubKey)], SIGHASH_ALL,
+            input_index=0, scriptpath=True, script=bytes(leaf.script),
+            leaf_ver=leaf.version)
+
+        witness = CTxInWitness()
+        witness.scriptWitness.stack = [
+            self.key.sign(sighash) + bytes([SIGHASH_ALL]),
+            bytes(leaf.script),
+            bytes([leaf.version | 1]) + leaf.merklebranch,
+        ]
+        tx.wit.vtxinwit = [witness]
+        tx.rehash()
+        return tx
+
+    def submit_block_with(self, tx):
+        """Mine a block containing tx and return (accepted, height_attempted)."""
+        tip_hash = self.node.getbestblockhash()
+        height = self.node.getblockcount() + 1
+        block = create_block(int(tip_hash, 16), create_coinbase(height),
+                             self.node.getblock(tip_hash)["time"] + 1, txlist=[tx])
+        add_witness_commitment(block)
+        block.solve()
+
+        self.node.submitblock(block.serialize().hex())
+        accepted = self.node.getbestblockhash() != tip_hash
+        return accepted, height
+
+    def mine_to(self, height):
+        missing = height - self.node.getblockcount()
+        if missing > 0:
+            self.generate(self.wallet, missing)
+        assert_equal(self.node.getblockcount(), height)
+
+    def assert_unspent(self, outpoint, spent):
+        txout = self.node.gettxout(f"{outpoint.hash:064x}", outpoint.n)
+        if spent:
+            assert txout is None, "output should have been spent"
+        else:
+            assert txout is not None, "output should still be unspent"
+
+    # --------------------------------------------------------------------- test
+    def run_test(self):
+        self.node = self.nodes[0]
+        self.wallet = MiniWallet(self.node)
+        self.generate(self.wallet, COINBASE_MATURITY + 10)
+
+        self.key = DilithiumKey(seed=b"\x07" * 32)
+        self.program = hash160(self.key.pubkey)
+        legacy_spk = CScript([OP_0, self.program])
+        self.p2mr = p2mr_construct([("only", CScript([self.key.pubkey, OP_CHECKSIGDILITHIUM]))])
+
+        assert self.node.getblockcount() < ACTIVATION_HEIGHT - 5, \
+            "setup already crossed the activation height"
+
+        self.log.info("Deployment reports inactive before the height")
+        assert_equal(self.node.getdeploymentinfo()["deployments"]["dilithium_p2mr"]["active"], False)
+
+        self.log.info("A legacy witness-v0 Dilithium spend is valid below the height")
+        legacy_a = self.fund(legacy_spk)
+        legacy_b = self.fund(legacy_spk)
+        p2mr_early = self.fund(self.p2mr.scriptPubKey)
+
+        accepted, height = self.submit_block_with(self.legacy_witness_v0_spend(legacy_a))
+        assert accepted, f"legacy Dilithium spend rejected at height {height}, below activation"
+        assert height < ACTIVATION_HEIGHT
+        self.assert_unspent(legacy_a, spent=True)
+        legacy_spend_block = self.node.getbestblockhash()
+
+        self.log.info("P2MR works below the height too")
+        accepted, _ = self.submit_block_with(self.p2mr_spend(p2mr_early))
+        assert accepted, "P2MR spend rejected before activation"
+
+        self.log.info("The mempool refuses the legacy spend on both sides, by policy")
+        # P2MR-only is unconditionally standard, so this is not what changes at
+        # the boundary. Asserting it keeps the block-level result below from
+        # being misread as a policy effect.
+        rejected = self.node.testmempoolaccept([self.legacy_witness_v0_spend(legacy_b).serialize().hex()])
+        assert_equal(rejected[0]["allowed"], False)
+
+        self.log.info("Mining to one block below the activation height")
+        # getdeploymentinfo answers for the block that would come next, so it
+        # flips one height early relative to the height that enforces the rule.
+        # Worth pinning down: it is the field an operator would watch when
+        # scheduling, and reading it as "already enforced" is off by one.
+        self.mine_to(ACTIVATION_HEIGHT - 2)
+        assert_equal(self.node.getdeploymentinfo()["deployments"]["dilithium_p2mr"]["active"], False)
+        self.mine_to(ACTIVATION_HEIGHT - 1)
+        assert_equal(self.node.getdeploymentinfo()["deployments"]["dilithium_p2mr"]["active"], True)
+
+        self.log.info("The same spend is rejected in the activation block")
+        accepted, height = self.submit_block_with(self.legacy_witness_v0_spend(legacy_b))
+        assert_equal(height, ACTIVATION_HEIGHT)
+        assert not accepted, "legacy Dilithium spend accepted at the activation height"
+        self.assert_unspent(legacy_b, spent=False)
+
+        self.log.info("The coin is frozen, not merely unrelayable")
+        # Same input, a different output amount, so it is a different
+        # transaction rather than a duplicate being rejected.
+        variant = self.legacy_witness_v0_spend(legacy_b)
+        variant.vout[0].nValue = SPEND_SATOSHIS - 1_000
+        variant.rehash()
+        accepted, _ = self.submit_block_with(variant)
+        assert not accepted, "a reworded legacy spend still should not confirm"
+
+        self.log.info("An ordinary block at the same height is fine")
+        # Proves the rejection is about the spend and not about the height.
+        self.generate(self.wallet, 1)
+        assert_equal(self.node.getblockcount(), ACTIVATION_HEIGHT)
+        assert_equal(self.node.getdeploymentinfo()["deployments"]["dilithium_p2mr"]["active"], True)
+
+        self.log.info("P2MR still works above the height")
+        p2mr_late = self.fund(self.p2mr.scriptPubKey)
+        accepted, _ = self.submit_block_with(self.p2mr_spend(p2mr_late))
+        assert accepted, "P2MR spend rejected after activation"
+
+        self.log.info("Activation is not retroactive: the old block survives a reindex")
+        tip_before = self.node.getbestblockhash()
+        height_before = self.node.getblockcount()
+        self.restart_node(0, self.extra_args[0] + ["-reindex"])
+        assert_equal(self.node.getbestblockhash(), tip_before)
+        assert_equal(self.node.getblockcount(), height_before)
+        assert_equal(self.node.getblock(legacy_spend_block)["confirmations"] > 0, True)
+        self.assert_unspent(legacy_a, spent=True)
+
+        self.log.info("A reorg cannot carry a legacy spend across the boundary")
+        # Rewinding to before activation and rebuilding past it must not leave
+        # the frozen coin spent, however the blocks are re-ordered.
+        self.node.invalidateblock(self.node.getblockhash(ACTIVATION_HEIGHT - 1))
+        assert_equal(self.node.getblockcount(), ACTIVATION_HEIGHT - 2)
+        self.assert_unspent(legacy_b, spent=False)
+        self.generate(self.wallet, 5)
+        assert self.node.getblockcount() > ACTIVATION_HEIGHT
+        self.assert_unspent(legacy_b, spent=False)
+        accepted, _ = self.submit_block_with(self.legacy_witness_v0_spend(legacy_b))
+        assert not accepted, "reorg past the boundary let a frozen coin be spent"
+
+        self.log.info("The pre-activation spend is still spent after all of that")
+        self.assert_unspent(legacy_a, spent=True)
+
+
+if __name__ == "__main__":
+    DilithiumP2MRActivationTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -335,6 +335,7 @@ BASE_SCRIPTS = [
     'wallet_fallbackfee.py --legacy-wallet',
     'wallet_fallbackfee.py --descriptors',
     'rpc_dumptxoutset.py',
+    'feature_dilithium_p2mr_activation.py',
     'feature_minchainwork.py',
     'rpc_estimatefee.py',
     'rpc_getblockstats.py',


### PR DESCRIPTION
Addresses #102. Does not close it — see below.

## The gap

Mainnet ships `nDilithiumP2MRHeight = 1`, so P2MR-only is on from the first block and no mainnet node ever crosses the boundary. Testnet leaves it unscheduled, so no live chain has crossed it either. #102's point is that the enforcement mainnet launches with has therefore never been observed switching on.

## Why this doesn't close it, and what changed my mind

#102 offers two options: reset testnet, or activate at a future height on the existing chain. Option B is conditional on first moving any value worth keeping.

The scan in #111 (PR #127) says that condition cannot be met. On testnet at height 191,361: **719,045 BTQ across 141,888 outputs would be frozen, out of 956,445 BTQ total — about 75% of the chain.** All legacy base58 Dilithium P2PKH, because testnet paid every coinbase to one until the miners moved to P2MR at height 159,436. It spans heights 1 to 159,436 evenly and the largest 1,000 outputs hold 2% of the value, so this is not a few pool addresses someone can sweep before a flag day. It is the chain's whole mining history.

So closing #102 means Option A, a reset, which is an operational act rather than a patch. This PR does the two parts that are code.

Two corrections to #102 worth folding into the decision, both verified against the running node rather than assumed:

- Testnet is at height **191,361**, not the ~407,568 the issue states. Two connected peers agree, both `/BTQ:0.4.2/`.
- `nLWMAHeight` is 300000, about 109k blocks past that tip, so **LWMA has never activated on testnet either.** #102 argues for Option A partly from LWMA being "well exercised: ~107k live blocks"; the reverse is true. Neither P2MR-only nor LWMA has ever validated a live chain. That strengthens Option A rather than weakening it, and it also means PR #124's window constant has no live data behind it.

## 1. A test that mines across an activation

This is the part that actually reduces risk now, and nothing did it before:

| existing coverage | what it does |
|---|---|
| `feature_p2mr.py` and the rest of regtest | rule on from height 1, never crosses |
| `tool_scan_legacy_dilithium.py` | rule off forever, never crosses |
| `dilithium_p2mr_only_tests.cpp` | toggles the flag directly, no chain |
| `validation_tests.cpp` | `GetBlockScriptFlags` at heights 0 and 1, no chain |
| `feature_dilithium_activation.py` | crosses `dilithium@150`, but P2MR-only is on from 1 throughout |

`feature_dilithium_p2mr_activation.py` sets `dilithium_p2mr@250` and checks:

- a legacy witness-v0 Dilithium spend confirms in a block **below** the height
- the same spend is rejected in a block **at** the height, and the coin stays unspent
- a reworded version of it is rejected too, so the coin is frozen rather than the transaction merely being a duplicate
- an ordinary block at that height is fine, so the rejection is about the spend and not the height
- activation is **not retroactive**: the pre-activation block survives `-reindex`
- a **reorg** back before the boundary and forward past it cannot leave the frozen coin spent
- **P2MR works on both sides**, so the restriction is as narrow as intended
- `getdeploymentinfo` flips one height early, because it answers for the next block — pinned down deliberately, since that is the field an operator would watch when scheduling and reading it as "already enforced" is off by one

Spends are real: `test_framework.dilithium.DilithiumKey` signs a BIP143 sighash over the scriptCode the interpreter synthesises for a v0 keyhash program held by a Dilithium key. They go in via `submitblock`, not the mempool, because `SCRIPT_VERIFY_DILITHIUM_P2MR_ONLY` is unconditionally in `STANDARD_SCRIPT_VERIFY_FLAGS` and the mempool refuses them on every chain regardless of activation. The test asserts that too, so the block-level result cannot be misread as a policy effect.

### Does the test bite?

Patching `GetBlockScriptFlags` to never set `SCRIPT_VERIFY_DILITHIUM_P2MR_ONLY` fails it with `legacy Dilithium spend accepted at the activation height`. Moving the height to never, and to 1, each fail it as well.

## 2. `-testnetdilithiump2mrheight`

`-testactivationheight` is regtest-only, so testnet's height cannot be changed today without recompiling. This adds a testnet-only option so a rehearsal, or a coordinated activation if one is ever agreed, is a config decision rather than a release.

**The default is unchanged.** Setting it is a consensus change — nodes on different values fork from each other, and every legacy Dilithium coin unspent at that height stops being spendable — so it logs a warning saying exactly that, and the help text says it too.

Unit tests cover the default, valid values, rejection of out-of-range ones, that it leaves mainnet and regtest at 1, and that it does not leak into the shared `ArgsManager`. That last one is not hypothetical: the first version of the test used `m_node.args` and broke `key_io_tests` by silently reconfiguring testnet for every test that ran after it.

## 3. The comment on the testnet height

The `TODO(release)` there said a height still needed picking. It now records what the scan found and why the answer is not a height on this chain, so the next reader does not have to rediscover it.

## Test plan

- [x] Full unit suite, 734 cases, from a clean `origin/master` base
- [x] `feature_dilithium_p2mr_activation.py` passes; fails under three separate mutations including a real consensus one
- [x] `feature_p2mr_rpc.py`, `feature_p2mr_dilithium_multisig.py`, `feature_dilithium_activation.py`, `feature_dilithium_sigops.py`, `wallet_dilithium_send.py`, `feature_config_args.py` all pass
- [x] `feature_p2mr.py` and `rpc_blockchain.py` fail identically on `origin/master` — pre-existing (the #104 subsidy mismatch, and an error-string drift in `feature_p2mr.py`)
- [ ] Decide Option A vs B on #102 with the scan numbers in hand

## Note on ordering

Independent of PR #127 (#111) and can merge in either order; only a source comment cross-references the scan.
