### PR TITLE
test: derive functional test amounts from BTQ's block subsidy

### DIFF
--- a/test/functional/interface_btq_cli.py
+++ b/test/functional/interface_btq_cli.py
@@ -7,7 +7,10 @@
 from decimal import Decimal
 import re
 
-from test_framework.blocktools import COINBASE_MATURITY
+from test_framework.blocktools import (
+    COINBASE_MATURITY,
+    cumulative_block_subsidy,
+)
 from test_framework.test_framework import BTQTestFramework
 from test_framework.util import (
     assert_equal,
@@ -18,11 +21,10 @@ from test_framework.util import (
 )
 import time
 
-# The block reward of coinbaseoutput.nValue (50) BTQ/block matures after
-# COINBASE_MATURITY (100) blocks. Therefore, after mining 101 blocks we expect
-# node 0 to have a balance of (BLOCKS - COINBASE_MATURITY) * 50 BTQ/block.
+# A block reward matures after COINBASE_MATURITY (100) blocks, so after mining
+# 101 blocks only the first block's subsidy is spendable.
 BLOCKS = COINBASE_MATURITY + 1
-BALANCE = (BLOCKS - 100) * 50
+BALANCE = cumulative_block_subsidy(1, BLOCKS - COINBASE_MATURITY)
 
 JSON_PARSING_ERROR = 'error: Error parsing JSON: foo'
 BLOCKS_VALUE_OF_ZERO = 'error: the first argument (number of blocks to generate, default: 1) must be an integer value greater than zero'
@@ -165,7 +167,7 @@ class TestBTQCli(BTQTestFramework):
 
             # Setup to test -getinfo, -generate, and -rpcwallet= with multiple wallets.
             wallets = [self.default_wallet_name, 'Encrypted', 'secret']
-            amounts = [BALANCE + Decimal('9.999928'), Decimal(9), Decimal(31)]
+            amounts = [BALANCE + Decimal('0.9999322'), Decimal('0.9'), Decimal('3.1')]
             self.nodes[0].createwallet(wallet_name=wallets[1])
             self.nodes[0].createwallet(wallet_name=wallets[2])
             w1 = self.nodes[0].get_wallet_rpc(wallets[0])
@@ -178,7 +180,7 @@ class TestBTQCli(BTQTestFramework):
             w1.sendtoaddress(w2.getnewaddress(), amounts[1])
             w1.sendtoaddress(w3.getnewaddress(), amounts[2])
 
-            # Mine a block to confirm; adds a block reward (50 BTQ) to the default wallet.
+            # Mine a block to confirm; adds a block reward to the default wallet.
             self.generate(self.nodes[0], 1)
 
             self.log.info("Test -getinfo with multiple wallets and -rpcwallet returns specified wallet balance")

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -32,6 +32,7 @@ from test_framework.blocktools import (
     TIME_GENESIS_BLOCK,
     create_block,
     create_coinbase,
+    cumulative_block_subsidy,
 )
 from test_framework.messages import (
     CBlockHeader,
@@ -202,6 +203,11 @@ class BlockchainTest(BTQTestFramework):
             'bip65': {'type': 'buried', 'active': True, 'height': 4},
             'csv': {'type': 'buried', 'active': True, 'height': 5},
             'segwit': {'type': 'buried', 'active': True, 'height': 6},
+            # BTQ-specific deployments. LWMA is scheduled far past the heights
+            # this helper is called at, so it is always still inactive here.
+            'lwma': {'type': 'buried', 'active': False, 'height': 300000},
+            'dilithium': {'type': 'buried', 'active': True, 'height': 1},
+            'dilithium_p2mr': {'type': 'buried', 'active': True, 'height': 1},
             'testdummy': {
                 'type': 'bip9',
                 'bip9': {
@@ -330,7 +336,7 @@ class BlockchainTest(BTQTestFramework):
         node = self.nodes[0]
         res = node.gettxoutsetinfo()
 
-        assert_equal(res['total_amount'], Decimal('8725.00000000'))
+        assert_equal(res['total_amount'], cumulative_block_subsidy(1, HEIGHT))
         assert_equal(res['transactions'], HEIGHT)
         assert_equal(res['height'], HEIGHT)
         assert_equal(res['txouts'], HEIGHT)

--- a/test/functional/test_framework/blocktools.py
+++ b/test/functional/test_framework/blocktools.py
@@ -4,6 +4,7 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Utilities for manipulating blocks and transactions."""
 
+from decimal import Decimal
 import struct
 import time
 import unittest
@@ -56,6 +57,14 @@ MAX_FUTURE_BLOCK_TIME = 15 * 60
 
 # Coinbase transaction outputs can only be spent after this number of new blocks (network rule)
 COINBASE_MATURITY = 100
+
+# BTQ pays 5 BTQ per block where Bitcoin pays 50, and on regtest halves every
+# 1500 blocks rather than 150 (consensus.nSubsidyHalvingInterval in
+# kernel/chainparams.cpp). Derive expected amounts from these instead of
+# writing upstream's numbers into tests: a bare 50 silently becomes a wrong
+# answer here rather than a failing import.
+INITIAL_BLOCK_SUBSIDY = 5
+SUBSIDY_HALVING_INTERVAL = 1500
 
 # From BIP141
 WITNESS_COMMITMENT_HEADER = b"\xaa\x21\xa9\xed"
@@ -122,22 +131,45 @@ def script_BIP34_coinbase_height(height):
     return CScript([CScriptNum(height)])
 
 
-def create_coinbase(height, pubkey=None, *, script_pubkey=None, extra_output_script=None, fees=0, nValue=5):
+def block_subsidy_sat(height, *, halving_interval=SUBSIDY_HALVING_INTERVAL):
+    """Consensus subsidy for the block at `height`, in satoshis."""
+    halvings = height // halving_interval
+    if halvings >= 64:
+        return 0
+    return (INITIAL_BLOCK_SUBSIDY * COIN) >> halvings
+
+
+def block_subsidy(height, *, halving_interval=SUBSIDY_HALVING_INTERVAL):
+    """Consensus subsidy for the block at `height`, in BTQ."""
+    return Decimal(block_subsidy_sat(height, halving_interval=halving_interval)) / COIN
+
+
+def cumulative_block_subsidy(first_height, last_height, *, halving_interval=SUBSIDY_HALVING_INTERVAL):
+    """Total subsidy paid by blocks `first_height` through `last_height`, inclusive, in BTQ."""
+    total = sum(block_subsidy_sat(h, halving_interval=halving_interval)
+                for h in range(first_height, last_height + 1))
+    return Decimal(total) / COIN
+
+
+def create_coinbase(height, pubkey=None, *, script_pubkey=None, extra_output_script=None, fees=0, nValue=None):
     """Create a coinbase transaction.
 
     If pubkey is passed in, the coinbase output will be a P2PK output;
     otherwise an anyone-can-spend output.
 
     If extra_output_script is given, make a 0-value output to that
-    script. This is useful to pad block weight/sigops as needed. """
+    script. This is useful to pad block weight/sigops as needed.
+
+    nValue overrides the payout (in BTQ) for tests that need a specific or
+    deliberately invalid amount; left unset, the block pays the consensus
+    subsidy for `height` plus `fees`."""
     coinbase = CTransaction()
     coinbase.vin.append(CTxIn(COutPoint(0, 0xffffffff), script_BIP34_coinbase_height(height), SEQUENCE_FINAL))
     coinbaseoutput = CTxOut()
-    coinbaseoutput.nValue = nValue * COIN
-    if nValue == 5:
-        halvings = int(height / 1500)  # regtest
-        coinbaseoutput.nValue >>= halvings
-        coinbaseoutput.nValue += fees
+    if nValue is None:
+        coinbaseoutput.nValue = block_subsidy_sat(height) + fees
+    else:
+        coinbaseoutput.nValue = nValue * COIN
     if pubkey is not None:
         coinbaseoutput.scriptPubKey = key_to_p2pk_script(pubkey)
     elif script_pubkey is not None:

--- a/test/functional/wallet_backup.py
+++ b/test/functional/wallet_backup.py
@@ -8,8 +8,8 @@ Test case is:
 4 nodes. 1 2 and 3 send transactions between each other,
 fourth node is a miner.
 1 2 3 each mine a block to start, then
-Miner creates 100 blocks so 1 2 3 each have 50 mature
-coins to spend.
+Miner creates 100 blocks so 1 2 3 each have one mature
+block reward to spend.
 Then 5 iterations of 1/2/3 sending coins amongst
 themselves to get transactions in the wallets,
 and the miner mining one block.
@@ -21,7 +21,7 @@ Miner then generates 101 more blocks, so any
 transaction fees paid mature.
 
 Sanity check:
-  Sum(1,2,3,4 balances) == 114*50
+  Sum(1,2,3,4 balances) == the subsidy of the 114 mature blocks
 
 1/2/3 are shutdown, and their wallets erased.
 Then restore using wallet.dat backup. And
@@ -35,7 +35,11 @@ import os
 from random import randint
 import shutil
 
-from test_framework.blocktools import COINBASE_MATURITY
+from test_framework.blocktools import (
+    COINBASE_MATURITY,
+    block_subsidy,
+    cumulative_block_subsidy,
+)
 from test_framework.test_framework import BTQTestFramework
 from test_framework.util import (
     assert_equal,
@@ -73,7 +77,9 @@ class WalletBackupTest(BTQTestFramework):
 
     def one_send(self, from_node, to_address):
         if (randint(1,2) == 1):
-            amount = Decimal(randint(1,10)) / Decimal(10)
+            # A tenth of upstream's amounts: ten rounds of these have to stay
+            # within one BTQ block reward rather than one Bitcoin block reward.
+            amount = Decimal(randint(1,10)) / Decimal(100)
             self.nodes[from_node].sendtoaddress(to_address, amount)
 
     def do_one_round(self):
@@ -146,9 +152,9 @@ class WalletBackupTest(BTQTestFramework):
         self.generate(self.nodes[2], 1)
         self.generate(self.nodes[3], COINBASE_MATURITY)
 
-        assert_equal(self.nodes[0].getbalance(), 50)
-        assert_equal(self.nodes[1].getbalance(), 50)
-        assert_equal(self.nodes[2].getbalance(), 50)
+        assert_equal(self.nodes[0].getbalance(), block_subsidy(1))
+        assert_equal(self.nodes[1].getbalance(), block_subsidy(2))
+        assert_equal(self.nodes[2].getbalance(), block_subsidy(3))
         assert_equal(self.nodes[3].getbalance(), 0)
 
         self.log.info("Creating transactions")
@@ -179,8 +185,8 @@ class WalletBackupTest(BTQTestFramework):
         total = balance0 + balance1 + balance2 + balance3
 
         # At this point, there are 214 blocks (103 for setup, then 10 rounds, then 101.)
-        # 114 are mature, so the sum of all wallets should be 114 * 50 = 5700.
-        assert_equal(total, 5700)
+        # 114 are mature, so the sum of all wallets should be their total subsidy.
+        assert_equal(total, cumulative_block_subsidy(1, 114))
 
         ##
         # Test restoring spender wallets from backups

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -6,7 +6,10 @@
 from decimal import Decimal
 from itertools import product
 
-from test_framework.blocktools import COINBASE_MATURITY
+from test_framework.blocktools import (
+    COINBASE_MATURITY,
+    block_subsidy,
+)
 from test_framework.descriptors import descsum_create
 from test_framework.messages import (
     COIN,
@@ -25,6 +28,11 @@ from test_framework.wallet import MiniWallet
 
 NOT_A_NUMBER_OR_STRING = "Amount is not a number or string"
 OUT_OF_RANGE = "Amount out of range"
+
+# Every block this test mines is well before the first halving, so one subsidy
+# is all it ever needs. The amounts it moves around are a tenth of upstream's
+# because BTQ's subsidy is a tenth of Bitcoin's.
+SUBSIDY = block_subsidy(1)
 
 
 class WalletTest(BTQTestFramework):
@@ -72,14 +80,14 @@ class WalletTest(BTQTestFramework):
         self.generate(self.nodes[0], 1, sync_fun=self.no_op)
 
         walletinfo = self.nodes[0].getwalletinfo()
-        assert_equal(walletinfo['immature_balance'], 50)
+        assert_equal(walletinfo['immature_balance'], SUBSIDY)
         assert_equal(walletinfo['balance'], 0)
 
         self.sync_all(self.nodes[0:3])
         self.generate(self.nodes[1], COINBASE_MATURITY + 1, sync_fun=lambda: self.sync_all(self.nodes[0:3]))
 
-        assert_equal(self.nodes[0].getbalance(), 50)
-        assert_equal(self.nodes[1].getbalance(), 50)
+        assert_equal(self.nodes[0].getbalance(), SUBSIDY)
+        assert_equal(self.nodes[1].getbalance(), SUBSIDY)
         assert_equal(self.nodes[2].getbalance(), 0)
 
         # Check that only first and second nodes have UTXOs
@@ -93,19 +101,19 @@ class WalletTest(BTQTestFramework):
         # First, outputs that are unspent both in the chain and in the
         # mempool should appear with or without include_mempool
         txout = self.nodes[0].gettxout(txid=confirmed_txid, n=confirmed_index, include_mempool=False)
-        assert_equal(txout['value'], 50)
+        assert_equal(txout['value'], SUBSIDY)
         txout = self.nodes[0].gettxout(txid=confirmed_txid, n=confirmed_index, include_mempool=True)
-        assert_equal(txout['value'], 50)
+        assert_equal(txout['value'], SUBSIDY)
 
-        # Send 21 BTQ from 0 to 2 using sendtoaddress call.
-        self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 11)
-        mempool_txid = self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 10)
+        # Send 2.1 BTQ from 0 to 2 using sendtoaddress call.
+        self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), Decimal('1.1'))
+        mempool_txid = self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 1)
 
         self.log.info("Test gettxout (second part)")
         # utxo spent in mempool should be visible if you exclude mempool
         # but invisible if you include mempool
         txout = self.nodes[0].gettxout(confirmed_txid, confirmed_index, False)
-        assert_equal(txout['value'], 50)
+        assert_equal(txout['value'], SUBSIDY)
         txout = self.nodes[0].gettxout(confirmed_txid, confirmed_index)  # by default include_mempool=True
         assert txout is None
         txout = self.nodes[0].gettxout(confirmed_txid, confirmed_index, True)
@@ -117,9 +125,9 @@ class WalletTest(BTQTestFramework):
         txout1 = self.nodes[0].gettxout(mempool_txid, 0, True)
         txout2 = self.nodes[0].gettxout(mempool_txid, 1, True)
         # note the mempool tx will have randomly assigned indices
-        # but 10 will go to node2 and the rest will go to node0
+        # but 1 will go to node2 and the rest will go to node0
         balance = self.nodes[0].getbalance()
-        assert_equal(set([txout1['value'], txout2['value']]), set([10, balance]))
+        assert_equal(set([txout1['value'], txout2['value']]), set([1, balance]))
         walletinfo = self.nodes[0].getwalletinfo()
         assert_equal(walletinfo['immature_balance'], 0)
 
@@ -160,7 +168,7 @@ class WalletTest(BTQTestFramework):
         assert_raises_rpc_error(-8, "Invalid parameter, output already locked", self.nodes[2].lockunspent, False, [unspent_0])
 
         # Locked outputs should not be used, even if they are the only available funds
-        assert_raises_rpc_error(-6, "Insufficient funds", self.nodes[2].sendtoaddress, self.nodes[2].getnewaddress(), 20)
+        assert_raises_rpc_error(-6, "Insufficient funds", self.nodes[2].sendtoaddress, self.nodes[2].getnewaddress(), 2)
         assert_equal([unspent_0], self.nodes[2].listlockunspent())
 
         # Unlocking should remove the persistent lock
@@ -205,10 +213,10 @@ class WalletTest(BTQTestFramework):
         # Have node1 generate 100 blocks (so node0 can recover the fee)
         self.generate(self.nodes[1], COINBASE_MATURITY, sync_fun=lambda: self.sync_all(self.nodes[0:3]))
 
-        # node0 should end up with 100 btc in block rewards plus fees, but
-        # minus the 21 plus fees sent to node2
-        assert_equal(self.nodes[0].getbalance(), 100 - 21)
-        assert_equal(self.nodes[2].getbalance(), 21)
+        # node0 should end up with two block rewards plus fees, but
+        # minus the 2.1 plus fees sent to node2
+        assert_equal(self.nodes[0].getbalance(), 2 * SUBSIDY - Decimal('2.1'))
+        assert_equal(self.nodes[2].getbalance(), Decimal('2.1'))
 
         # Node0 should have two unspent outputs.
         # Create a couple of transactions to send them to node2, submit them through
@@ -222,7 +230,7 @@ class WalletTest(BTQTestFramework):
             inputs = []
             outputs = {}
             inputs.append({"txid": utxo["txid"], "vout": utxo["vout"]})
-            outputs[self.nodes[2].getnewaddress()] = utxo["amount"] - 3
+            outputs[self.nodes[2].getnewaddress()] = utxo["amount"] - Decimal('0.3')
             raw_tx = self.nodes[0].createrawtransaction(inputs, outputs)
             txns_to_send.append(self.nodes[0].signrawtransactionwithwallet(raw_tx))
 
@@ -234,55 +242,55 @@ class WalletTest(BTQTestFramework):
         self.generate(self.nodes[1], 1, sync_fun=lambda: self.sync_all(self.nodes[0:3]))
 
         assert_equal(self.nodes[0].getbalance(), 0)
-        assert_equal(self.nodes[2].getbalance(), 94)
+        assert_equal(self.nodes[2].getbalance(), Decimal('9.4'))
 
         # Verify that a spent output cannot be locked anymore
         spent_0 = {"txid": node0utxos[0]["txid"], "vout": node0utxos[0]["vout"]}
         assert_raises_rpc_error(-8, "Invalid parameter, expected unspent output", self.nodes[0].lockunspent, False, [spent_0])
 
-        # Send 10 BTQ normal
+        # Send 1 BTQ normal
         address = self.nodes[0].getnewaddress("test")
         fee_per_byte = Decimal('0.001') / 1000
         self.nodes[2].settxfee(fee_per_byte * 1000)
-        txid = self.nodes[2].sendtoaddress(address, 10, "", "", False)
+        txid = self.nodes[2].sendtoaddress(address, 1, "", "", False)
         self.generate(self.nodes[2], 1, sync_fun=lambda: self.sync_all(self.nodes[0:3]))
-        node_2_bal = self.check_fee_amount(self.nodes[2].getbalance(), Decimal('84'), fee_per_byte, self.get_vsize(self.nodes[2].gettransaction(txid)['hex']))
-        assert_equal(self.nodes[0].getbalance(), Decimal('10'))
+        node_2_bal = self.check_fee_amount(self.nodes[2].getbalance(), Decimal('8.4'), fee_per_byte, self.get_vsize(self.nodes[2].gettransaction(txid)['hex']))
+        assert_equal(self.nodes[0].getbalance(), Decimal('1'))
 
-        # Send 10 BTQ with subtract fee from amount
-        txid = self.nodes[2].sendtoaddress(address, 10, "", "", True)
+        # Send 1 BTQ with subtract fee from amount
+        txid = self.nodes[2].sendtoaddress(address, 1, "", "", True)
         self.generate(self.nodes[2], 1, sync_fun=lambda: self.sync_all(self.nodes[0:3]))
-        node_2_bal -= Decimal('10')
+        node_2_bal -= Decimal('1')
         assert_equal(self.nodes[2].getbalance(), node_2_bal)
-        node_0_bal = self.check_fee_amount(self.nodes[0].getbalance(), Decimal('20'), fee_per_byte, self.get_vsize(self.nodes[2].gettransaction(txid)['hex']))
+        node_0_bal = self.check_fee_amount(self.nodes[0].getbalance(), Decimal('2'), fee_per_byte, self.get_vsize(self.nodes[2].gettransaction(txid)['hex']))
 
         self.log.info("Test sendmany")
 
-        # Sendmany 10 BTQ
-        txid = self.nodes[2].sendmany('', {address: 10}, 0, "", [])
+        # Sendmany 1 BTQ
+        txid = self.nodes[2].sendmany('', {address: 1}, 0, "", [])
         self.generate(self.nodes[2], 1, sync_fun=lambda: self.sync_all(self.nodes[0:3]))
-        node_0_bal += Decimal('10')
-        node_2_bal = self.check_fee_amount(self.nodes[2].getbalance(), node_2_bal - Decimal('10'), fee_per_byte, self.get_vsize(self.nodes[2].gettransaction(txid)['hex']))
+        node_0_bal += Decimal('1')
+        node_2_bal = self.check_fee_amount(self.nodes[2].getbalance(), node_2_bal - Decimal('1'), fee_per_byte, self.get_vsize(self.nodes[2].gettransaction(txid)['hex']))
         assert_equal(self.nodes[0].getbalance(), node_0_bal)
 
-        # Sendmany 10 BTQ with subtract fee from amount
-        txid = self.nodes[2].sendmany('', {address: 10}, 0, "", [address])
+        # Sendmany 1 BTQ with subtract fee from amount
+        txid = self.nodes[2].sendmany('', {address: 1}, 0, "", [address])
         self.generate(self.nodes[2], 1, sync_fun=lambda: self.sync_all(self.nodes[0:3]))
-        node_2_bal -= Decimal('10')
+        node_2_bal -= Decimal('1')
         assert_equal(self.nodes[2].getbalance(), node_2_bal)
-        node_0_bal = self.check_fee_amount(self.nodes[0].getbalance(), node_0_bal + Decimal('10'), fee_per_byte, self.get_vsize(self.nodes[2].gettransaction(txid)['hex']))
+        node_0_bal = self.check_fee_amount(self.nodes[0].getbalance(), node_0_bal + Decimal('1'), fee_per_byte, self.get_vsize(self.nodes[2].gettransaction(txid)['hex']))
 
-        # Sendmany 5 BTQ to two addresses with subtracting fee from both addresses
+        # Sendmany 0.5 BTQ to two addresses with subtracting fee from both addresses
         a0 = self.nodes[0].getnewaddress()
         a1 = self.nodes[0].getnewaddress()
-        txid = self.nodes[2].sendmany(dummy='', amounts={a0: 5, a1: 5}, subtractfeefrom=[a0, a1])
+        txid = self.nodes[2].sendmany(dummy='', amounts={a0: Decimal('0.5'), a1: Decimal('0.5')}, subtractfeefrom=[a0, a1])
         self.generate(self.nodes[2], 1, sync_fun=lambda: self.sync_all(self.nodes[0:3]))
-        node_2_bal -= Decimal('10')
+        node_2_bal -= Decimal('1')
         assert_equal(self.nodes[2].getbalance(), node_2_bal)
         tx = self.nodes[2].gettransaction(txid)
-        node_0_bal = self.check_fee_amount(self.nodes[0].getbalance(), node_0_bal + Decimal('10'), fee_per_byte, self.get_vsize(tx['hex']))
+        node_0_bal = self.check_fee_amount(self.nodes[0].getbalance(), node_0_bal + Decimal('1'), fee_per_byte, self.get_vsize(tx['hex']))
         assert_equal(self.nodes[0].getbalance(), node_0_bal)
-        expected_bal = Decimal('5') + (tx['fee'] / 2)
+        expected_bal = Decimal('0.5') + (tx['fee'] / 2)
         assert_equal(self.nodes[0].getreceivedbyaddress(a0), expected_bal)
         assert_equal(self.nodes[0].getreceivedbyaddress(a1), expected_bal)
 
@@ -292,12 +300,12 @@ class WalletTest(BTQTestFramework):
         explicit_fee_rate_btc_kvb = Decimal(fee_rate_btc_kvb) / 1000
 
         # Test passing fee_rate as a string
-        txid = self.nodes[2].sendmany(amounts={address: 10}, fee_rate=str(fee_rate_sat_vb))
+        txid = self.nodes[2].sendmany(amounts={address: 1}, fee_rate=str(fee_rate_sat_vb))
         self.generate(self.nodes[2], 1, sync_fun=lambda: self.sync_all(self.nodes[0:3]))
         balance = self.nodes[2].getbalance()
-        node_2_bal = self.check_fee_amount(balance, node_2_bal - Decimal('10'), explicit_fee_rate_btc_kvb, self.get_vsize(self.nodes[2].gettransaction(txid)['hex']))
+        node_2_bal = self.check_fee_amount(balance, node_2_bal - Decimal('1'), explicit_fee_rate_btc_kvb, self.get_vsize(self.nodes[2].gettransaction(txid)['hex']))
         assert_equal(balance, node_2_bal)
-        node_0_bal += Decimal('10')
+        node_0_bal += Decimal('1')
         assert_equal(self.nodes[0].getbalance(), node_0_bal)
 
         # Test passing fee_rate as an integer
@@ -315,7 +323,7 @@ class WalletTest(BTQTestFramework):
         # Test setting explicit fee rate just below the minimum.
         self.log.info("Test sendmany raises 'fee rate too low' if fee_rate of 0.99999999 is passed")
         assert_raises_rpc_error(-6, "Fee rate (0.999 sat/vB) is lower than the minimum fee rate setting (1.000 sat/vB)",
-            self.nodes[2].sendmany, amounts={address: 10}, fee_rate=0.999)
+            self.nodes[2].sendmany, amounts={address: 1}, fee_rate=0.999)
 
         self.log.info("Test sendmany raises if an invalid fee_rate is passed")
         # Test fee_rate with zero values.
