### PR TITLE
wallet: stop aborting on Dilithium types from the legacy keypool

### DIFF
--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -393,6 +393,11 @@ util::Result<CTxDestination> LegacyScriptPubKeyMan::GetReservedDestination(const
     if (LEGACY_OUTPUT_TYPES.count(type) == 0) {
         return util::Error{_("Error: Legacy wallets only support the \"legacy\", \"p2sh-segwit\", and \"bech32\" address types")};
     }
+    // Reserved destinations come out of the keypool, which holds ECDSA keys
+    // only; a Dilithium destination cannot be derived from one.
+    if (type == OutputType::DILITHIUM_LEGACY) {
+        return util::Error{_("Error: dilithium-legacy addresses cannot be reserved from the keypool")};
+    }
     assert(type != OutputType::BECH32M);
 
     LOCK(cs_KeyStore);
@@ -443,6 +448,10 @@ std::vector<WalletDestination> LegacyScriptPubKeyMan::MarkUnusedAddresses(const 
             for (const auto& keypool : MarkReserveKeysAsUsed(mi->second)) {
                 // derive all possible destinations as any of them could have been used
                 for (const auto& type : LEGACY_OUTPUT_TYPES) {
+                    // Keypool entries hold an ECDSA key. Dilithium destinations
+                    // come from separate Dilithium keys, so this key has none,
+                    // and asking for one would abort in GetDestinationForKey.
+                    if (type == OutputType::DILITHIUM_LEGACY) continue;
                     const auto& dest = GetDestinationForKey(keypool.vchPubKey, type);
                     result.push_back({dest, keypool.fInternal});
                 }


### PR DESCRIPTION
## What

`LEGACY_OUTPUT_TYPES` gained `OutputType::DILITHIUM_LEGACY`, but `GetDestinationForKey` still asserts on it:

```cpp
case OutputType::BECH32M:
case OutputType::DILITHIUM_LEGACY:
case OutputType::DILITHIUM_BECH32:
case OutputType::UNKNOWN: {} // ...so let it assert
}
assert(false);
```

Any caller that walks that set and asks for a destination therefore takes the node down with `Assertion 'false' failed`.

## Why it matters

`MarkUnusedAddresses` is reachable in ordinary operation and needs no Dilithium involvement from the user at all. It runs whenever a legacy wallet notices a used keypool key, and the loop simply asks for all four types in turn:

```cpp
for (const auto& type : LEGACY_OUTPUT_TYPES) {
    const auto& dest = GetDestinationForKey(keypool.vchPubKey, type);
```

The fourth one aborts. This is not a theoretical path: `wallet_backup.py --legacy-wallet` kills the node this way while restoring a wallet from backup, which is how I found it.

`GetReservedDestination` has the same hole. It admits `DILITHIUM_LEGACY` past the membership check and then reaches the same assert.

## The fix

A keypool entry holds an ECDSA key. Dilithium destinations are derived from separate Dilithium keys, so there is genuinely no destination of that type for this key — skip it in `MarkUnusedAddresses`, and return an error rather than asserting in `GetReservedDestination`.

`GetNewDestination` already special-cases the type before it can reach `GetDestinationForKey`; this brings the other two callers in line with it.

## Testing

`wallet_backup.py --legacy-wallet` fails on master with the node aborting, and passes with this change. `wallet_listtransactions.py --legacy-wallet` is fixed by it too. No regressions across the full functional suite.