### PR TITLE
backport: CVE-2024-52919 — widen the addrman entry id past 32 bits

### DIFF
--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -186,7 +186,7 @@ void AddrManImpl::Serialize(Stream& s_) const
 
     int nUBuckets = ADDRMAN_NEW_BUCKET_COUNT ^ (1 << 30);
     s << nUBuckets;
-    std::unordered_map<int, int> mapUnkIds;
+    std::unordered_map<nid_type, int> mapUnkIds;
     int nIds = 0;
     for (const auto& entry : mapInfo) {
         mapUnkIds[entry.first] = nIds;
@@ -396,7 +396,7 @@ void AddrManImpl::Unserialize(Stream& s_)
     }
 }
 
-AddrInfo* AddrManImpl::Find(const CService& addr, int* pnId)
+AddrInfo* AddrManImpl::Find(const CService& addr, nid_type* pnId)
 {
     AssertLockHeld(cs);
 
@@ -411,11 +411,11 @@ AddrInfo* AddrManImpl::Find(const CService& addr, int* pnId)
     return nullptr;
 }
 
-AddrInfo* AddrManImpl::Create(const CAddress& addr, const CNetAddr& addrSource, int* pnId)
+AddrInfo* AddrManImpl::Create(const CAddress& addr, const CNetAddr& addrSource, nid_type* pnId)
 {
     AssertLockHeld(cs);
 
-    int nId = nIdCount++;
+    nid_type nId = nIdCount++;
     mapInfo[nId] = AddrInfo(addr, addrSource);
     mapAddr[addr] = nId;
     mapInfo[nId].nRandomPos = vRandom.size();
@@ -436,8 +436,8 @@ void AddrManImpl::SwapRandom(unsigned int nRndPos1, unsigned int nRndPos2) const
 
     assert(nRndPos1 < vRandom.size() && nRndPos2 < vRandom.size());
 
-    int nId1 = vRandom[nRndPos1];
-    int nId2 = vRandom[nRndPos2];
+    nid_type nId1 = vRandom[nRndPos1];
+    nid_type nId2 = vRandom[nRndPos2];
 
     const auto it_1{mapInfo.find(nId1)};
     const auto it_2{mapInfo.find(nId2)};
@@ -451,7 +451,7 @@ void AddrManImpl::SwapRandom(unsigned int nRndPos1, unsigned int nRndPos2) const
     vRandom[nRndPos2] = nId1;
 }
 
-void AddrManImpl::Delete(int nId)
+void AddrManImpl::Delete(nid_type nId)
 {
     AssertLockHeld(cs);
 
@@ -474,7 +474,7 @@ void AddrManImpl::ClearNew(int nUBucket, int nUBucketPos)
 
     // if there is an entry in the specified bucket, delete it.
     if (vvNew[nUBucket][nUBucketPos] != -1) {
-        int nIdDelete = vvNew[nUBucket][nUBucketPos];
+        nid_type nIdDelete = vvNew[nUBucket][nUBucketPos];
         AddrInfo& infoDelete = mapInfo[nIdDelete];
         assert(infoDelete.nRefCount > 0);
         infoDelete.nRefCount--;
@@ -486,7 +486,7 @@ void AddrManImpl::ClearNew(int nUBucket, int nUBucketPos)
     }
 }
 