@@ -328,12 +336,12 @@ class WalletTest(BTQTestFramework):
             assert_raises_rpc_error(-3, msg, self.nodes[2].sendmany, amounts={address: 1.0}, fee_rate=invalid_value)
         # Test fee_rate values that cannot be represented in sat/vB.
         for invalid_value in [0.0001, 0.00000001, 0.00099999, 31.99999999]:
-            assert_raises_rpc_error(-3, msg, self.nodes[2].sendmany, amounts={address: 10}, fee_rate=invalid_value)
+            assert_raises_rpc_error(-3, msg, self.nodes[2].sendmany, amounts={address: 1}, fee_rate=invalid_value)
         # Test fee_rate out of range (negative number).
-        assert_raises_rpc_error(-3, OUT_OF_RANGE, self.nodes[2].sendmany, amounts={address: 10}, fee_rate=-1)
+        assert_raises_rpc_error(-3, OUT_OF_RANGE, self.nodes[2].sendmany, amounts={address: 1}, fee_rate=-1)
         # Test type error.
         for invalid_value in [True, {"foo": "bar"}]:
-            assert_raises_rpc_error(-3, NOT_A_NUMBER_OR_STRING, self.nodes[2].sendmany, amounts={address: 10}, fee_rate=invalid_value)
+            assert_raises_rpc_error(-3, NOT_A_NUMBER_OR_STRING, self.nodes[2].sendmany, amounts={address: 1}, fee_rate=invalid_value)
 
         self.log.info("Test sendmany raises if an invalid conf_target or estimate_mode is passed")
         for target, mode in product([-1, 0, 1009], ["economical", "conservative"]):
