### PR TITLE
net: drop the placeholder fixed seeds and say when bootstrap is impossible

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -177,6 +177,7 @@ BTQ_TESTS =\
   test/versionbits_tests.cpp \
   test/xoroshiro128plusplus_tests.cpp \
   test/chainparams_genesis_tests.cpp \
+  test/chainparams_seeds_tests.cpp \
   test/pow_lwma_tests.cpp
 
 if ENABLE_WALLET

--- a/src/chainparamsseeds.h
+++ b/src/chainparamsseeds.h
@@ -1,21 +1,38 @@
 #ifndef BTQ_CHAINPARAMSSEEDS_H
 #define BTQ_CHAINPARAMSSEEDS_H
+
+#include <array>
+#include <cstdint>
+
 /**
  * List of fixed seed nodes for the BTQ network
- * These will be populated once BTQ nodes are running
  *
- * Each line contains a BIP155 serialized (networkID, addr, port) tuple.
+ * Each entry is a BIP155 serialized (networkID, addr, port) tuple.
+ *
+ * These lists are empty: BTQ has not provisioned fixed seeds for any network
+ * yet. See issue #114.
+ *
+ * They previously held a single entry of
+ *
+ *     0x01, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+ *
+ * described in a comment as an ignored placeholder. It was ignored, but not
+ * harmlessly: it deserialises to 0.0.0.0:0, which is then discarded as
+ * unroutable, so a node logged "Added 0 fixed seeds from reachable networks"
+ * and read as though seeding had failed at runtime rather than never having
+ * been configured at all. An empty list says the same thing without the
+ * misdirection, and lets a test assert that every fixed seed we do ship is
+ * routable.
+ *
+ * To populate these, run contrib/seeds/generate-seeds.py against a node with a
+ * healthy peers.dat, then restore the vFixedSeeds assignment in
+ * src/kernel/chainparams.cpp. Do this before mainnet launch: DNS seeding is the
+ * only other bootstrap mechanism, and fixed seeds are precisely what covers the
+ * case where it fails.
  */
 
-// BTQ mainnet seeds - to be added after network launch
-// Format: networkID (1 byte), address length (1 byte), address, port (2 bytes big-endian)
-static const uint8_t chainparams_seed_main[] = {
-    0x01, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00  // Placeholder entry (invalid, will be ignored)
-};
+static constexpr std::array<uint8_t, 0> chainparams_seed_main{};
 
-// BTQ testnet seeds - to be added after network launch  
-static const uint8_t chainparams_seed_test[] = {
-    0x01, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00  // Placeholder entry (invalid, will be ignored)
-};
+static constexpr std::array<uint8_t, 0> chainparams_seed_test{};
 
 #endif // BTQ_CHAINPARAMSSEEDS_H

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -148,6 +148,9 @@ public:
         bech32_hrp = "qbtc";
         dilithium_bech32_hrp = "dbtc";
 
+        // Currently empty: no fixed seeds have been provisioned for mainnet
+        // (issue #114). The assignment is kept so that populating
+        // chainparams_seed_main is the only step needed.
         vFixedSeeds = std::vector<uint8_t>(std::begin(chainparams_seed_main), std::end(chainparams_seed_main));
 
         fDefaultConsistencyChecks = false;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2506,6 +2506,18 @@ void CConnman::ThreadOpenConnections(const std::vector<std::string> connect)
                 addrman.Add(seed_addrs, local);
                 add_fixed_seeds = false;
                 LogPrintf("Added %d fixed seeds from reachable networks.\n", seed_addrs.size());
+
+                // Fixed seeds are the last bootstrap mechanism, and this branch
+                // runs at most once. If it yielded nothing and we still know no
+                // peers, the node will sit at zero connections indefinitely with
+                // nothing further logged, which is indistinguishable from a
+                // network problem. Say so plainly instead.
+                if (seed_addrs.empty() && addrman.Size() == 0) {
+                    LogPrintf("Warning: no fixed seeds are configured for %s and no peers are known. "
+                              "If DNS seeding does not supply any either, this node cannot discover "
+                              "peers on its own; use -addnode or -seednode to connect manually.\n",
+                              m_params.GetChainTypeString());
+                }
             }
         }
 