-void AddrManImpl::MakeTried(AddrInfo& info, int nId)
+void AddrManImpl::MakeTried(AddrInfo& info, nid_type nId)
 {
     AssertLockHeld(cs);
 
@@ -513,7 +513,7 @@ void AddrManImpl::MakeTried(AddrInfo& info, int nId)
     // first make space to add it (the existing tried entry there is moved to new, deleting whatever is there).
     if (vvTried[nKBucket][nKBucketPos] != -1) {
         // find an item to evict
-        int nIdEvict = vvTried[nKBucket][nKBucketPos];
+        nid_type nIdEvict = vvTried[nKBucket][nKBucketPos];
         assert(mapInfo.count(nIdEvict) == 1);
         AddrInfo& infoOld = mapInfo[nIdEvict];
 
@@ -552,7 +552,7 @@ bool AddrManImpl::AddSingle(const CAddress& addr, const CNetAddr& source, std::c
     if (!addr.IsRoutable())
         return false;
 
-    int nId;
+    nid_type nId;
     AddrInfo* pinfo = Find(addr, &nId);
 
     // Do not set a penalty for a source's self-announcement
@@ -625,7 +625,7 @@ bool AddrManImpl::Good_(const CService& addr, bool test_before_evict, NodeSecond
 {
     AssertLockHeld(cs);
 
-    int nId;
+    nid_type nId;
 
     m_last_good = time;
 

--- a/src/addrman_impl.h
+++ b/src/addrman_impl.h
@@ -33,6 +33,15 @@ static constexpr int ADDRMAN_NEW_BUCKET_COUNT{1 << ADDRMAN_NEW_BUCKET_COUNT_LOG2
 static constexpr int32_t ADDRMAN_BUCKET_SIZE_LOG2{6};
 static constexpr int ADDRMAN_BUCKET_SIZE{1 << ADDRMAN_BUCKET_SIZE_LOG2};
 
+/** User-defined type for the internally used nIds
+ *
+ * Deliberately wider than the bucket indices it used to share a type with.
+ * nIdCount only ever increases, so a 32-bit counter wraps after 2^31
+ * insertions and the negative id that follows collides with the -1 sentinel
+ * used for empty bucket positions, tripping an assert. See CVE-2024-52919.
+ */
+using nid_type = int64_t;
+
 /**
  * Extended statistics about a CAddress
  */
@@ -180,30 +189,30 @@ private:
     static constexpr uint8_t INCOMPATIBILITY_BASE = 32;
 
     //! last used nId
-    int nIdCount GUARDED_BY(cs){0};
+    nid_type nIdCount GUARDED_BY(cs){0};
 
     //! table with information about all nIds
-    std::unordered_map<int, AddrInfo> mapInfo GUARDED_BY(cs);
+    std::unordered_map<nid_type, AddrInfo> mapInfo GUARDED_BY(cs);
 
     //! find an nId based on its network address and port.
-    std::unordered_map<CService, int, CServiceHash> mapAddr GUARDED_BY(cs);
+    std::unordered_map<CService, nid_type, CServiceHash> mapAddr GUARDED_BY(cs);
 
     //! randomly-ordered vector of all nIds
     //! This is mutable because it is unobservable outside the class, so any
     //! changes to it (even in const methods) are also unobservable.
-    mutable std::vector<int> vRandom GUARDED_BY(cs);
+    mutable std::vector<nid_type> vRandom GUARDED_BY(cs);
 
     // number of "tried" entries
     int nTried GUARDED_BY(cs){0};
 
     //! list of "tried" buckets
-    int vvTried[ADDRMAN_TRIED_BUCKET_COUNT][ADDRMAN_BUCKET_SIZE] GUARDED_BY(cs);
+    nid_type vvTried[ADDRMAN_TRIED_BUCKET_COUNT][ADDRMAN_BUCKET_SIZE] GUARDED_BY(cs);
 
     //! number of (unique) "new" entries
     int nNew GUARDED_BY(cs){0};
 
     //! list of "new" buckets
-    int vvNew[ADDRMAN_NEW_BUCKET_COUNT][ADDRMAN_BUCKET_SIZE] GUARDED_BY(cs);
+    nid_type vvNew[ADDRMAN_NEW_BUCKET_COUNT][ADDRMAN_BUCKET_SIZE] GUARDED_BY(cs);
 
     //! last time Good was called (memory only). Initially set to 1 so that "never" is strictly worse.
     NodeSeconds m_last_good GUARDED_BY(cs){1s};
@@ -226,22 +235,22 @@ private:
     std::unordered_map<Network, NewTriedCount> m_network_counts GUARDED_BY(cs);
 
     //! Find an entry.
-    AddrInfo* Find(const CService& addr, int* pnId = nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    AddrInfo* Find(const CService& addr, nid_type* pnId = nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     //! Create a new entry and add it to the internal data structures mapInfo, mapAddr and vRandom.
-    AddrInfo* Create(const CAddress& addr, const CNetAddr& addrSource, int* pnId = nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    AddrInfo* Create(const CAddress& addr, const CNetAddr& addrSource, nid_type* pnId = nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     //! Swap two elements in vRandom.
     void SwapRandom(unsigned int nRandomPos1, unsigned int nRandomPos2) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     //! Delete an entry. It must not be in tried, and have refcount 0.
-    void Delete(int nId) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void Delete(nid_type nId) EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     //! Clear a position in a "new" table. This is the only place where entries are actually deleted.
     void ClearNew(int nUBucket, int nUBucketPos) EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     //! Move an entry from the "new" table(s) to the "tried" table
-    void MakeTried(AddrInfo& info, int nId) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void MakeTried(AddrInfo& info, nid_type nId) EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /** Attempt to add a single address to addrman's new table.
      *  @see AddrMan::Add() for parameters. */

--- a/src/test/addrman_tests.cpp
+++ b/src/test/addrman_tests.cpp
@@ -17,8 +17,11 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <cstdint>
+#include <limits>
 #include <optional>
 #include <string>
+#include <type_traits>
 
 using namespace std::literals;
 using node::NodeContext;
@@ -1115,6 +1118,35 @@ BOOST_AUTO_TEST_CASE(addrman_size)
     BOOST_CHECK_EQUAL(addrman->Size(/*net=*/NET_I2P, /*in_new=*/true), 1U);
     BOOST_CHECK_EQUAL(addrman->Size(/*net=*/std::nullopt, /*in_new=*/true), 2U);
     BOOST_CHECK_EQUAL(addrman->Size(/*net=*/std::nullopt, /*in_new=*/false), 1U);
+}
+
+//! The internal entry id must outlast a 32-bit insertion counter.
+//!
+//! nIdCount only ever increases, one per address inserted. At 32 bits it wraps
+//! to negative after 2^31 insertions, and -1 is the sentinel stored in vvNew
+//! and vvTried for "this bucket position is empty". The entry that lands on -1
+//! is therefore read back as an empty slot, and the node asserts. Rate
+//! limiting (one address per peer per ten seconds) made reaching that count
+//! expensive rather than impossible, which is why CVE-2024-52919 needed a
+//! second fix: widening the counter so it cannot be reached at all.
+//!
+//! Actually exhausting 2^31 insertions is not testable -- upstream measured it
+//! at over a year with a thousand attacking peers -- so what is pinned here is
+//! the property that makes it unreachable. This is the assertion that fails if
+//! someone narrows the type back.
+BOOST_AUTO_TEST_CASE(addrman_nid_outlasts_a_32bit_counter)
+{
+    static_assert(std::is_signed_v<nid_type>,
+                  "nid_type is compared against the -1 empty-bucket sentinel");
+    static_assert(std::numeric_limits<nid_type>::max() > std::numeric_limits<int32_t>::max(),
+                  "nid_type must be wider than 32 bits (CVE-2024-52919)");
+
+    // One past where the old counter wrapped: still positive, and still
+    // distinguishable from an empty bucket position.
+    nid_type id{std::numeric_limits<int32_t>::max()};
+    ++id;
+    BOOST_CHECK_GT(id, nid_type{std::numeric_limits<int32_t>::max()});
+    BOOST_CHECK_NE(id, nid_type{-1});
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Third of the six in #120, after #135 and #136.

## The defect

`nIdCount` is addrman's internal entry counter. It only ever increases, one per address inserted, and it was an `int`. At 32 bits it wraps to negative after 2^31 insertions — and `-1` is the sentinel stored in `vvNew` and `vvTried` meaning *this bucket position is empty*. The entry that lands on `-1` is read back as an empty slot, and the node asserts.

Confirmed present: `src/addrman_impl.h` had `int nIdCount GUARDED_BY(cs){0};`, with `mapInfo`, `mapAddr`, `vRandom`, `vvNew` and `vvTried` all keyed on `int` to match.

This is the *second* fix for this CVE. v22.0 rate-limited insertions to one address per peer per ten seconds, which made the count expensive to reach rather than impossible — upstream measured over a year with a thousand attacking peers. Widening the counter is what actually closes it, and that shipped in 29.0.

## Applied by hand, not cherry-picked

[PR #30568](https://github.com/bitcoin/bitcoin/pull/30568) does not apply: it is written against a much later tree, and BTQ has renamed symbols through addrman (`d7344fcbb merge rename manually`). \`git apply --check\` fails on the first hunk.

Both upstream commits are reproduced rather than collapsed into one — first the `nid_type` alias, then the widening to `int64_t` — so the change stays legible as a type change rather than a diff that touches thirty unrelated-looking lines.

Everything that holds an entry id moves: the counter, `mapInfo`'s key, `mapAddr`'s value, `vRandom`'s elements, both bucket arrays, and the `Find`/`Create`/`Delete`/`SwapRandom`/`ClearNew`/`MakeTried` signatures. The one `int` left alone is `int nIds` in `Serialize()`, which counts entries rather than identifying one — upstream leaves it too.

## The on-disk format is untouched

Worth being explicit, since widening a field that gets serialised would be a quiet way to break every existing `peers.dat`.

It does not get serialised. `Serialize()` remaps entry ids to sequential indices through `mapUnkIds`, and that map's **value** type stays `int` — only its key widens. The bytes written are unchanged. `feature_addrman.py`, which round-trips `peers.dat`, passes.

## Testing

Exhausting 2^31 insertions is not testable, so the new case in `addrman_tests` pins the property that makes it unreachable: `nid_type` is signed, is wider than 32 bits, and one past the old wrap point is still positive and still distinguishable from the `-1` empty-bucket sentinel. That is the assertion that fires if someone narrows it back, which is the realistic regression.

`AddrManDeterministic` — the existing friend that could reach `nIdCount` directly — lives in `src/test/fuzz/addrman.cpp` and is not available to the unit suite. Adding a second friend to the production header for a Low-severity type widening seemed a worse trade than testing the invariant.

- `addrman_tests`: 23 cases, no errors.
- Full unit suite: 734 cases, no errors.
- `feature_addrman.py`, `rpc_net.py`, `p2p_addrv2_relay.py` pass.
- `p2p_addr_relay.py` fails, and fails identically on `origin/master` at 5ce8e10bd. Pre-existing.

Refs #120.