@@ -352,9 +360,9 @@ class WalletTest(BTQTestFramework):
         # 2. hex-changed one output to 0.0
         # 3. sign and send
         # 4. check if recipient (node0) can list the zero value tx
-        usp = self.nodes[1].listunspent(query_options={'minimumAmount': '49.998'})[0]
+        usp = self.nodes[1].listunspent(query_options={'minimumAmount': '4.9998'})[0]
         inputs = [{"txid": usp['txid'], "vout": usp['vout']}]
-        outputs = {self.nodes[1].getnewaddress(): 49.998, self.nodes[0].getnewaddress(): 11.11}
+        outputs = {self.nodes[1].getnewaddress(): 4.9998, self.nodes[0].getnewaddress(): 11.11}
 
         raw_tx = self.nodes[1].createrawtransaction(inputs, outputs).replace("c0833842", "00000000")  # replace 11.11 with 0.0 (int32)
         signed_raw_tx = self.nodes[1].signrawtransactionwithwallet(raw_tx)
@@ -383,7 +391,7 @@ class WalletTest(BTQTestFramework):
         self.connect_nodes(0, 2)
         self.sync_all(self.nodes[0:3])
 
-        txid_not_broadcast = self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 2)
+        txid_not_broadcast = self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), Decimal('0.2'))
         tx_obj_not_broadcast = self.nodes[0].gettransaction(txid_not_broadcast)
         self.generate(self.nodes[1], 1, sync_fun=lambda: self.sync_all(self.nodes[0:3]))  # mine a block, tx should not be in there
         assert_equal(self.nodes[2].getbalance(), node_2_bal)  # should not be changed because tx was not broadcasted
