### PR TITLE
backport: CVE-2025-54604 and CVE-2025-54605 — rate-limit unconditional logging

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1148,6 +1148,16 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         }
     }, std::chrono::minutes{5});
 
+    // Rate-limit unconditional logging from here on. It is installed only once
+    // a scheduler exists to reset the windows, which also means startup
+    // logging -- bounded, and useful in full -- is never suppressed.
+    LogInstance().SetRateLimiting(std::make_unique<BCLog::LogRateLimiter>(
+        [&scheduler = *node.scheduler](std::function<void()> func, std::chrono::milliseconds window) {
+            scheduler.scheduleEvery(std::move(func), window);
+        },
+        BCLog::RATELIMIT_MAX_BYTES,
+        BCLog::RATELIMIT_WINDOW));
+
     GetMainSignals().RegisterBackgroundSignalScheduler(*node.scheduler);
 
     // Create client interfaces for wallets that are supposed to be loaded

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -392,9 +392,68 @@ namespace BCLog {
     }
 } // namespace BCLog
 
-void BCLog::Logger::LogPrintStr(const std::string& str, const std::string& logging_function, const std::string& source_file, int source_line, BCLog::LogFlags category, BCLog::Level level)
+BCLog::LogRateLimiter::LogRateLimiter(
+    SchedulerFunction scheduler_func,
+    uint64_t max_bytes,
+    std::chrono::seconds reset_window) : m_max_bytes{max_bytes}, m_reset_window{reset_window}
+{
+    scheduler_func([this] { Reset(); }, reset_window);
+}
+
+bool BCLog::LogLimitStats::Consume(uint64_t bytes)
+{
+    if (bytes > m_available_bytes) {
+        m_dropped_bytes += bytes;
+        m_available_bytes = 0;
+        return false;
+    }
+
+    m_available_bytes -= bytes;
+    return true;
+}
+
+BCLog::LogRateLimiter::Status BCLog::LogRateLimiter::Consume(const LogSource& source, const std::string& str)
+{
+    StdLockGuard scoped_lock(m_mutex);
+    auto& counter{m_source_locations.try_emplace(source, m_max_bytes).first->second};
+    Status status{counter.GetDroppedBytes() > 0 ? Status::STILL_SUPPRESSED : Status::UNSUPPRESSED};
+
+    if (!counter.Consume(str.size()) && status == Status::UNSUPPRESSED) {
+        status = Status::NEWLY_SUPPRESSED;
+        m_suppression_active = true;
+    }
+
+    return status;
+}
+
+void BCLog::LogRateLimiter::Reset()
+{
+    decltype(m_source_locations) source_locations;
+    {
+        StdLockGuard scoped_lock(m_mutex);
+        source_locations.swap(m_source_locations);
+        m_suppression_active = false;
+    }
+    // Report what was lost, so a gap in the log is never silent.
+    for (const auto& [source, counter] : source_locations) {
+        const uint64_t dropped_bytes{counter.GetDroppedBytes()};
+        if (dropped_bytes == 0) continue;
+        LogPrintf_(__func__, __FILE__, __LINE__, BCLog::LogFlags::ALL, BCLog::Level::Info,
+                   BCLog::RateLimit::No,
+                   "Restarting logging from %s:%d: %d bytes were dropped during the last %ss.\n",
+                   source.file, source.line, dropped_bytes, Ticks<std::chrono::seconds>(m_reset_window));
+    }
+}
+
+void BCLog::Logger::LogPrintStr(const std::string& str, const std::string& logging_function, const std::string& source_file, int source_line, BCLog::LogFlags category, BCLog::Level level, bool should_ratelimit)
 {
     StdLockGuard scoped_lock(m_cs);
+    LogPrintStr_(str, logging_function, source_file, source_line, category, level, should_ratelimit);
+}
+
+// NOLINTNEXTLINE(misc-no-recursion)
+void BCLog::Logger::LogPrintStr_(const std::string& str, const std::string& logging_function, const std::string& source_file, int source_line, BCLog::LogFlags category, BCLog::Level level, bool should_ratelimit)
+{
     std::string str_prefixed = LogEscapeMessage(str);
 
     if ((category != LogFlags::NONE || level != Level::None) && m_started_new_line) {
@@ -436,6 +495,30 @@ void BCLog::Logger::LogPrintStr(const std::string& str, const std::string& loggi
         return;
     }
 
+    bool ratelimit{false};
+    if (should_ratelimit && m_limiter) {
+        const LogSource source{source_file, source_line};
+        const auto status{m_limiter->Consume(source, str_prefixed)};
+        if (status == BCLog::LogRateLimiter::Status::NEWLY_SUPPRESSED) {
+            // should_ratelimit is false here, so this cannot recurse again.
+            // NOLINTNEXTLINE(misc-no-recursion)
+            LogPrintStr_(strprintf("Excessive logging detected from %s:%d: >%d bytes logged during "
+                                   "the last time window of %is. Suppressing logging to disk from "
+                                   "this source location until the window resets. Console logging "
+                                   "unaffected. Last log entry.\n",
+                                   source_file, source_line, m_limiter->m_max_bytes,
+                                   Ticks<std::chrono::seconds>(m_limiter->m_reset_window)),
+                         __func__, __FILE__, __LINE__, BCLog::LogFlags::ALL, BCLog::Level::Warning,
+                         /*should_ratelimit=*/false);
+        }
+        ratelimit = status == BCLog::LogRateLimiter::Status::STILL_SUPPRESSED;
+        // Mark lines written while anything is suppressed, so a reader
+        // debugging from this log knows it is incomplete.
+        if (m_limiter->SuppressionsActive()) {
+            str_prefixed.insert(0, "[*] ");
+        }
+    }
+
     if (m_print_to_console) {
         // print to console
         fwrite(str_prefixed.data(), 1, str_prefixed.size(), stdout);
@@ -444,7 +527,7 @@ void BCLog::Logger::LogPrintStr(const std::string& str, const std::string& loggi
     for (const auto& cb : m_print_callbacks) {
         cb(str_prefixed);
     }
-    if (m_print_to_file) {
+    if (m_print_to_file && !ratelimit) {
         assert(m_fileout != nullptr);
 
         // reopen the log file, if requested

--- a/src/logging.h
+++ b/src/logging.h
@@ -6,15 +6,18 @@
 #ifndef BTQ_LOGGING_H
 #define BTQ_LOGGING_H
 
+#include <crypto/siphash.h>
 #include <threadsafety.h>
 #include <tinyformat.h>
 #include <util/fs.h>
 #include <util/string.h>
 
 #include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <functional>
 #include <list>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <unordered_map>
@@ -32,6 +35,37 @@ extern bool fLogIPs;
 struct LogCategory {
     std::string category;
     bool active;
+};
+
+/**
+ * Identifies the place in the source a log line came from.
+ *
+ * Upstream keys its rate limiter on std::source_location, which is C++20; this
+ * tree still builds as C++17 by default (--enable-c++20 is off). It does not
+ * need it: LogPrintf_ already receives __FILE__ and __LINE__ as arguments, so
+ * the same identity is available without the newer type. File and line alone
+ * are enough -- the function name adds nothing a line number does not already
+ * distinguish.
+ */
+struct LogSource {
+    std::string file;
+    int line;
+
+    bool operator==(const LogSource& other) const noexcept
+    {
+        return line == other.line && file == other.file;
+    }
+};
+
+struct LogSourceHasher {
+    size_t operator()(const LogSource& s) const noexcept
+    {
+        // CSipHasher(0, 0) purely as a cheap way to get a uniform spread.
+        return static_cast<size_t>(CSipHasher(0, 0)
+                                       .Write(std::hash<std::string>{}(s.file))
+                                       .Write(static_cast<uint64_t>(s.line))
+                                       .Finalize());
+    }
 };
 
 namespace BCLog {
@@ -81,6 +115,95 @@ namespace BCLog {
     };
     constexpr auto DEFAULT_LOG_LEVEL{Level::Debug};
 
+    //! Whether a log statement is subject to rate limiting.
+    //!
+    //! Scoped, rather than a bool, because this argument sits immediately
+    //! before the format string and a `const char*` converts to bool without
+    //! complaint. A caller who omits it would otherwise compile cleanly and
+    //! log nonsense -- which is exactly what happened to logging_LogPrintf_
+    //! while this was being written, with no diagnostic from the compiler.
+    enum class RateLimit {
+        No,
+        Yes,
+    };
+
+    //! Bytes a single source location may write to disk within one window.
+    constexpr uint64_t RATELIMIT_MAX_BYTES{1024 * 1024};
+    //! How often the per-location budgets are refilled.
+    constexpr auto RATELIMIT_WINDOW{std::chrono::hours{1}};
+
+    //! Budget for one source location within the current window.
+    class LogLimitStats
+    {
+    private:
+        //! Bytes still available in this window.
+        uint64_t m_available_bytes;
+        //! Bytes this location tried to log after running out.
+        uint64_t m_dropped_bytes{0};
+
+    public:
+        explicit LogLimitStats(uint64_t max_bytes) : m_available_bytes{max_bytes} {}
+
+        //! Deduct `bytes` if the budget covers it. Returns whether it did.
+        bool Consume(uint64_t bytes);
+
+        uint64_t GetAvailableBytes() const { return m_available_bytes; }
+        uint64_t GetDroppedBytes() const { return m_dropped_bytes; }
+    };
+
+    /**
+     * Fixed-window rate limiter for logging, keyed by source location.
+     *
+     * A peer that can make the node log unconditionally can otherwise fill the
+     * operator's disk: a spoofed self-connection (CVE-2025-54604) or a stream
+     * of invalid blocks (CVE-2025-54605) each reach a LogPrintf that has no
+     * cap on how often it fires. Limiting per location rather than per message
+     * is what makes this general -- it covers the next such log site too,
+     * without anyone having to notice it is one.
+     *
+     * Only writes to disk are suppressed. Console output and log callbacks are
+     * left alone, since neither consumes the resource under attack.
+     */
+    class LogRateLimiter
+    {
+    private:
+        mutable StdMutex m_mutex;
+
+        //! Per-location budgets for the current window.
+        std::unordered_map<LogSource, LogLimitStats, LogSourceHasher> m_source_locations GUARDED_BY(m_mutex);
+        //! Whether anything is currently suppressed. A cached view of
+        //! m_source_locations, so the common path need not take the lock.
+        std::atomic<bool> m_suppression_active{false};
+
+    public:
+        using SchedulerFunction = std::function<void(std::function<void()>, std::chrono::milliseconds)>;
+
+        /**
+         * @param scheduler_func Used to schedule the periodic window reset.
+         * @param max_bytes      Budget per source location per window.
+         * @param reset_window   How long a window lasts.
+         */
+        LogRateLimiter(SchedulerFunction scheduler_func, uint64_t max_bytes, std::chrono::seconds reset_window);
+
+        const uint64_t m_max_bytes;
+        const std::chrono::seconds m_reset_window;
+
+        enum class Status {
+            UNSUPPRESSED,     //!< within budget
+            NEWLY_SUPPRESSED, //!< this message is the one that exhausted it
+            STILL_SUPPRESSED, //!< already exhausted earlier in this window
+        };
+
+        //! Charge `str` against `source`'s budget and report the result.
+        [[nodiscard]] Status Consume(const LogSource& source, const std::string& str)
+            EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+
+        //! Refill every budget. Called on the scheduler once per window.
+        void Reset() EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+
+        bool SuppressionsActive() const { return m_suppression_active; }
+    };
+
     class Logger
     {
     private:
@@ -97,6 +220,10 @@ namespace BCLog {
          */
         std::atomic_bool m_started_new_line{true};
 
+        //! Rate limiter for unconditional log locations. Null until AppInitMain
+        //! installs one, so early startup logging is never suppressed.
+        std::unique_ptr<LogRateLimiter> m_limiter GUARDED_BY(m_cs);
+
         //! Category-specific log level. Overrides `m_log_level`.
         std::unordered_map<LogFlags, Level> m_category_log_levels GUARDED_BY(m_cs);
 
@@ -112,6 +239,9 @@ namespace BCLog {
         /** Slots that connect to the print signal */
         std::list<std::function<void(const std::string&)>> m_print_callbacks GUARDED_BY(m_cs) {};
 
+        /** Send a string to the log output, with m_cs already held. */
+        void LogPrintStr_(const std::string& str, const std::string& logging_function, const std::string& source_file, int source_line, BCLog::LogFlags category, BCLog::Level level, bool should_ratelimit) EXCLUSIVE_LOCKS_REQUIRED(m_cs);
+
     public:
         bool m_print_to_console = false;
         bool m_print_to_file = false;
@@ -125,7 +255,14 @@ namespace BCLog {
         std::atomic<bool> m_reopen_file{false};
 
         /** Send a string to the log output */
-        void LogPrintStr(const std::string& str, const std::string& logging_function, const std::string& source_file, int source_line, BCLog::LogFlags category, BCLog::Level level);
+        void LogPrintStr(const std::string& str, const std::string& logging_function, const std::string& source_file, int source_line, BCLog::LogFlags category, BCLog::Level level, bool should_ratelimit);
+
+        /** Install the rate limiter. Passing nullptr disables rate limiting. */
+        void SetRateLimiting(std::unique_ptr<LogRateLimiter>&& limiter)
+        {
+            StdLockGuard scoped_lock(m_cs);
+            m_limiter = std::move(limiter);
+        }
 
         /** Returns whether logs will be written to any output */
         bool Enabled() const
@@ -217,7 +354,7 @@ bool GetLogCategory(BCLog::LogFlags& flag, const std::string& str);
 // peer can fill up a user's disk with debug.log entries.
 
 template <typename... Args>
-static inline void LogPrintf_(const std::string& logging_function, const std::string& source_file, const int source_line, const BCLog::LogFlags flag, const BCLog::Level level, const char* fmt, const Args&... args)
+static inline void LogPrintf_(const std::string& logging_function, const std::string& source_file, const int source_line, const BCLog::LogFlags flag, const BCLog::Level level, const BCLog::RateLimit rate_limit, const char* fmt, const Args&... args)
 {
     if (LogInstance().Enabled()) {
         std::string log_msg;
@@ -227,35 +364,44 @@ static inline void LogPrintf_(const std::string& logging_function, const std::st
             /* Original format string will have newline so don't add one here */
             log_msg = "Error \"" + std::string(fmterr.what()) + "\" while formatting log message: " + fmt;
         }
-        LogInstance().LogPrintStr(log_msg, logging_function, source_file, source_line, flag, level);
+        LogInstance().LogPrintStr(log_msg, logging_function, source_file, source_line, flag, level, rate_limit == BCLog::RateLimit::Yes);
     }
 }
 
-#define LogPrintLevel_(category, level, ...) LogPrintf_(__func__, __FILE__, __LINE__, category, level, __VA_ARGS__)
+#define LogPrintLevel_(category, level, rate_limit, ...) LogPrintf_(__func__, __FILE__, __LINE__, category, level, rate_limit, __VA_ARGS__)
 
-// Log unconditionally.
-#define LogPrintf(...) LogPrintLevel_(BCLog::LogFlags::NONE, BCLog::Level::None, __VA_ARGS__)
+// Log unconditionally. Rate-limited per source location, because a caller here
+// cannot know whether a peer can drive it (see BCLog::LogRateLimiter).
+#define LogPrintf(...) LogPrintLevel_(BCLog::LogFlags::NONE, BCLog::Level::None, BCLog::RateLimit::Yes, __VA_ARGS__)
 
 // Log unconditionally, prefixing the output with the passed category name.
-#define LogPrintfCategory(category, ...) LogPrintLevel_(category, BCLog::Level::None, __VA_ARGS__)
+#define LogPrintfCategory(category, ...) LogPrintLevel_(category, BCLog::Level::None, BCLog::RateLimit::Yes, __VA_ARGS__)
 
 // Use a macro instead of a function for conditional logging to prevent
 // evaluating arguments when logging for the category is not enabled.
 
 // Log conditionally, prefixing the output with the passed category name.
-#define LogPrint(category, ...)                                        \
-    do {                                                               \
-        if (LogAcceptCategory((category), BCLog::Level::Debug)) {      \
-            LogPrintLevel_(category, BCLog::Level::None, __VA_ARGS__); \
-        }                                                              \
+// Not rate-limited: reaching this requires -debug, and an operator who asked
+// for debug output has accepted the volume that comes with it.
+#define LogPrint(category, ...)                                                              \
+    do {                                                                                     \
+        if (LogAcceptCategory((category), BCLog::Level::Debug)) {                            \
+            LogPrintLevel_(category, BCLog::Level::None, BCLog::RateLimit::No, __VA_ARGS__); \
+        }                                                                                    \
     } while (0)
 
 // Log conditionally, prefixing the output with the passed category name and severity level.
-#define LogPrintLevel(category, level, ...)               \
-    do {                                                  \
-        if (LogAcceptCategory((category), (level))) {     \
-            LogPrintLevel_(category, level, __VA_ARGS__); \
-        }                                                 \
+// Info and above pass the default log level without -debug, so they are
+// effectively unconditional and are rate-limited on the same reasoning as
+// LogPrintf. Below Info requires -debug and is not.
+#define LogPrintLevel(category, level, ...)                                       \
+    do {                                                                          \
+        if (LogAcceptCategory((category), (level))) {                             \
+            const auto rate_limit{(level) >= BCLog::Level::Info                   \
+                                      ? BCLog::RateLimit::Yes                     \
+                                      : BCLog::RateLimit::No};                    \
+            LogPrintLevel_(category, level, rate_limit, __VA_ARGS__);             \
+        }                                                                         \
     } while (0)
 
 template <typename... Args>

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -6,11 +6,17 @@
 #include <logging.h>
 #include <logging/timer.h>
 #include <test/util/setup_common.h>
+#include <util/fs_helpers.h>
 #include <util/string.h>
 
 #include <chrono>
+#include <cstdint>
 #include <fstream>
+#include <functional>
+#include <ios>
 #include <iostream>
+#include <memory>
+#include <string>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -83,10 +89,10 @@ BOOST_AUTO_TEST_CASE(logging_timer)
 BOOST_FIXTURE_TEST_CASE(logging_LogPrintf_, LogSetup)
 {
     LogInstance().m_log_sourcelocations = true;
-    LogPrintf_("fn1", "src1", 1, BCLog::LogFlags::NET, BCLog::Level::Debug, "foo1: %s\n", "bar1");
-    LogPrintf_("fn2", "src2", 2, BCLog::LogFlags::NET, BCLog::Level::None, "foo2: %s\n", "bar2");
-    LogPrintf_("fn3", "src3", 3, BCLog::LogFlags::NONE, BCLog::Level::Debug, "foo3: %s\n", "bar3");
-    LogPrintf_("fn4", "src4", 4, BCLog::LogFlags::NONE, BCLog::Level::None, "foo4: %s\n", "bar4");
+    LogPrintf_("fn1", "src1", 1, BCLog::LogFlags::NET, BCLog::Level::Debug, BCLog::RateLimit::No, "foo1: %s\n", "bar1");
+    LogPrintf_("fn2", "src2", 2, BCLog::LogFlags::NET, BCLog::Level::None, BCLog::RateLimit::No, "foo2: %s\n", "bar2");
+    LogPrintf_("fn3", "src3", 3, BCLog::LogFlags::NONE, BCLog::Level::Debug, BCLog::RateLimit::No, "foo3: %s\n", "bar3");
+    LogPrintf_("fn4", "src4", 4, BCLog::LogFlags::NONE, BCLog::Level::None, BCLog::RateLimit::No, "foo4: %s\n", "bar4");
     std::ifstream file{tmp_log_path};
     std::vector<std::string> log_lines;
     for (std::string log; std::getline(file, log);) {
@@ -249,6 +255,145 @@ BOOST_FIXTURE_TEST_CASE(logging_Conf, LogSetup)
         BOOST_CHECK(http_it != category_levels.end());
         BOOST_CHECK_EQUAL(http_it->second, BCLog::Level::Info);
     }
+}
+
+//! Budget arithmetic for a single source location.
+BOOST_AUTO_TEST_CASE(logging_log_limit_stats)
+{
+    BCLog::LogLimitStats counter{500};
+    BOOST_CHECK_EQUAL(counter.GetAvailableBytes(), 500ull);
+    BOOST_CHECK_EQUAL(counter.GetDroppedBytes(), 0ull);
+
+    BOOST_CHECK(counter.Consume(200));
+    BOOST_CHECK_EQUAL(counter.GetAvailableBytes(), 300ull);
+
+    // Exactly exhausting the budget still counts as a success: the bytes fit.
+    BOOST_CHECK(counter.Consume(300));
+    BOOST_CHECK_EQUAL(counter.GetAvailableBytes(), 0ull);
+    BOOST_CHECK_EQUAL(counter.GetDroppedBytes(), 0ull);
+
+    // One byte past, and everything after it, is accounted as dropped rather
+    // than silently discarded -- the reset message reports the total.
+    BOOST_CHECK(!counter.Consume(1));
+    BOOST_CHECK_EQUAL(counter.GetDroppedBytes(), 1ull);
+    BOOST_CHECK(!counter.Consume(500));
+    BOOST_CHECK_EQUAL(counter.GetDroppedBytes(), 501ull);
+}
+
+namespace {
+//! Each case is a distinct source location, so each gets its own budget.
+//! Cases 0 and 1 are deliberately identical statements in different places.
+void LogFromLocation(int location, const std::string& message)
+{
+    switch (location) {
+    case 0:
+        LogPrintf("%s\n", message);
+        break;
+    case 1:
+        LogPrintf("%s\n", message);
+        break;
+    case 2:
+        LogPrint(BCLog::NET, "%s\n", message);
+        break;
+    }
+}
+
+struct RateLimitSetup : public LogSetup {
+    //! Small enough to keep the test quick, large enough that a line fits.
+    static constexpr uint64_t BUDGET{16 * 1024};
+    //! Lines of exactly 1 KiB, so the budget is a line count.
+    static constexpr int LINES_IN_BUDGET{static_cast<int>(BUDGET / 1024)};
+
+    BCLog::LogRateLimiter* limiter{nullptr};
+
+    RateLimitSetup()
+    {
+        // No scheduler: the test calls Reset() itself rather than waiting an
+        // hour or mocking time.
+        auto owned{std::make_unique<BCLog::LogRateLimiter>(
+            [](std::function<void()>, std::chrono::milliseconds) {},
+            BUDGET, std::chrono::seconds{3600})};
+        limiter = owned.get();
+        LogInstance().SetRateLimiting(std::move(owned));
+        LogInstance().EnableCategory(BCLog::NET);
+    }
+
+    ~RateLimitSetup()
+    {
+        LogInstance().DisableCategory(BCLog::NET);
+        // Must happen before ~LogSetup, which logs a sentinel line.
+        LogInstance().SetRateLimiting(nullptr);
+        limiter = nullptr;
+    }
+
+    std::streamsize LogFileSize() const
+    {
+        return static_cast<std::streamsize>(GetFileSize(fs::PathToString(tmp_log_path).c_str()));
+    }
+
+    bool LogContains(const std::string& needle) const
+    {
+        std::ifstream file{tmp_log_path};
+        std::string line;
+        while (std::getline(file, line)) {
+            if (line.find(needle) != std::string::npos) return true;
+        }
+        return false;
+    }
+};
+} // namespace
+
+//! A single log location that a peer can drive must not be able to fill the
+//! disk, and must not take the rest of the log down with it.
+//!
+//! This is what closes CVE-2025-54604 (a spoofed self-connection reaching the
+//! unconditional "connected to self" LogPrintf) and CVE-2025-54605 (repeated
+//! invalid blocks reaching the unconditional failure logs). Both are the same
+//! defect -- an attacker-reachable log site with no ceiling -- so the fix is
+//! per-location rather than per-message, and covers the next such site too.
+BOOST_FIXTURE_TEST_CASE(logging_rate_limit, RateLimitSetup)
+{
+    // 1023 characters plus the newline the format string adds.
+    const std::string line(1023, 'a');
+
+    // A full budget's worth gets through untouched.
+    std::streamsize size{LogFileSize()};
+    for (int i = 0; i < LINES_IN_BUDGET; ++i) LogFromLocation(0, line);
+    BOOST_CHECK_MESSAGE(LogFileSize() > size, "a location within its budget must reach disk");
+
+    // The line that exceeds it is still written, and says why it is the last.
+    // Announcing the gap matters: a silently truncated log is worse to debug
+    // than a noisy one.
+    LogFromLocation(0, line);
+    BOOST_CHECK_MESSAGE(LogContains("Excessive logging detected"),
+                        "hitting the limit must be announced in the log");
+
+    // After which the location writes nothing further. This is the property
+    // the CVEs need.
+    size = LogFileSize();
+    for (int i = 0; i < LINES_IN_BUDGET * 2; ++i) LogFromLocation(0, line);
+    BOOST_CHECK_MESSAGE(LogFileSize() == size, "a suppressed location must stop reaching disk");
+
+    // An unrelated location keeps its own budget. Without this a single
+    // attacker-driven site would blind the operator to everything else.
+    LogFromLocation(1, line);
+    BOOST_CHECK_MESSAGE(LogFileSize() > size, "an unrelated location must keep logging");
+
+    // Debug logging is exempt: reaching it requires -debug, and an operator
+    // who asked for that has accepted the volume.
+    size = LogFileSize();
+    for (int i = 0; i < LINES_IN_BUDGET * 2; ++i) LogFromLocation(2, line);
+    BOOST_CHECK_MESSAGE(LogFileSize() > size, "-debug output must not be rate limited");
+
+    // Resetting the window restores the location and accounts for what was
+    // lost, so the gap in the log is quantified rather than merely implied.
+    limiter->Reset();
+    BOOST_CHECK_MESSAGE(LogContains("Restarting logging"), "the reset must be announced");
+    BOOST_CHECK_MESSAGE(LogContains("bytes were dropped"), "the reset must report the loss");
+
+    size = LogFileSize();
+    LogFromLocation(0, line);
+    BOOST_CHECK_MESSAGE(LogFileSize() > size, "the location must log again after a reset");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2738,7 +2738,13 @@ static void UpdateTipLog(
 {
 
     AssertLockHeld(::cs_main);
-    LogPrintf("%s%s: new best=%s height=%d version=0x%08x log2_work=%f tx=%lu date='%s' progress=%f cache=%.1fMiB(%utxo)%s\n",
+    // Exempt from rate limiting: this fires once per block, so during IBD it
+    // legitimately exceeds any per-window budget, and it is the single most
+    // useful line in the log to still have. Nothing an attacker controls
+    // reaches it -- a block has to connect first. BTQ's 60s spacing makes this
+    // ten times more frequent than upstream's, so the exemption matters more.
+    LogPrintLevel_(BCLog::LogFlags::NONE, BCLog::Level::None, BCLog::RateLimit::No,
+        "%s%s: new best=%s height=%d version=0x%08x log2_work=%f tx=%lu date='%s' progress=%f cache=%.1fMiB(%utxo)%s\n",
         prefix, func_name,
         tip->GetBlockHash().ToString(), tip->nHeight, tip->nVersion,
         log(tip->nChainWork.getdouble()) / log(2.0), (unsigned long)tip->nChainTx,


### PR DESCRIPTION
Fourth of the six in #120, after #135, #136 and #137. This one closes **two** CVEs, because upstream fixed both with a single change.

## One defect, two ways in

Both are a log site an attacker can drive, with no ceiling on how often it fires:

- **CVE-2025-54604** — reuse a victim's own version nonce and it detects your connections as self-connections, hitting `net_processing.cpp:3421`, `LogPrintf(\"connected to self at %s, disconnecting\n\", ...)`.
- **CVE-2025-54605** — send invalid blocks repeatedly and hit the unconditional failure logs in validation, including `validation.cpp:3824` for forks prior to the last checkpoint.

Both confirmed present in our tree at those lines. Either fills the operator's disk given time.

Upstream ([#32604](https://github.com/bitcoin/bitcoin/pull/32604)) fixed both with per-source-location rate limiting rather than patching the two known sites, on the reasoning that patching them leaves the next one. Our `logging.h` already carried the warning and not the enforcement:

```
// Be conservative when using LogPrintf/error or other things which
// unconditionally log to debug.log! It should not be the case that an inbound
// peer can fill up a user's disk with debug.log entries.
```

## Two adaptations

**No `std::source_location`.** Upstream keys the limiter on it, which is C++20. We build C++17 — `configure.ac` has `--enable-c++20` defaulting to off, and `src/Makefile` confirms `-std=c++17`. We don't need it: `LogPrintf_` already receives `__FILE__` and `__LINE__` as arguments, so the same identity is available. Upstream's commit 3 is purely the `source_location` migration and is skipped entirely; commits 2 and 4 are what this reproduces.

**A scoped enum instead of a bool.** Upstream threads `bool should_ratelimit` immediately before the format string. A `const char*` converts to `bool` silently, so a caller who omits it compiles cleanly and logs nonsense — the format string becomes the flag and the first argument becomes the format string.

That isn't hypothetical. It is what happened to the existing `logging_LogPrintf_` test when I added the parameter: it built without a single diagnostic and produced garbage, and only an unrelated string comparison caught it. `BCLog::RateLimit::{Yes,No}` makes it a type error instead, and reads better at the call sites.

## What is and isn't limited

Following upstream: `LogPrintf` and `LogPrintfCategory` always; `LogPrintLevel` at `Info` and above, since those pass the default log level and are effectively unconditional; `LogPrint` never, because reaching it requires `-debug` and an operator who asked for that has accepted the volume.

`UpdateTipLog` is exempted, as upstream exempts it. It fires once per block, so during IBD it legitimately exceeds any window, and it is the line most worth still having. **BTQ's 60-second spacing makes it ten times more frequent than upstream's**, so the exemption matters more here than there.

Only writes to disk are suppressed. Console output and log callbacks are untouched, since neither consumes the resource under attack.

## Nothing disappears silently

A truncated log is worse to debug than a noisy one, so: suppression is announced on the line that triggers it, every line written while anything is suppressed carries a `[*]` marker, and the window reset reports how many bytes were dropped and from where.

## One behaviour worth knowing about

`error()` is a template in `logging.h` that calls `LogPrintf`, so `__FILE__`/`__LINE__` resolve to *its* line, not the caller's. Every `error()` call in the codebase therefore shares one budget. Upstream has exactly the same property for the same reason — its macro expands `source_location::current()` inside `error()` too.

The consequence: flooding invalid blocks through `error()` can suppress other `error()` output for up to a window. That is a real trade against filling the disk, and it is upstream's trade. Making `error()` capture its caller would mean turning it into a macro, and `error` is far too common an identifier for that to be safe. Flagging it rather than hiding it.

## Testing

New `logging_rate_limit` covers the full lifecycle against the real logger and real log file: a budget's worth gets through, the line that exceeds it is written and announced, the location then writes nothing, an unrelated location is unaffected, `-debug` output is exempt, and a reset restores the location and reports the loss. New `logging_log_limit_stats` covers the budget arithmetic, including that exactly exhausting a budget still succeeds.

Mutation-tested, three ways:

| mutation | failing assertions |
|---|---|
| suppressed lines still written to disk | 1 |
| `LogPrintf` opts out of rate limiting | 4 |
| one shared budget instead of per-location | 1 |

Clean when restored.

- Full unit suite: 735 cases, no errors.
- `feature_logging.py`, `feature_config_args.py`, `feature_shutdown.py`, `feature_reindex.py`, `rpc_misc.py`, `rpc_net.py`, `p2p_disconnect_ban.py` (both transports) all pass.
- `rpc_blockchain.py` fails on `total_amount` `1000` vs `8725` — the 5-vs-50 block subsidy from #104, unrelated.

A functional reproduction of either CVE isn't practical: at 1 MiB per window it needs on the order of 17,000 spoofed connections or thousands of invalid blocks to reach the threshold. The unit tests drive the same code path with a smaller budget instead.

Refs #120.