### PR TITLE
backport: CVE-2025-46598 (1/3) — detect witness stripping without re-running scripts

### DIFF
--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -316,6 +316,44 @@ bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
     return true;
 }
 
+bool SpendsWitnessProgram(const CTransaction& tx, const CCoinsViewCache& prevouts)
+{
+    if (tx.IsCoinBase()) {
+        return false;
+    }
+
+    int version;
+    std::vector<unsigned char> program;
+    for (const auto& txin : tx.vin) {
+        const auto& prev_spk{prevouts.AccessCoin(txin.prevout).out.scriptPubKey};
+
+        // Covers every witness version, including v2 P2MR and versions not
+        // yet defined -- anything whose spend could need a witness.
+        if (prev_spk.IsWitnessProgram(version, program)) {
+            return true;
+        }
+
+        // P2SH-wrapped witness programs need the redeem script to tell.
+        // Calling EvalScript here is safe for the same reason
+        // AreInputsStandard and IsWitnessStandard may: this only runs after
+        // IsStandardTx, which has already required a push-only scriptSig.
+        if (prev_spk.IsPayToScriptHash()) {
+            // A scriptSig that fails to evaluate, or leaves nothing behind,
+            // belongs to a transaction that is invalid by consensus anyway.
+            std::vector<std::vector<unsigned char>> stack;
+            if (!EvalScript(stack, txin.scriptSig, SCRIPT_VERIFY_NONE, BaseSignatureChecker{}, SigVersion::BASE) || stack.empty()) {
+                continue;
+            }
+            const CScript redeem_script{stack.back().begin(), stack.back().end()};
+            if (redeem_script.IsWitnessProgram(version, program)) {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
 int64_t GetVirtualTransactionSize(int64_t nWeight, int64_t nSigOpCost, unsigned int bytes_per_sigop)
 {
     return (std::max(nWeight, nSigOpCost * bytes_per_sigop) + WITNESS_SCALE_FACTOR - 1) / WITNESS_SCALE_FACTOR;

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -177,6 +177,16 @@ bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
 */
 bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs);
 
+/**
+ * Whether this transaction spends any witness program, including versions not
+ * yet defined and P2SH-wrapped ones.
+ *
+ * Used to tell a stripped witness apart from an ordinary script failure
+ * without re-running every input script to find out. May return false early
+ * for transactions that are already invalid by consensus.
+ */
+bool SpendsWitnessProgram(const CTransaction& tx, const CCoinsViewCache& prevouts);
+
 /** Compute the virtual transaction size (weight reinterpreted as bytes). */
 int64_t GetVirtualTransactionSize(int64_t nWeight, int64_t nSigOpCost, unsigned int bytes_per_sigop);
 int64_t GetVirtualTransactionSize(const CTransaction& tx, int64_t nSigOpCost, unsigned int bytes_per_sigop);

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -1045,4 +1045,91 @@ BOOST_AUTO_TEST_CASE(test_IsWitnessStandard_stack_item_size_limits)
     BOOST_CHECK(!check_witness_standard(p2mr_script, tapscript_witness(MAX_STANDARD_TAPSCRIPT_STACK_ITEM_SIZE + 1)));
 }
 
+//! SpendsWitnessProgram must agree with what the interpreter would conclude,
+//! across every output type we define.
+//!
+//! It replaces two full re-runs of every input script that existed only to
+//! tell a stripped witness apart from an ordinary script failure
+//! (CVE-2025-46598). That substitution is only sound if the structural answer
+//! matches the executed one, so each output type is checked explicitly --
+//! including P2MR, which is a witness program at version 2 and which upstream
+//! has no equivalent of.
+BOOST_AUTO_TEST_CASE(spends_witness_program)
+{
+    CCoinsView coins_dummy;
+    CCoinsViewCache coins(&coins_dummy);
+    CKey key;
+    key.MakeNewKey(true);
+    const CPubKey pubkey{key.GetPubKey()};
+
+    CMutableTransaction tx_create{}, tx_spend{};
+    tx_create.vout.emplace_back(0, CScript{});
+    tx_spend.vin.emplace_back(uint256{}, 0);
+
+    // If a destination type is added, decide whether it is a witness program
+    // and extend this test rather than letting it pass by omission.
+    static_assert(std::variant_size_v<CTxDestination> == 14);
+
+    const auto verdict = [&]() { return ::SpendsWitnessProgram(CTransaction{tx_spend}, coins); };
+
+    // Funds tx_spend from an output with `spk` and reports the verdict.
+    const auto spends_from = [&](const CScript& spk) {
+        tx_create.vout[0].scriptPubKey = spk;
+        tx_spend.vin[0].prevout.hash = tx_create.GetHash();
+        AddCoins(coins, CTransaction{tx_create}, 0, false);
+        return verdict();
+    };
+
+    std::vector<std::vector<unsigned char>> sol_dummy;
+
+    // Non-witness outputs: a missing witness cannot be what went wrong.
+    BOOST_CHECK(!spends_from(GetScriptForDestination(PubKeyDestination{pubkey})));
+    BOOST_CHECK(!spends_from(GetScriptForDestination(PKHash{pubkey})));
+
+    // Bare P2SH over a non-witness redeem script is likewise not one.
+    const CScript plain_redeem{CScript{} << OP_1 << OP_CHECKSIG};
+    tx_spend.vin[0].scriptSig = CScript{} << ToByteVector(plain_redeem);
+    BOOST_CHECK(!spends_from(GetScriptForDestination(ScriptHash{plain_redeem})));
+    tx_spend.vin[0].scriptSig.clear();
+
+    // Every native witness version is one, defined or not.
+    const CScript witness_script{CScript{} << OP_12 << OP_HASH160 << OP_DUP << OP_EQUAL};
+    BOOST_CHECK(spends_from(GetScriptForDestination(WitnessV0KeyHash{pubkey})));
+    BOOST_CHECK(spends_from(GetScriptForDestination(WitnessV0ScriptHash{witness_script})));
+    BOOST_CHECK(spends_from(GetScriptForDestination(WitnessV1Taproot{XOnlyPubKey{pubkey}})));
+
+    // P2MR: BTQ's quantum-resistant output, witness version 2. The reason this
+    // test exists in this form -- the helper must not be limited to the
+    // versions upstream knows about.
+    const CScript p2mr{CScript{} << OP_2 << std::vector<unsigned char>(WITNESS_V2_P2MR_SIZE, 0x11)};
+    BOOST_CHECK_EQUAL(Solver(p2mr, sol_dummy), TxoutType::WITNESS_V2_P2MR);
+    BOOST_CHECK(spends_from(p2mr));
+
+    // An undefined future witness version too, since a witness it does not yet
+    // know how to check is still a witness that can be stripped.
+    const CScript witness_future{CScript{} << OP_16 << std::vector<unsigned char>(32, 0x22)};
+    BOOST_CHECK(spends_from(witness_future));
+
+    // P2SH-wrapped witness programs need the redeem script to see.
+    for (const CScript& wrapped : {GetScriptForDestination(WitnessV0KeyHash{pubkey}),
+                                   GetScriptForDestination(WitnessV0ScriptHash{witness_script}),
+                                   p2mr}) {
+        tx_spend.vin[0].scriptSig = CScript{} << ToByteVector(wrapped);
+        BOOST_CHECK(spends_from(GetScriptForDestination(ScriptHash{wrapped})));
+
+        // Without the redeem script revealed there is nothing to go on, and
+        // the transaction is unspendable anyway. Same coin, so re-evaluate
+        // rather than re-fund.
+        tx_spend.vin[0].scriptSig.clear();
+        BOOST_CHECK(!verdict());
+    }
+
+    // A coinbase has no prevouts to inspect.
+    CMutableTransaction coinbase{};
+    coinbase.vin.emplace_back(COutPoint{}, CScript{} << OP_1);
+    coinbase.vout.emplace_back(0, CScript{});
+    BOOST_CHECK(CTransaction{coinbase}.IsCoinBase());
+    BOOST_CHECK(!::SpendsWitnessProgram(CTransaction{coinbase}, coins));
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1042,13 +1042,18 @@ bool MemPoolAccept::PolicyScriptChecks(const ATMPArgs& args, Workspace& ws)
     // Check input scripts and signatures.
     // This is done last to help prevent CPU exhaustion denial-of-service attacks.
     if (!CheckInputScripts(tx, state, m_view, scriptVerifyFlags, true, false, ws.m_precomputed_txdata)) {
-        // SCRIPT_VERIFY_CLEANSTACK requires SCRIPT_VERIFY_WITNESS, so we
-        // need to turn both off, and compare against just turning off CLEANSTACK
-        // to see if the failure is specifically due to witness validation.
-        TxValidationState state_dummy; // Want reported failures to be from first CheckInputScripts
-        if (!tx.HasWitness() && CheckInputScripts(tx, state_dummy, m_view, scriptVerifyFlags & ~(SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_CLEANSTACK), true, false, ws.m_precomputed_txdata) &&
-                !CheckInputScripts(tx, state_dummy, m_view, scriptVerifyFlags & ~SCRIPT_VERIFY_CLEANSTACK, true, false, ws.m_precomputed_txdata)) {
-            // Only the witness is missing, so the transaction itself may be fine.
+        // Detect a stripped witness, so p2p code knows not to cache the
+        // rejection against a txid that a witness would have made valid.
+        //
+        // This used to be established by re-running every input script twice
+        // more under relaxed flags. That made a rejected transaction cost up
+        // to three full script passes, which an attacker can repeat for free
+        // because a non-standard transaction is not a disconnection offence
+        // (CVE-2025-46598). The prevout script types say the same thing
+        // structurally, at no verification cost. Dilithium verification is
+        // far dearer than ECDSA, so the passes avoided are worth more here
+        // than upstream.
+        if (!tx.HasWitness() && SpendsWitnessProgram(tx, m_view)) {
             state.Invalid(TxValidationResult::TX_WITNESS_STRIPPED,
                     state.GetRejectReason(), state.GetDebugMessage());
         }

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -709,6 +709,21 @@ class SegWitTest(BTQTestFramework):
                 expected_msgs=[spend_tx.hash, 'was not accepted: mandatory-script-verify-flag-failed (Witness program was passed an empty witness)']):
             test_transaction_acceptance(self.nodes[0], self.test_node, spend_tx, with_witness=False, accepted=False)
 
+        # The rejection above was recognised as a stripped witness, so it was
+        # not cached in the reject filter -- a witness would have made it
+        # valid, and caching it under a txid the witness does not commit to
+        # would block the real transaction. Resending must therefore be
+        # re-evaluated and produce the same error rather than being ignored.
+        #
+        # This is the observable consequence of detecting witness stripping
+        # structurally instead of by re-running every input script, so it is
+        # asserted for the p2sh-wrapped case specifically: that path reads the
+        # redeem script out of the scriptSig, which is where it could go wrong
+        # without anything else noticing.
+        with self.nodes[0].assert_debug_log(
+                expected_msgs=[spend_tx.hash, 'was not accepted: mandatory-script-verify-flag-failed (Witness program was passed an empty witness)']):
+            test_transaction_acceptance(self.nodes[0], self.test_node, spend_tx, with_witness=False, accepted=False)
+
         # Try to put the witness script in the scriptSig, should also fail.
         spend_tx.vin[0].scriptSig = CScript([p2wsh_pubkey, b'a'])
         spend_tx.rehash()


### PR DESCRIPTION
Last of the six in #120, after #135, #136, #137 and #138. Unlike those, this CVE took upstream **three** separate PRs, and only one of them is unambiguously ours to take. This is that one.

## The defect

A transaction that fails script validation in the mempool has every input script executed up to three times:

```
CheckInputScripts(flags)                                    // the real check
CheckInputScripts(flags & ~(WITNESS | CLEANSTACK))          // only to classify
CheckInputScripts(flags & ~CLEANSTACK)                      // only to classify
```

The second and third exist purely to work out whether the failure was a *stripped witness* rather than a genuine script error, which matters because a witness-stripped transaction must not be cached in the reject filter under a txid the witness does not commit to.

None of it is free and none of it is rate-limited: a non-standard transaction is rejected *without* disconnecting the sender, so an attacker repeats it indefinitely. Upstream measured a few seconds of validation per transaction, enough to delay block propagation.

**This is worse here than upstream.** Dilithium verification costs far more than ECDSA, and BTQ's `MAX_BLOCK_WEIGHT` and `MAX_BLOCK_SERIALIZED_SIZE` are 8 MB against upstream's 4. The passes being avoided are more expensive passes.

## The fix

The prevout script types answer the same question structurally, for free: no witness, and it spends a witness program, then the missing witness is the explanation. Upstream [PR #33105](https://github.com/bitcoin/bitcoin/pull/33105).

Two adaptations:

- Upstream's helper excludes pay-to-anchor. P2A does not exist in this tree — it landed upstream in v28 — so there is nothing to exclude, and the helper is named `SpendsWitnessProgram` for what it actually does here.
- **It must recognise witness version 2**, because that is BTQ's P2MR. Anything transcribed from upstream's version set would silently miss it, and a P2MR spend with a stripped witness would be misclassified. This is the part of the backport that is genuinely ours and not upstream's.

## Testing

`transaction_tests/spends_witness_program` walks every output type: P2PK and P2PKH negative, bare P2SH over a non-witness redeem script negative, v0 keyhash and scripthash positive, taproot positive, **P2MR positive**, an undefined future version positive, all three P2SH-wrapped forms positive with the redeem script and negative without, and coinbase negative. It carries a `static_assert` on `variant_size_v<CTxDestination> == 14` so adding a destination type forces a decision here rather than passing by omission.

Mutation-tested:

| mutation | failing assertions |
|---|---|
| helper always returns false | 8 |
| P2SH-wrapped programs not examined | 3 |
| only recognise witness versions < 2 (i.e. drop P2MR) | 2 |

That third row is the one worth noting: it is the proof the P2MR handling is actually load-bearing and not decoration.

- Full unit suite: 734 cases, no errors.
- `p2p_segwit.py`, `mempool_accept.py`, `p2p_invalid_tx.py`, `feature_segwit.py`, `feature_p2mr.py` all fail — and fail **identically on `origin/master`**. The cause is `bad-txns-in-belowout, value in (5.00) < value out (49.30)`: the 5-vs-50 block subsidy of #104. No regression.

I added the upstream assertion to `p2p_segwit.py` that a witness-stripped transaction stays out of the reject filter, but **it does not currently execute** — the test dies at `test_non_witness_transaction` on the subsidy problem long before reaching it. It is correct and will start covering this once #104 is fixed; flagging it rather than implying coverage that isn't there today.

## The other two mitigations, and why they are not here

**[#32473](https://github.com/bitcoin/bitcoin/pull/32473) — sighash midstate caching.** A pure optimisation against worst-case quadratic legacy sighash. It applies: `SignatureHash` is untouched by BTQ (last modified by upstream's own \"Use HashWriter where possible\"). Worth doing as a follow-up; kept separate because it is an interpreter change and belongs under its own review rather than bundled behind a policy helper.

**[#33050](https://github.com/bitcoin/bitcoin/pull/33050) — drop `MaybePunishNodeForTx`, check input scripts once.** This removes the remaining re-run, the `check2()` inside `CheckInputScripts`. **It needs a decision from you, not just a backport**, for two reasons:

1. It works by no longer punishing peers for consensus-invalid transactions at all. The second run exists only to tell `TX_NOT_STANDARD` from `TX_CONSENSUS` so the peer can be banned for the latter; drop the banning and the distinction stops being needed. That is a deliberate policy change upstream made, not an implementation detail.
2. Our tree has a BTQ-specific comment at `validation.cpp` saying the distinction is **required** for the testnet policy-ahead `SCRIPT_VERIFY_DILITHIUM_P2MR_ONLY` regime — a consensus-valid legacy Dilithium spend must soft-fail as `TX_NOT_STANDARD` rather than return as `TX_CONSENSUS` and get the peer misbehaving-scored.

Dropping peer punishment resolves that concern by removing the consequence entirely, so the two are compatible — but that is a call about BTQ's relay policy and it should be made deliberately.

Happy to do either or both as follow-ups; say which.

Refs #120.