@@ -391,12 +399,12 @@ class WalletTest(BTQTestFramework):
         # now broadcast from another node, mine a block, sync, and check the balance
         self.nodes[1].sendrawtransaction(tx_obj_not_broadcast['hex'])
         self.generate(self.nodes[1], 1, sync_fun=lambda: self.sync_all(self.nodes[0:3]))
-        node_2_bal += 2
+        node_2_bal += Decimal('0.2')
         tx_obj_not_broadcast = self.nodes[0].gettransaction(txid_not_broadcast)
         assert_equal(self.nodes[2].getbalance(), node_2_bal)
 
         # create another tx
-        self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 2)
+        self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), Decimal('0.2'))
 
         # restart the nodes with -walletbroadcast=1
         self.stop_nodes()
@@ -409,15 +417,15 @@ class WalletTest(BTQTestFramework):
         self.sync_blocks(self.nodes[0:3])
 
         self.generate(self.nodes[0], 1, sync_fun=lambda: self.sync_blocks(self.nodes[0:3]))
-        node_2_bal += 2
+        node_2_bal += Decimal('0.2')
 
         # tx should be added to balance because after restarting the nodes tx should be broadcast
         assert_equal(self.nodes[2].getbalance(), node_2_bal)
 
         # send a tx with value in a string (PR#6380 +)