--- a/src/test/chainparams_seeds_tests.cpp
+++ b/src/test/chainparams_seeds_tests.cpp
@@ -1,0 +1,180 @@
+// Copyright (c) 2026 The BTQ Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+//! Tests for the bootstrap seed configuration.
+//!
+//! A node with an empty peers.dat has exactly two ways to find its first peer:
+//! DNS seeds, and the hardcoded fixed seeds that exist to cover the case where
+//! DNS seeding fails. Neither is exercised by any other test, and a mistake in
+//! either is invisible until a fresh node cannot join the network -- which is
+//! the situation described in issue #114.
+
+#include <chainparams.h>
+#include <kernel/chainparams.h>
+#include <netaddress.h>
+#include <protocol.h>
+#include <streams.h>
+#include <test/util/setup_common.h>
+#include <util/chaintype.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+BOOST_FIXTURE_TEST_SUITE(chainparams_seeds_tests, BasicTestingSetup)
+
+namespace {
+//! Deserialise a fixed-seed blob the same way CConnman::ThreadOpenConnections
+//! does, so this tests the bytes that actually reach addrman rather than a
+//! reimplementation of the format.
+std::vector<CService> DecodeFixedSeeds(const std::vector<uint8_t>& blob)
+{
+    std::vector<CService> out;
+    DataStream underlying_stream{blob};
+    ParamsStream s{CAddress::V2_NETWORK, underlying_stream};
+    while (!s.eof()) {
+        CService endpoint;
+        s >> endpoint;
+        out.push_back(endpoint);
+    }
+    return out;
+}
+
+//! The predicate net.cpp effectively applies: anything failing this is dropped
+//! before it reaches addrman.
+bool IsUsableSeed(const CService& seed)
+{
+    return seed.IsValid() && seed.IsRoutable() && seed.GetPort() != 0;
+}
+} // namespace
+
+//! The exact bytes mainnet and testnet shipped until #114, described in a
+//! comment as an ignored placeholder.
+//!
+//! This is what gives fixed_seeds_are_routable below its teeth. That test
+//! iterates the seeds we ship, and we currently ship none, so it would pass
+//! vacuously and keep passing if the guard itself were broken. Running the
+//! known-bad entry through the same decoder proves the guard detects the class
+//! of defect it exists for.
+BOOST_AUTO_TEST_CASE(historical_placeholder_seed_is_rejected)
+{
+    const std::vector<uint8_t> placeholder{0x01, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+    const std::vector<CService> decoded{DecodeFixedSeeds(placeholder)};
+
+    // It parses as a well-formed record, which is why it was never noticed.
+    BOOST_REQUIRE_EQUAL(decoded.size(), 1U);
+    BOOST_CHECK_EQUAL(decoded[0].ToStringAddrPort(), "0.0.0.0:0");
+
+    // And is then discarded, so it contributed nothing but a misleading
+    // "Added 0 fixed seeds from reachable networks" at runtime.
+    BOOST_CHECK(!IsUsableSeed(decoded[0]));
+}
+
+//! A well-formed entry must survive the same path, so the guard is not simply
+//! rejecting everything.
+BOOST_AUTO_TEST_CASE(a_real_seed_is_accepted)
+{
+    // An arbitrary routable IPv4 address and port. Nothing connects to it; it
+    // only has to survive the filter. Note that the RFC 5737 documentation
+    // ranges cannot be used here, because IsRoutable() rejects them by design.
+    const std::vector<uint8_t> good{0x01, 0x04, 1, 2, 3, 4, 0x20, 0x8D};
+    const std::vector<CService> decoded{DecodeFixedSeeds(good)};
+
+    BOOST_REQUIRE_EQUAL(decoded.size(), 1U);
+    BOOST_CHECK_EQUAL(decoded[0].ToStringAddrPort(), "1.2.3.4:8333");
+    BOOST_CHECK(IsUsableSeed(decoded[0]));
+}
+
+//! Every fixed seed we ship must be a routable address on a real port.
+//!
+//! net.cpp discards unroutable fixed seeds silently, so a malformed or
+//! placeholder entry does not fail anything -- it just quietly reduces the
+//! usable seed count, and the node logs "Added 0 fixed seeds from reachable
+//! networks" as though seeding had failed at runtime. Mainnet shipped exactly
+//! such an entry (0.0.0.0:0) until #114; this is the assertion that would have
+//! caught it, and that keeps the next one from landing.
+BOOST_AUTO_TEST_CASE(fixed_seeds_are_routable)
+{
+    const std::vector<std::pair<std::string, std::unique_ptr<const CChainParams>>> chains = [] {
+        std::vector<std::pair<std::string, std::unique_ptr<const CChainParams>>> v;
+        v.emplace_back("main", CChainParams::Main());
+        v.emplace_back("test", CChainParams::TestNet());
+        v.emplace_back("signet", CChainParams::SigNet({}));
+        v.emplace_back("regtest", CChainParams::RegTest({}));
+        return v;
+    }();
+
+    for (const auto& [name, params] : chains) {
+        std::vector<CService> seeds;
+        // A truncated or misaligned blob throws here rather than yielding
+        // garbage, so this is an assertion even when the list is empty.
+        BOOST_CHECK_NO_THROW(seeds = DecodeFixedSeeds(params->FixedSeeds()));
+
+        for (const CService& seed : seeds) {
+            BOOST_CHECK_MESSAGE(IsUsableSeed(seed),
+                                name + ": fixed seed " + seed.ToStringAddrPort() +
+                                    " is not a routable address on a real port, so net.cpp will "
+                                    "silently discard it");
+        }
+    }
+}
+
+//! Mainnet has no fixed seeds yet. This is a known launch blocker, not an
+//! accident, and it is asserted here so that provisioning them is a deliberate
+//! change that has to come past this test rather than something that can drift
+//! back to a placeholder.
+//!
+//! When mainnet seeds are generated (see src/chainparamsseeds.h), this
+//! assertion is the one to invert: require a nonzero count, and keep
+//! fixed_seeds_are_routable above as the standing guard on their contents.
+BOOST_AUTO_TEST_CASE(mainnet_fixed_seeds_are_not_yet_provisioned)
+{
+    const std::unique_ptr<const CChainParams> main{CChainParams::Main()};
+    const std::vector<CService> seeds{DecodeFixedSeeds(main->FixedSeeds())};
+
+    BOOST_CHECK_MESSAGE(seeds.empty(),
+                        "mainnet now ships " + std::to_string(seeds.size()) +
+                            " fixed seed(s). If these are real, invert this assertion to require a "
+                            "nonzero count and resolve issue #114.");
+}
+
+//! Bootstrap needs at least one source. Mainnet currently relies entirely on
+//! DNS seeding because it has no fixed seeds, so losing the seed list would
+//! leave a fresh node with nothing at all.
+//!
+//! This cannot check that the hostnames resolve -- a unit test must not depend
+//! on DNS -- so resolution is verified out of band and tracked in #114.
+BOOST_AUTO_TEST_CASE(networks_have_a_bootstrap_source)
+{
+    for (const auto& [name, params] : [] {
+             std::vector<std::pair<std::string, std::unique_ptr<const CChainParams>>> v;
+             v.emplace_back("main", CChainParams::Main());
+             v.emplace_back("test", CChainParams::TestNet());
+             return v;
+         }()) {
+        const bool has_dns{!params->DNSSeeds().empty()};
+        const bool has_fixed{!params->FixedSeeds().empty()};
+        BOOST_CHECK_MESSAGE(has_dns || has_fixed,
+                            name + ": no DNS seeds and no fixed seeds, so a node with an empty "
+                                   "peers.dat cannot bootstrap");
+    }
+}
+
+//! Regtest must never reach the network. Its seed is a deliberately
+//! unresolvable sentinel; a real hostname here would have test nodes calling
+//! out to the internet.
+BOOST_AUTO_TEST_CASE(regtest_does_not_seed_from_the_network)
+{
+    const std::unique_ptr<const CChainParams> regtest{CChainParams::RegTest({})};
+    BOOST_CHECK(regtest->FixedSeeds().empty());
+    for (const std::string& seed : regtest->DNSSeeds()) {
+        BOOST_CHECK_MESSAGE(seed.find(".invalid") != std::string::npos,
+                            "regtest DNS seed " + seed + " is not an .invalid sentinel");
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Addresses the code half of #114. Does not close it — the blocking parts are operational, see below.

## Confirming the report first

Re-ran the resolution check today, controls included so this is not mistaken for a local DNS fault:

| host | A record |
| --- | --- |
| `github.com` | 140.82.121.4 |
| `bitcoinquantum.com` | 76.76.21.21 |
| `btq.com` | 216.150.1.1 |
| `btq.tech` | 31.43.161.6, 31.43.160.6 |
| **`seed1.btq.com`** | **none** |
| **`signet-seed1.btq.com`** | **none** |
| **`signet-seed2.btq.com`** | **none** |
| `testnet-seed1.bitcoinquantum.com` | 208.85.16.175 |
| `testnet-seed2.bitcoinquantum.com` | 16.16.123.185 |

Every apex resolves and both testnet seeds resolve. Only the `btq.com` subdomains are missing, so this is absent records rather than filtering. `seed1.btq.com` is mainnet's entire seed list.

## What the placeholder actually did

Not nothing, which is what the comment claimed:

```cpp
0x01, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00  // Placeholder entry (invalid, will be ignored)
```

It deserialises cleanly to `0.0.0.0:0`, is then discarded by the reachable-networks filter because it is unroutable, and the node logs `Added 0 fixed seeds from reachable networks`. So it produced a message that reads like seeding failed at runtime, when in truth seeding was never configured. It also made it impossible to state the invariant worth having — *every fixed seed we ship is routable* — because a deliberately invalid entry violated it.

Both lists are now empty. Behaviour is unchanged (zero usable seeds either way); what changes is that the configuration no longer misrepresents itself, and the invariant becomes assertable.

## The silent failure

`ThreadOpenConnections` reaches the fixed-seed fallback at most once, then sets `add_fixed_seeds = false`:

```cpp
addrman.Add(seed_addrs, local);
add_fixed_seeds = false;
LogPrintf("Added %d fixed seeds from reachable networks.\n", seed_addrs.size());
```

On mainnet today that logs `Added 0`, and then nothing more is ever emitted. The node stays at zero connections forever, and from the operator's side that is indistinguishable from a firewall or an ISP problem. This adds a warning on exactly that path — no seeds produced, and addrman still empty — naming `-addnode`/`-seednode` as the manual route.

## Tests

`src/test/chainparams_seeds_tests.cpp`, six cases.

The lists are empty, so a test that only iterates the shipped seeds passes vacuously and would keep passing if the check itself broke — Boost reports it as "did not check any assertions". So the decoder is tested directly, using the same `ParamsStream`/`CAddress::V2_NETWORK` path as `ConvertSeeds`:

- `historical_placeholder_seed_is_rejected` — the exact bytes that shipped until now parse to one well-formed record, `0.0.0.0:0`, and are then rejected. This is what gives the guard teeth.
- `a_real_seed_is_accepted` — a routable entry survives, so the guard is not simply rejecting everything. Worth noting the RFC 5737 documentation ranges cannot serve as the positive case, since `IsRoutable()` rejects them by design.
- `fixed_seeds_are_routable` — the standing guard across all four chains.
- `mainnet_fixed_seeds_are_not_yet_provisioned` — pins the known gap so provisioning is deliberate and cannot silently regress to a placeholder. Its failure message says to invert it.
- `networks_have_a_bootstrap_source`, `regtest_does_not_seed_from_the_network`.

Mutation check — restoring the placeholder is caught by both relevant tests:

```
error: in "fixed_seeds_are_routable": main: fixed seed 0.0.0.0:0 is not a
  routable address on a real port, so net.cpp will silently discard it
error: in "mainnet_fixed_seeds_are_not_yet_provisioned": mainnet now ships 1
  fixed seed(s). If these are real, invert this assertion and resolve #114.
```

Full unit suite: 739 cases, no errors. `feature_addrman.py`, `rpc_net.py`, `p2p_net_deadlock.py` pass. `p2p_dns_seeds.py` fails identically on `origin/master`, so it is pre-existing and not touched here.

## What this does not fix

The two things that would actually let a mainnet node bootstrap are not code:

1. **Does BTQ control `btq.com`?** Still the blocking question from #114 and unanswerable from the repository. Every other piece of infrastructure is on `bitcoinquantum.com`, team email is `@btq.tech`, and `btq.com` resolves to 216.150.1.1, which matches nothing else we run. If it is not ours, mainnet and signet are pointing their trust anchor at a domain someone else controls, which is an eclipse position against every new node — that is worth answering before it is worth writing any more code here.
2. **Real seeds have to be generated and records published.** `contrib/seeds/generate-seeds.py` needs a node with a healthy peers.dat, which needs a running network.

Also unaddressed, and worth deciding separately: mainnet has one DNS seed where Bitcoin ships nine. One seed is both a single point of failure for bootstrap and a single point of control over which peers a new node meets.