### PR TITLE
backport: CVE-2024-52911 — use-after-free in the script interpreter

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2380,10 +2380,16 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
     // Precomputed transaction data pointers must not be invalidated
     // until after `control` has run the script checks (potentially
     // in multiple threads). Preallocate the vector size so a new allocation
-    // doesn't invalidate pointers into the vector, and keep txsdata in scope
-    // for as long as `control`.
-    CCheckQueueControl<CScriptCheck> control(fScriptChecks && parallel_script_checks ? &scriptcheckqueue : nullptr);
+    // doesn't invalidate pointers into the vector.
+    //
+    // `txsdata` must also be declared *before* `control`: local objects are
+    // destroyed in reverse order of construction, so this is what guarantees
+    // the check queue is drained before the data its CScriptChecks point at
+    // goes away. Inverting these two lines reintroduces CVE-2024-52911, where
+    // an early return below unwinds through ~CCheckQueueControl and the
+    // background threads read freed memory.
     std::vector<PrecomputedTransactionData> txsdata(block.vtx.size());
+    CCheckQueueControl<CScriptCheck> control(fScriptChecks && parallel_script_checks ? &scriptcheckqueue : nullptr);
 
     std::vector<int> prevheights;
     CAmount nFees = 0;

--- a/test/functional/feature_cve_2024_52911.py
+++ b/test/functional/feature_cve_2024_52911.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The BTQ Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Regression test for CVE-2024-52911 (use-after-free in the script interpreter).
+
+ConnectBlock dispatches script checks to background threads as CScriptCheck
+functors. Each holds a *pointer* into a PrecomputedTransactionData, so that data
+must outlive the check queue.
+
+Local objects are destroyed in reverse order of construction, so the queue
+control has to be constructed *after* the data it points at. When the order is
+inverted, an early return between queueing the checks and the explicit
+control.Wait() frees the precomputed data while it is still needed:
+~CCheckQueueControl calls Wait(), and Wait() runs the outstanding checks.
+
+Three conditions all have to hold for the dangling pointer to actually be
+dereferenced, which is why this block is shaped so specifically.
+
+1.  The queue must be deep at the instant of the return. One transaction with
+    many inputs queues a large batch in a single control.Add(), and the *next*
+    transaction is rejected, so the main thread does almost no work in between.
+    Padding the block with ordinary transactions instead lets the worker drain
+    the queue while the main thread grinds through the rest of the loop.
+
+2.  The inputs must use a segwit sighash. BIP143 reads the cached midstate out
+    of PrecomputedTransactionData; legacy P2PK and P2PKH sighashes never touch
+    it, so a block full of those leaves the pointer dangling but unread and
+    nothing is observable.
+
+3.  The transaction must not be in the mempool. ConnectBlock consults the
+    script execution cache first, and a hit means no checks are queued at all --
+    hence signing here rather than broadcasting.
+
+Under a normal build the freed read is silent and this only confirms the node
+rejects the block and stays up. Observing the defect itself needs an
+AddressSanitizer build:
+
+    ./configure --with-sanitizers=address && make
+    ASAN_OPTIONS=detect_leaks=0 test/functional/feature_cve_2024_52911.py
+
+Against the unfixed tree that reports a heap-use-after-free in SignatureHash(),
+read by a b-scriptch worker and freed by the thread running ConnectBlock.
+"""
+
+from test_framework.address import key_to_p2wpkh
+from test_framework.blocktools import add_witness_commitment, create_block, create_coinbase
+from test_framework.key import ECKey
+from test_framework.messages import (
+    COIN,
+    COutPoint,
+    CTransaction,
+    CTxIn,
+    CTxInWitness,
+    CTxOut,
+)
+from test_framework.script import (
+    CScript,
+    OP_RETURN,
+    SIGHASH_ALL,
+    SegwitV0SignatureHash,
+    hash160,
+)
+from test_framework.script_util import key_to_p2wpkh_script, keyhash_to_p2pkh_script
+from test_framework.test_framework import BTQTestFramework
+from test_framework.util import assert_equal
+
+# Inputs on the single large transaction, each one a queued BIP143
+# verification. Only a handful need to still be outstanding when the return
+# fires, so this is comfortably more than enough.
+NUM_INPUTS = 400
+
+
+class Cve202452911Test(BTQTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+        # -par counts the main thread, so this is exactly one background
+        # worker. At -par=1 there are zero workers, no checks are queued at
+        # all, and the defect cannot appear.
+        self.extra_args = [["-par=2"]]
+
+    def run_test(self):
+        node = self.nodes[0]
+
+        key = ECKey()
+        key.set((11).to_bytes(32, "big"), True)
+        pubkey = key.get_pubkey().get_bytes()
+        # P2WPKH so spending uses the BIP143 sighash, which is what reads the
+        # precomputed data. No wallet is involved anywhere.
+        script_code = keyhash_to_p2pkh_script(hash160(pubkey))
+
+        self.log.info(f"Mining {NUM_INPUTS + 150} blocks to a P2WPKH address")
+        self.generatetoaddress(node, NUM_INPUTS + 150, key_to_p2wpkh(pubkey))
+
+        self.log.info(f"Collecting {NUM_INPUTS} mature coinbase outputs")
+        utxos = []
+        for height in range(1, NUM_INPUTS + 1):
+            coinbase = node.getblock(node.getblockhash(height), 2)["tx"][0]
+            utxos.append((coinbase["txid"], int(coinbase["vout"][0]["value"] * COIN)))
+
+        self.log.info(f"Building and signing one transaction with {NUM_INPUTS} inputs")
+        big_tx = CTransaction()
+        for txid, _ in utxos:
+            big_tx.vin.append(CTxIn(COutPoint(int(txid, 16), 0)))
+        big_tx.vout.append(CTxOut(sum(v for _, v in utxos) - 10000,
+                                  key_to_p2wpkh_script(pubkey)))
+        big_tx.wit.vtxinwit = [CTxInWitness() for _ in utxos]
+        for i, (_, value) in enumerate(utxos):
+            sighash = SegwitV0SignatureHash(script_code, big_tx, i, SIGHASH_ALL, value)
+            signature = key.sign_ecdsa(sighash) + bytes([SIGHASH_ALL])
+            big_tx.wit.vtxinwit[i].scriptWitness.stack = [signature, pubkey]
+        big_tx.rehash()
+
+        # Spends an outpoint that has never existed, so CheckTxInputs rejects it
+        # and ConnectBlock returns while the queue behind it is still full.
+        missing = CTransaction()
+        missing.vin.append(CTxIn(COutPoint(0xdead_beef, 0)))
+        missing.vout.append(CTxOut(0, CScript([OP_RETURN])))
+        missing.calc_sha256()
+
+        height = node.getblockcount() + 1
+        block = create_block(
+            int(node.getbestblockhash(), 16),
+            create_coinbase(height),
+            txlist=[big_tx, missing],
+        )
+        add_witness_commitment(block)
+        block.solve()
+
+        self.log.info("Submitting; ConnectBlock must reject it and stay alive")
+        assert_equal(node.submitblock(block.serialize().hex()),
+                     "bad-txns-inputs-missingorspent")
+
+        # If the node died the next call raises rather than returning.
+        assert_equal(node.getblockcount(), height - 1)
+        self.log.info("Node survived and the chain is unchanged")
+
+
+if __name__ == '__main__':
+    Cve202452911Test().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -113,6 +113,7 @@ BASE_SCRIPTS = [
     'feature_p2mr_dilithium_multisig.py',
     'feature_p2mr_rpc.py --descriptors',
     'feature_block.py',
+    'feature_cve_2024_52911.py',
     'btq_regtest_mining.py',
     'btq_chain_identity.py',
     # vv Tests less than 2m vv


### PR DESCRIPTION
First of the six backports tracked in #120, and the only High. Taken alone, as that issue asks.

## The defect

`ConnectBlock` dispatches script checks to background threads as `CScriptCheck` functors. Each holds a **pointer** into a `PrecomputedTransactionData`, so that data has to outlive the check queue. Our tree declared them the wrong way round:

```cpp
CCheckQueueControl<CScriptCheck> control(...);              // constructed first
std::vector<PrecomputedTransactionData> txsdata(...);       // constructed second
```

Local objects are destroyed in reverse order of construction, so `txsdata` is freed **first** and `~CCheckQueueControl` then calls `Wait()` — which drains the queue — on threads reading memory that is already gone.

The comment directly above those two lines already said *"keep txsdata in scope for as long as `control`"*. The intent was right; the declaration order silently defeated it.

This is harmless when the block is valid, because `control.Wait()` is called explicitly at line 2474 before the function returns. It is not harmless on an early return. There are **six** between the declarations and that call:

| Line | Rejection |
| --- | --- |
| 2407 | `Consensus::CheckTxInputs` failed |
| 2412 | `bad-txns-accumulated-fee-outofrange` |
| 2425 | `bad-txns-nonfinal` |
| 2436 | `bad-blk-sigops` |
| 2448 | `CheckInputScripts` failed |
| 2471 | `bad-cb-amount` |

The last one is notable: it fires *after* every transaction in the block has already had its checks queued. An attacker able to mine a block at the tip could crash a node with any of them.

## The fix

Declare `txsdata` before `control`. That is the entire change.

This is upstream [1ed799fb](https://github.com/bitcoin/bitcoin/commit/1ed799fb21db51a12cbd5579420a61b9b5b3ee7d) (\"validation: correct lifetime of precomputed tx data\", [PR #35209](https://github.com/bitcoin/bitcoin/pull/35209)), which fixes the root cause. Note it is *not* the fix that shipped in 29.0 — that one ([#31112](https://github.com/bitcoin/bitcoin/pull/31112)) was a covert workaround that removed the early returns instead. The later cleanup is both smaller and the one upstream deliberately kept backport-friendly; it is what they backported to 31.x, 30.x, 29.x and 28.x.

Upstream declares `control` as a `std::optional`, which we do not, so the change here is the two lines swapped rather than a clean cherry-pick. The comment is extended to say *why* the order matters, since nothing else in the code expresses it.

## Verification

Built with \`--with-sanitizers=address\` and reproduced before and after.

**Before**, the node dies and ASan reports:

\`\`\`
ERROR: AddressSanitizer: heap-use-after-free on address 0x5180001c02a9
READ of size 1 at 0x5180001c02a9 thread T1 (b-scriptch.0)
    #0 SignatureHash<CTransaction>(...) script/interpreter.cpp:1795
    #1 GenericTransactionSignatureChecker<...>::CheckECDSASignature(...)
    #4 EvalScript(...) script/interpreter.cpp:1123
    #7 VerifyScript(...) script/interpreter.cpp:2334
    #8 CScriptCheck::operator()() validation.cpp:1816
    #9 CCheckQueue<CScriptCheck>::Loop(bool) checkqueue.h:123

0x5180001c02a9 is located 553 bytes inside of 888-byte region
freed by thread T7 (b-httpworker.3) here:
    #4 std::_Vector_base<PrecomputedTransactionData, ...>::~_Vector_base()
\`\`\`

A background script-check worker reading data freed by the thread running `ConnectBlock`. **After**, the same test is clean.

## About the test

Getting the read to happen is fussier than it looks, and the block in `feature_cve_2024_52911.py` is shaped around three conditions that all have to hold at once. Each of these was found by getting it wrong first:

1. **The queue must be deep at the instant of the return.** One transaction with 400 inputs queues a large batch in a single `control.Add()`, and the *next* transaction is rejected. Padding the block with ordinary transactions instead gives the worker time to drain the queue while the main thread grinds through the rest of the loop, and nothing is observable.

2. **The inputs must use a segwit sighash.** BIP143 reads the cached midstate out of `PrecomputedTransactionData`. Legacy P2PK and P2PKH sighashes never touch it, so a block full of those leaves the pointer dangling but never dereferences it. My first attempt used P2PK precisely because ECDSA verification is slow, which was exactly the wrong choice.

3. **The transaction must not be in the mempool.** `ConnectBlock` consults the script execution cache first, and a hit means no checks are queued at all — so the transaction is signed in the test rather than broadcast.

Also worth recording: at \`-par=1\` there are **zero** worker threads, because \`-par\` counts the main thread. \`parallel_script_checks\` is then false, no checks are queued, and the bug cannot appear at all. The test uses \`-par=2\`.

Under a normal build the freed read is silent, so the test asserts only that the block is rejected and the node survives. Running it under ASan is what makes it a real regression test, and the docstring says how.

## Testing

- New: \`feature_cve_2024_52911.py\` — passes; fails under ASan without the fix.
- Unit suite: 733 cases, no errors.
- \`feature_block.py\` passes.
- \`feature_assumevalid.py\`, \`p2p_segwit.py\` and \`rpc_blockchain.py\` fail, and fail identically on \`origin/master\` at 5ce8e10bd. Pre-existing, not touched by this change.

## Remaining in #120

Five to go, all mechanical by comparison: CVE-2025-46598, CVE-2025-54604, CVE-2025-54605 (Medium) and CVE-2024-52919, CVE-2025-46597 (Low).

Closes nothing on its own; #120 stays open until all six land.