-        txid = self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), "2")
+        txid = self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), "0.2")
         tx_obj = self.nodes[0].gettransaction(txid)
-        assert_equal(tx_obj['amount'], Decimal('-2'))
+        assert_equal(tx_obj['amount'], Decimal('-0.2'))
 
         txid = self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), "0.0001")
         tx_obj = self.nodes[0].gettransaction(txid)
@@ -466,12 +474,12 @@ class WalletTest(BTQTestFramework):
             assert_raises_rpc_error(-5, "Pubkey is not a valid public key", self.nodes[0].importpubkey, "5361746f736869204e616b616d6f746f")
 
             # Bech32m addresses cannot be imported into a legacy wallet
-            assert_raises_rpc_error(-5, "Bech32m addresses cannot be imported into legacy wallets", self.nodes[0].importaddress, "bcrt1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqc8gma6")
+            assert_raises_rpc_error(-5, "Bech32m addresses cannot be imported into legacy wallets", self.nodes[0].importaddress, "qcrt1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqsjn9ns")
 
             # Import address and private key to check correct behavior of spendable unspents
             # 1. Send some coins to generate new UTXO
             address_to_import = self.nodes[2].getnewaddress()
-            txid = self.nodes[0].sendtoaddress(address_to_import, 1)
+            txid = self.nodes[0].sendtoaddress(address_to_import, Decimal('0.1'))
             self.sync_mempools(self.nodes[0:3])
             vout = find_vout_for_address(self.nodes[2], txid, address_to_import)
             self.nodes[2].lockunspent(False, [{"txid": txid, "vout": vout}])
