### PR TITLE
backport: CVE-2025-46597 — cap -maxmempool on 32-bit systems

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -111,6 +111,7 @@ BTQ_TESTS =\
   test/key_io_tests.cpp \
   test/key_tests.cpp \
   test/logging_tests.cpp \
+  test/mempool_args_tests.cpp \
   test/mempool_tests.cpp \
   test/merkle_tests.cpp \
   test/merkleblock_tests.cpp \

--- a/src/node/mempool_args.cpp
+++ b/src/node/mempool_args.cpp
@@ -37,11 +37,23 @@ void ApplyArgsManOptions(const ArgsManager& argsman, MemPoolLimits& mempool_limi
 }
 }
 
+util::Result<void> CheckMaxMempoolSize(int64_t mb, bool is_32bit)
+{
+    if (is_32bit && mb > MAX_32BIT_MEMPOOL_MB) {
+        return util::Error{Untranslated(strprintf(
+            "-maxmempool is set to %i but can't be over %i MB on 32-bit systems", mb, MAX_32BIT_MEMPOOL_MB))};
+    }
+    return {};
+}
+
 util::Result<void> ApplyArgsManOptions(const ArgsManager& argsman, const CChainParams& chainparams, MemPoolOptions& mempool_opts)
 {
     mempool_opts.check_ratio = argsman.GetIntArg("-checkmempool", mempool_opts.check_ratio);
 
-    if (auto mb = argsman.GetIntArg("-maxmempool")) mempool_opts.max_size_bytes = *mb * 1'000'000;
+    if (auto mb = argsman.GetIntArg("-maxmempool")) {
+        if (auto result{CheckMaxMempoolSize(*mb, sizeof(void*) == 4)}; !result) return result;
+        mempool_opts.max_size_bytes = *mb * 1'000'000;
+    }
 
     if (auto hours = argsman.GetIntArg("-mempoolexpiry")) mempool_opts.expiry = std::chrono::hours{*hours};
 

--- a/src/node/mempool_args.h
+++ b/src/node/mempool_args.h
@@ -7,12 +7,32 @@
 
 #include <util/result.h>
 
+#include <cstdint>
+
 class ArgsManager;
 class CChainParams;
 struct bilingual_str;
 namespace kernel {
 struct MemPoolOptions;
 };
+
+//! Largest -maxmempool, in MB, accepted on a 32-bit build.
+static constexpr int64_t MAX_32BIT_MEMPOOL_MB{500};
+
+/**
+ * Reject a -maxmempool that a 32-bit build cannot safely carry.
+ *
+ * The whole address space is 4 GiB there. A mempool large enough to
+ * reconstruct a compact block of over 1 GB overflows the size arithmetic done
+ * before the block is written to disk, crashing the node (CVE-2025-46597).
+ * Capping the mempool removes the precondition, which is how upstream chose to
+ * close it.
+ *
+ * Taking `is_32bit` as an argument rather than testing sizeof(void*) inline is
+ * what makes this testable: on a 64-bit host the interesting branch would
+ * otherwise be eliminated at compile time and never run.
+ */
+[[nodiscard]] util::Result<void> CheckMaxMempoolSize(int64_t mb, bool is_32bit);
 
 /**
  * Overlay the options set in \p argsman on top of corresponding members in \p mempool_opts.

--- a/src/test/mempool_args_tests.cpp
+++ b/src/test/mempool_args_tests.cpp
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 The BTQ Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+//! Tests for the -maxmempool ceiling that closes CVE-2025-46597.
+//!
+//! On a 32-bit build the address space is 4 GiB, and a mempool large enough to
+//! reconstruct a compact block of over 1 GB overflows the size arithmetic done
+//! before the block is written to disk. Capping -maxmempool removes the
+//! precondition.
+//!
+//! The check takes the architecture as an argument precisely so it can be
+//! exercised here. Testing sizeof(void*) inline would leave the 32-bit branch
+//! compiled out and unrun on every machine this suite is likely to run on,
+//! which is the same shape of untested guard the cap exists to replace.
+
+#include <node/mempool_args.h>
+
+#include <test/util/setup_common.h>
+#include <util/result.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <cstdint>
+#include <initializer_list>
+#include <string>
+
+BOOST_FIXTURE_TEST_SUITE(mempool_args_tests, BasicTestingSetup)
+
+//! A 64-bit build takes any size, including ones far past the 32-bit ceiling.
+BOOST_AUTO_TEST_CASE(maxmempool_is_unrestricted_on_64bit)
+{
+    for (const int64_t mb : std::initializer_list<int64_t>{0, 5, 300, MAX_32BIT_MEMPOOL_MB, MAX_32BIT_MEMPOOL_MB + 1, 4000, 100000}) {
+        BOOST_CHECK_MESSAGE(CheckMaxMempoolSize(mb, /*is_32bit=*/false),
+                            "-maxmempool=" + std::to_string(mb) + " was rejected on a 64-bit build");
+    }
+}
+
+//! A 32-bit build accepts everything up to and including the ceiling.
+BOOST_AUTO_TEST_CASE(maxmempool_allows_up_to_the_ceiling_on_32bit)
+{
+    for (const int64_t mb : std::initializer_list<int64_t>{0, 1, 300, MAX_32BIT_MEMPOOL_MB - 1, MAX_32BIT_MEMPOOL_MB}) {
+        BOOST_CHECK_MESSAGE(CheckMaxMempoolSize(mb, /*is_32bit=*/true),
+                            "-maxmempool=" + std::to_string(mb) + " was rejected below the 32-bit ceiling");
+    }
+}
+
+//! And refuses anything past it. Without this the node starts, fills a mempool
+//! it cannot address, and dies later on a block it cannot write.
+BOOST_AUTO_TEST_CASE(maxmempool_is_capped_on_32bit)
+{
+    for (const int64_t mb : std::initializer_list<int64_t>{MAX_32BIT_MEMPOOL_MB + 1, 1000, 3001, 100000}) {
+        const auto result{CheckMaxMempoolSize(mb, /*is_32bit=*/true)};
+        BOOST_CHECK_MESSAGE(!result,
+                            "-maxmempool=" + std::to_string(mb) + " was accepted on a 32-bit build");
+        // The operator has to be told what to change, not just that it failed.
+        const std::string message{util::ErrorString(result).original};
+        BOOST_CHECK_MESSAGE(message.find(std::to_string(MAX_32BIT_MEMPOOL_MB)) != std::string::npos,
+                            "error does not mention the limit: " + message);
+        BOOST_CHECK_MESSAGE(message.find("32-bit") != std::string::npos,
+                            "error does not mention the architecture: " + message);
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Second of the six in #120, after #135.

## The defect

A 32-bit build has 4 GiB of address space. The size arithmetic done before a block is written to disk overflows for blocks over 1 GB. Such a block cannot arrive in a `BLOCK` message, but it can be *reconstructed* from a compact block if the victim's mempool already holds that much — which needs `-maxmempool` above 3 GB on a machine that has at most 4 GiB.

Upstream did not fix the overflow. They removed the precondition by capping `-maxmempool`, and this backport does the same.

## Applicability

Confirmed rather than assumed:

- `src/node/mempool_args.cpp` had upstream's pre-fix line unchanged: `if (auto mb = argsman.GetIntArg(\"-maxmempool\")) mempool_opts.max_size_bytes = *mb * 1'000'000;` — no ceiling at all.
- `depends/hosts/` carries 32-bit toolchains (`i686_freebsd_CC=clang -m32` and friends), so this is not hypothetical for us.

## Only half of upstream's PR is needed

[PR #32530](https://github.com/bitcoin/bitcoin/pull/32530) has two commits. Only the first applies.

The second caps `-dbcache` on the same 4 GiB reasoning, and **26.0 already has that protection** — `src/txdb.h` still carries `nMaxDbCache = sizeof(void*) > 4 ? 16384 : 1024`. Upstream lost it in a later refactor of `CalculateCacheSizes` and the commit was restoring it. Backporting it here would be re-adding something we never lost.

## A small deliberate deviation, for testability

Upstream writes the check inline:

\`\`\`cpp
constexpr bool is_32bit{sizeof(void*) == 4};
if (is_32bit && *mb > MAX_32BIT_MEMPOOL_MB) { ... }
\`\`\`

On a 64-bit host that branch is eliminated at compile time, so the guard never runs anywhere this test suite realistically runs. Given the whole point is to replace an unchecked path, shipping it permanently unexercised seemed like the wrong trade.

So the predicate is a small function taking the architecture as an argument, and `ApplyArgsManOptions` passes `sizeof(void*) == 4`. Behaviour on both architectures is identical to upstream; the difference is that both branches are now reachable from a test.

## Testing

New `mempool_args_tests` with three cases: unrestricted on 64-bit, accepted up to and including the ceiling on 32-bit, refused past it — the last also asserting the error names both the limit and the architecture, since an operator who hits this needs to know what to change.

Mutation-checked by neutering the cap, which produces 12 failures; clean when restored.

Full unit suite: 736 cases, no errors (733 before, plus these three).

## Note on severity

#120's table lists this as Low, which matches. Worth flagging separately that the same table lists CVE-2025-46598, CVE-2025-54604 and CVE-2025-54605 as **Medium**, but all three advisory pages rate them **Low**. Only CVE-2024-52911, already fixed in #135, was High. The remaining four are all Low.

Refs #120.