@@ -479,9 +487,9 @@ class WalletTest(BTQTestFramework):
 
             self.log.info("Test sendtoaddress with fee_rate param (explicit fee rate in sat/vB)")
             prebalance = self.nodes[2].getbalance()
-            assert prebalance > 2
+            assert prebalance > Decimal('0.2')
             address = self.nodes[1].getnewaddress()
-            amount = 3
+            amount = Decimal('0.3')
             fee_rate_sat_vb = 2
             fee_rate_btc_kvb = fee_rate_sat_vb * 1e3 / 1e8
             # Test passing fee_rate as an integer
@@ -703,14 +711,14 @@ class WalletTest(BTQTestFramework):
 
         self.log.info("Test send* RPCs with verbose=True")
         address = self.nodes[0].getnewaddress("test")
-        txid_feeReason_one = self.nodes[2].sendtoaddress(address=address, amount=5, verbose=True)
+        txid_feeReason_one = self.nodes[2].sendtoaddress(address=address, amount=Decimal('0.5'), verbose=True)
         assert_equal(txid_feeReason_one["fee_reason"], "Fallback fee")
-        txid_feeReason_two = self.nodes[2].sendmany(dummy='', amounts={address: 5}, verbose=True)
+        txid_feeReason_two = self.nodes[2].sendmany(dummy='', amounts={address: Decimal('0.5')}, verbose=True)
         assert_equal(txid_feeReason_two["fee_reason"], "Fallback fee")
         self.log.info("Test send* RPCs with verbose=False")
-        txid_feeReason_three = self.nodes[2].sendtoaddress(address=address, amount=5, verbose=False)
+        txid_feeReason_three = self.nodes[2].sendtoaddress(address=address, amount=Decimal('0.5'), verbose=False)
         assert_equal(self.nodes[2].gettransaction(txid_feeReason_three)['txid'], txid_feeReason_three)
-        txid_feeReason_four = self.nodes[2].sendmany(dummy='', amounts={address: 5}, verbose=False)
+        txid_feeReason_four = self.nodes[2].sendmany(dummy='', amounts={address: Decimal('0.5')}, verbose=False)
         assert_equal(self.nodes[2].gettransaction(txid_feeReason_four)['txid'], txid_feeReason_four)
 
         if self.options.descriptors:
@@ -791,7 +799,7 @@ class WalletTest(BTQTestFramework):
         if not self.options.descriptors:
             return
         self.wallet = MiniWallet(self.nodes[0])
-        self.nodes[0].get_wallet_rpc(self.default_wallet_name).sendtoaddress(self.wallet.get_address(), "5")
+        self.nodes[0].get_wallet_rpc(self.default_wallet_name).sendtoaddress(self.wallet.get_address(), "0.5")
         self.generate(self.wallet, 1, sync_fun=self.no_op)
         self.nodes[0].createwallet("watch_wallet", disable_private_keys=True)
         watch_wallet = self.nodes[0].get_wallet_rpc("watch_wallet")

--- a/test/functional/wallet_multiwallet.py
+++ b/test/functional/wallet_multiwallet.py
@@ -15,7 +15,10 @@ import sys
 import time
 
 from test_framework.authproxy import JSONRPCException
-from test_framework.blocktools import COINBASE_MATURITY
+from test_framework.blocktools import (
+    COINBASE_MATURITY,
+    block_subsidy,
+)
 from test_framework.test_framework import BTQTestFramework
 from test_framework.test_node import ErrorMatch
 from test_framework.util import (
@@ -197,7 +200,7 @@ class MultiWalletTest(BTQTestFramework):
         assert_equal(set(node.listwallets()), {"w4", "w5"})
         w5 = wallet("w5")
         w5_info = w5.getwalletinfo()
-        assert_equal(w5_info['immature_balance'], 50)
+        assert_equal(w5_info['immature_balance'], block_subsidy(1))
 
         competing_wallet_dir = os.path.join(self.options.tmpdir, 'competing_walletdir')
         os.mkdir(competing_wallet_dir)
@@ -222,7 +225,7 @@ class MultiWalletTest(BTQTestFramework):
         self.generatetoaddress(node, nblocks=1, address=wallets[0].getnewaddress(), sync_fun=self.no_op)
         for wallet_name, wallet in zip(wallet_names, wallets):
             info = wallet.getwalletinfo()
-            assert_equal(info['immature_balance'], 50 if wallet is wallets[0] else 0)
+            assert_equal(info['immature_balance'], block_subsidy(1) if wallet is wallets[0] else 0)
             assert_equal(info['walletname'], wallet_name)
 
         # accessing invalid wallet fails
@@ -233,7 +236,7 @@ class MultiWalletTest(BTQTestFramework):
 
         w1, w2, w3, w4, *_ = wallets
         self.generatetoaddress(node, nblocks=COINBASE_MATURITY + 1, address=w1.getnewaddress(), sync_fun=self.no_op)
-        assert_equal(w1.getbalance(), 100)
+        assert_equal(w1.getbalance(), 2 * block_subsidy(1))
         assert_equal(w2.getbalance(), 0)
         assert_equal(w3.getbalance(), 0)
         assert_equal(w4.getbalance(), 0)

--- a/test/functional/wallet_orphanedreward.py
+++ b/test/functional/wallet_orphanedreward.py
@@ -4,6 +4,7 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test orphaned block rewards in the wallet."""
 
+from test_framework.blocktools import block_subsidy
 from test_framework.test_framework import BTQTestFramework
 from test_framework.util import assert_equal
 
@@ -29,13 +30,15 @@ class OrphanedBlockRewardTest(BTQTestFramework):
         # it later.
         self.sync_blocks()
         blk = self.generate(self.nodes[1], 1)[0]
+        reward = block_subsidy(self.nodes[1].getblock(blk)["height"])
 
         # Let the block reward mature and send coins including both
         # the existing balance and the block reward.
         self.generate(self.nodes[0], 150)
-        assert_equal(self.nodes[1].getbalance(), 10 + 25)
+        assert_equal(self.nodes[1].getbalance(), 10 + reward)
         pre_reorg_conf_bals = self.nodes[1].getbalances()
-        txid = self.nodes[1].sendtoaddress(self.nodes[0].getnewaddress(), 30)
+        # Spend more than the pre-existing balance, so the reward is drawn on too.
+        txid = self.nodes[1].sendtoaddress(self.nodes[0].getnewaddress(), 10 + reward / 2)
         orig_chain_tip = self.nodes[0].getbestblockhash()
         self.sync_mempools()
 

--- a/test/functional/wallet_simulaterawtx.py
+++ b/test/functional/wallet_simulaterawtx.py
@@ -6,7 +6,10 @@
 """
 
 from decimal import Decimal
-from test_framework.blocktools import COINBASE_MATURITY
+from test_framework.blocktools import (
+    COINBASE_MATURITY,
+    block_subsidy,
+)
 from test_framework.test_framework import BTQTestFramework
 from test_framework.util import (
     assert_approx,
@@ -41,7 +44,7 @@ class SimulateTxTest(BTQTestFramework):
         w2 = node.get_wallet_rpc('w2')
 
         self.generatetoaddress(node, COINBASE_MATURITY + 1, w0.getnewaddress())
-        assert_equal(w0.getbalance(), 50.0)
+        assert_equal(w0.getbalance(), block_subsidy(1))
         assert_equal(w1.getbalance(), 0.0)
 
         address1 = w1.getnewaddress()
@@ -50,22 +53,22 @@ class SimulateTxTest(BTQTestFramework):
         # Add address1 as watch-only to w2
         w2.importpubkey(pubkey=w1.getaddressinfo(address1)["pubkey"])
 
-        tx1 = node.createrawtransaction([], [{address1: 5.0}])
-        tx2 = node.createrawtransaction([], [{address2: 10.0}])
+        tx1 = node.createrawtransaction([], [{address1: 0.5}])
+        tx2 = node.createrawtransaction([], [{address2: 1.0}])
 
-        # w0 should be unaffected, w2 should see +5 for tx1
+        # w0 should be unaffected, w2 should see +0.5 for tx1
         assert_equal(w0.simulaterawtransaction([tx1])["balance_change"], 0.0)
-        assert_equal(w2.simulaterawtransaction([tx1])["balance_change"], 5.0)
+        assert_equal(w2.simulaterawtransaction([tx1])["balance_change"], 0.5)
 
-        # w1 should see +5 balance for tx1
-        assert_equal(w1.simulaterawtransaction([tx1])["balance_change"], 5.0)
+        # w1 should see +0.5 balance for tx1
+        assert_equal(w1.simulaterawtransaction([tx1])["balance_change"], 0.5)
 
-        # w0 should be unaffected, w2 should see +5 for both transactions
+        # w0 should be unaffected, w2 should see +0.5 for both transactions
         assert_equal(w0.simulaterawtransaction([tx1, tx2])["balance_change"], 0.0)
-        assert_equal(w2.simulaterawtransaction([tx1, tx2])["balance_change"], 5.0)
+        assert_equal(w2.simulaterawtransaction([tx1, tx2])["balance_change"], 0.5)
 
-        # w1 should see +15 balance for both transactions
-        assert_equal(w1.simulaterawtransaction([tx1, tx2])["balance_change"], 15.0)
+        # w1 should see +1.5 balance for both transactions
+        assert_equal(w1.simulaterawtransaction([tx1, tx2])["balance_change"], 1.5)
 
         # w0 funds transaction; it should now see a decrease in (tx fee and payment), and w1 should see the same as above
         funding = w0.fundrawtransaction(tx1)
@@ -73,12 +76,12 @@ class SimulateTxTest(BTQTestFramework):
         tx1changepos = funding["changepos"]
         btq_fee = Decimal(funding["fee"])
 
-        # w0 sees fee + 5 btc decrease, w2 sees + 5 btc
-        assert_approx(w0.simulaterawtransaction([tx1])["balance_change"], -(Decimal("5") + btq_fee))
-        assert_approx(w2.simulaterawtransaction([tx1])["balance_change"], Decimal("5"))
+        # w0 sees fee + 0.5 btq decrease, w2 sees + 0.5 btq
+        assert_approx(w0.simulaterawtransaction([tx1])["balance_change"], -(Decimal("0.5") + btq_fee))
+        assert_approx(w2.simulaterawtransaction([tx1])["balance_change"], Decimal("0.5"))
 
         # w1 sees same as before
-        assert_equal(w1.simulaterawtransaction([tx1])["balance_change"], 5.0)
+        assert_equal(w1.simulaterawtransaction([tx1])["balance_change"], 0.5)
 
         # same inputs (tx) more than once should error
         assert_raises_rpc_error(-8, "Transaction(s) are spending the same output more than once", w0.simulaterawtransaction, [tx1,tx1])
@@ -87,9 +90,9 @@ class SimulateTxTest(BTQTestFramework):
         tx1hex = tx1ob["txid"]
         tx1vout = 1 - tx1changepos
         # tx3 spends new w1 UTXO paying to w0
-        tx3 = node.createrawtransaction([{"txid": tx1hex, "vout": tx1vout}], {w0.getnewaddress(): 4.9999})
+        tx3 = node.createrawtransaction([{"txid": tx1hex, "vout": tx1vout}], {w0.getnewaddress(): 0.49999})
         # tx4 spends new w1 UTXO paying to w1
-        tx4 = node.createrawtransaction([{"txid": tx1hex, "vout": tx1vout}], {w1.getnewaddress(): 4.9999})
+        tx4 = node.createrawtransaction([{"txid": tx1hex, "vout": tx1vout}], {w1.getnewaddress(): 0.49999})
 
         # on their own, both should fail due to missing input(s)
         assert_raises_rpc_error(-8, "One or more transaction inputs are missing or have been spent already", w0.simulaterawtransaction, [tx3])
@@ -99,12 +102,12 @@ class SimulateTxTest(BTQTestFramework):
 
         # they should succeed when including tx1:
         #       wallet                  tx3                             tx4
-        #       w0                      -5 - btq_fee + 4.9999       -5 - btq_fee
-        #       w1                      0                               +4.9999
-        assert_approx(w0.simulaterawtransaction([tx1, tx3])["balance_change"], -Decimal("5") - btq_fee + Decimal("4.9999"))
+        #       w0                      -0.5 - btq_fee + 0.49999    -0.5 - btq_fee
+        #       w1                      0                               +0.49999
+        assert_approx(w0.simulaterawtransaction([tx1, tx3])["balance_change"], -Decimal("0.5") - btq_fee + Decimal("0.49999"))
         assert_approx(w1.simulaterawtransaction([tx1, tx3])["balance_change"], 0)
-        assert_approx(w0.simulaterawtransaction([tx1, tx4])["balance_change"], -Decimal("5") - btq_fee)
-        assert_approx(w1.simulaterawtransaction([tx1, tx4])["balance_change"], Decimal("4.9999"))
+        assert_approx(w0.simulaterawtransaction([tx1, tx4])["balance_change"], -Decimal("0.5") - btq_fee)
+        assert_approx(w1.simulaterawtransaction([tx1, tx4])["balance_change"], Decimal("0.49999"))
 
         # they should fail if attempting to include both tx3 and tx4
         assert_raises_rpc_error(-8, "Transaction(s) are spending the same output more than once", w0.simulaterawtransaction, [tx1, tx3, tx4])
@@ -119,8 +122,8 @@ class SimulateTxTest(BTQTestFramework):
         funding = w0.fundrawtransaction(tx2)
         tx2 = funding["hex"]
         btq_fee2 = Decimal(funding["fee"])
-        assert_approx(w0.simulaterawtransaction([tx2])["balance_change"], -(Decimal("10") + btq_fee2))
-        assert_approx(w1.simulaterawtransaction([tx2])["balance_change"], +(Decimal("10")))
+        assert_approx(w0.simulaterawtransaction([tx2])["balance_change"], -(Decimal("1") + btq_fee2))
+        assert_approx(w1.simulaterawtransaction([tx2])["balance_change"], +(Decimal("1")))
         assert_approx(w2.simulaterawtransaction([tx2])["balance_change"], 0)
 
         # w0-w2 error due to tx1 already being mined


### PR DESCRIPTION
Part of #104.

## What

A large block of the functional suite still asserts Bitcoin's numbers. BTQ pays 5 BTQ per block rather than 50, and halves every 1500 regtest blocks rather than 150, so those tests fail on arithmetic alone.

The adaptation had been started but only partly. `create_coinbase` already paid 5, while `interface_btq_cli.py` carried a BTQ-branded comment with upstream's constant still underneath it:

```python
# The block reward of coinbaseoutput.nValue (50) BTQ/block matures after ...
BALANCE = (BLOCKS - 100) * 50
```

## Approach

Give `blocktools` the subsidy schedule — `INITIAL_BLOCK_SUBSIDY`, `SUBSIDY_HALVING_INTERVAL`, `block_subsidy()`, `cumulative_block_subsidy()` — have `create_coinbase` use it, and express the affected expectations in those terms.

Tests that assert a coinbase value now say so. Tests that only need "some amount smaller than a block reward" are scaled to a tenth, which is what preserves their original intent: `wallet_basic.py` moves 2.1 BTQ around where upstream moved 21, because both are the same fraction of one coinbase.

Two incidental fixes fell out:

- `create_coinbase`'s `nValue` defaulted to `5` and only applied halving and fees when it was left at exactly that value, so `fees` were silently dropped whenever a caller passed an explicit amount. It now defaults to `None`, meaning "pay the consensus subsidy for this height".
- `wallet_basic.py` had a `bcrt1p...` literal that BTQ's address validation rejects outright, so the bech32m-into-legacy-wallet check behind it never actually ran. Recomputed for the `qcrt` HRP.

## Result

15 tests fixed, no regressions:

| | before | after |
|---|---|---|
| passed | 160 | 175 |
| failed | 132 | 117 |

`interface_btq_cli` (both), `rpc_blockchain` (both), `wallet_backup` (both), `wallet_basic` (both), `wallet_multiwallet` (all three), `wallet_orphanedreward`, `wallet_simulaterawtx` (both), `wallet_listtransactions --legacy-wallet`.

`wallet_backup.py --legacy-wallet` and `wallet_listtransactions.py --legacy-wallet` also need #140, which fixes a node abort they hit before reaching any of these assertions.

## Note on the remaining 117

The issue describes the subsidy as the dominant cause. Having categorised the whole suite, it is the largest single family but not the majority — roughly 40% once the indirect cases are counted, since a test that mines blocks expecting 50 each fails with `Insufficient funds` rather than a visible `50`. The rest is a long tail I'll follow up on separately; the next largest is address literals that were switched from `bcrt` to `qcrt` without recomputing the bech32 checksum.
