### PR TITLE
consensus: raise the LWMA window to 144 blocks

### DIFF
--- a/doc/audit-briefing.md
+++ b/doc/audit-briefing.md
@@ -97,7 +97,7 @@ from a constant that moved sitting next to one that did not.
 | Block subsidy | 50 BTC | 5 BTQ | `validation.cpp` |
 | `nPowTargetSpacing` | 600s | 60s | `kernel/chainparams.cpp` |
 | `nSubsidyHalvingInterval` | 210,000 | 2,100,000 | `kernel/chainparams.cpp` |
-| Difficulty algorithm | 2016-block retarget | LWMA, window 45, every block | `pow.cpp`, `consensus/params.h` |
+| Difficulty algorithm | 2016-block retarget | LWMA, window 144, every block | `pow.cpp`, `consensus/params.h` |
 | `CSVHeight` / `SegwitHeight` | 419,328 / 481,824 | 1 / 1 | `kernel/chainparams.cpp` |
 | `nDilithiumP2MRHeight` | n/a | 1 on mainnet, signet, regtest; unscheduled on testnet | `kernel/chainparams.cpp` |
 | `MAX_MONEY` | 21,000,000 | 21,000,000 (unchanged) | `consensus/amount.h` |

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -147,20 +147,33 @@ struct Params {
      *  Blocks at or above this height reject Dilithium opcodes outside P2MR
      *  tapscript and disable the legacy witness-v0 Dilithium keyhash routing. */
     int nDilithiumP2MRHeight{1};
-    /** LWMA averaging window, in blocks.
+    /** LWMA averaging window, in blocks. 144 blocks = 2.4 hours at 60s spacing.
      *
      *  Consensus-critical: changing it on a live chain is a hard fork.
      *
-     *  Inherited as 45 from chains with ~10x longer block spacing, where it
-     *  covers 7.5 hours of history. At BTQ's 60-second spacing the same number
-     *  covers 45 minutes, which is short enough that a half-hour hashrate burst
-     *  dominates the weighted window (weights 1..N sum to N(N+1)/2, so the most
-     *  recent 30 blocks carry 88% of it at N=45 against 20% at N=288).
+     *  Was 45, inherited from chains with ~10x longer block spacing where it
+     *  covers 7.5 hours. At BTQ's 60-second spacing it covered 45 minutes --
+     *  short enough that a half-hour burst dominates the weighted window
+     *  (weights 1..N sum to N(N+1)/2, so the most recent 30 blocks carry 88%
+     *  of it at N=45 against 20% at N=288).
+     *
+     *  Raised to 144 on the April 2026 testnet cliff, the only real profile
+     *  we have (recovered block headers; see issue #110). There a 164-block
+     *  burst drove difficulty 2,235x above baseline in ~2.5 hours, took ~56
+     *  hours to come back, and undershot to 9x BELOW baseline before settling.
+     *  That undershoot is the cheap-block window that makes on-off mining pay.
+     *
+     *  Replaying that event against this formula, driven by the hashrate the
+     *  headers imply: the undershoot collapses between N=120 and N=132 and is
+     *  flat above it, while recovery time grows roughly linearly in N. So 144
+     *  buys the whole of the undershoot protection, and 288 would cost a
+     *  further ~84 hours of recovery for none of it. Statistical jitter at
+     *  constant hashrate also falls from +/-17.1% at N=45 to +/-9.6% here.
+     *  This is where zawy's guidance lands for on-off-plagued coins.
      *
      *  A field rather than a constant so the value can be swept in tests and
-     *  overridden on regtest; see issue #110 and pow_lwma_tests.cpp. Every
-     *  network currently sets 45, so this change is behaviour-preserving. */
-    int nLWMAWindow{45};
+     *  overridden on regtest; see pow_lwma_tests.cpp. */
+    int nLWMAWindow{144};
     std::chrono::seconds PowTargetSpacing() const
     {
         return std::chrono::seconds{nPowTargetSpacing};

--- a/src/test/pow_lwma_tests.cpp
+++ b/src/test/pow_lwma_tests.cpp
@@ -104,7 +104,7 @@ BOOST_AUTO_TEST_CASE(lwma_activation_height_configured)
     const auto testnet_params = CreateChainParams(*m_node.args, ChainType::BTQTEST);
     BOOST_CHECK_EQUAL(testnet_params->GetConsensus().nLWMAHeight, 300000);
     BOOST_CHECK(params->GetConsensus().nDilithiumHeight > 0);
-    BOOST_CHECK_EQUAL(params->GetConsensus().nLWMAWindow, 45);
+    BOOST_CHECK_EQUAL(params->GetConsensus().nLWMAWindow, 144);
 }
 
 BOOST_AUTO_TEST_CASE(lwma_before_activation_uses_legacy_path)
@@ -300,7 +300,14 @@ BOOST_AUTO_TEST_CASE(lwma_formula_reference_parity)
     const int64_t T = consensus.nPowTargetSpacing;
 
     const int64_t k = static_cast<int64_t>(N) * (N + 1) * T / 2;
-    BOOST_CHECK_EQUAL(k, 62100);
+    // Cross-check the closed form against a direct summation of the weights,
+    // rather than against a constant frozen at one N: k is T times the sum of
+    // weights 1..N. At the default N=144, T=60 that is 626,400.
+    int64_t weight_sum = 0;
+    for (int i = 1; i <= N; ++i) {
+        weight_sum += i;
+    }
+    BOOST_CHECK_EQUAL(k, weight_sum * T);
 
     struct Scenario {
         int64_t spacing;


### PR DESCRIPTION
Raises the LWMA averaging window from 45 to 144 blocks — 45 minutes to 2.4 hours at BTQ's 60-second spacing. Closes the value question in #110; PR #124 made the field settable, this picks the value.

## Why 144

45 was inherited from chains with ~10x longer block spacing, where it covers 7.5 hours. Nobody had re-derived it against 60-second blocks.

@unkn0wn747 recovered the block headers from the April 2026 testnet cliff by parsing raw `blk*.dat` records — 10,111 headers over 118 hours, the only real LWMA profile that exists for this chain. What it shows:

- difficulty rose **2,235x** above baseline in ~2.5 hours, on a **164-block** burst
- it took **~56 hours** to come back — a 25-30x asymmetry between recovery and climb
- it then **undershot to ~9x below baseline** before settling

That undershoot is the important part. It is the cheap-block window that makes on-off mining pay: the departure creates the discount that rewards the return.

Replaying that event against `LwmaGetNextWorkRequired`, driven by the hashrate profile the recovered headers imply, and validated against the known outcome before use (N=45 reproduces peak 107,272 vs 127,619 observed, recovery 41 h vs 56 h, undershoot present in both):

| N | peak vs baseline | undershoot | recovery |
| --- | --- | --- | --- |
| 45 | 1,983x | 47x | 41 h |
| 120 | 1,117x | 7.9x | 100 h |
| **144** | **1,055x** | **1.2x** | **123 h** |
| 288 | 580x | 1.2x | 207 h |
| 576 | 326x | 1.2x | 325 h |

The undershoot collapses between N=120 and N=132 and is flat above it, while recovery time grows roughly linearly in N. So 144 buys the whole of the undershoot protection, and 288 would cost a further ~84 hours of recovery for none of it.

Statistical jitter at constant hashrate also drops from ±17.1% at N=45 to ±9.6% at 144 (CV = √(Σw²)/Σw for weights 1..N). At 45 the difficulty wanders ±17% with no hashrate change at all, which is itself an invitation to on-off mining.

144 is also where zawy's guidance lands for coins with on-off mining, as against his general 288.

## Deployment constraint — please confirm before merge

Consensus-critical. Two networks to think about:

- **Mainnet** is pre-launch and sets `nLWMAHeight = 1`, so there is no history to invalidate. Free now, impossible later.
- **Testnet** sets `nLWMAHeight = 300000`. If the live testnet is still **below** height 300,000 this is safe, because LWMA has not activated and the legacy retarget governed every block so far. If it is already past 300,000, **this is a hard fork for testnet** and needs a scheduled activation height instead.

I could not determine the current testnet height from the repo. Someone with a synced testnet node please confirm before this merges.

## What this does not fix

Raising N **lengthens** the bootstrap window. `LwmaGetNextWorkRequired` returns `powLimit` for `height < N`, and mainnet genesis `nBits` already equals `powLimit`, so blocks 1..N are mined at minimum difficulty by construction — now 144 blocks instead of 45.

That is a pre-existing defect, not one this PR introduces, and the exposure is not meaningfully different at either value: at 1 TH/s a `powLimit` block costs 4,838,420 hashes, so the offered rate is ~207,000 blocks/second either way. April produced 518 valid siblings on a single parent at difficulty 57, which is 50,600x *harder* than `powLimit`.

It does mean the bootstrap fix should land too, and ideally first. Filing that separately per the discussion in #110 — the shape is a partial window (`N_eff = min(height, N)`) plus a calibrated genesis `nBits`, which only work together: calibration alone is inert because the branch overrides it, and a partial window alone still leaves several hundred blocks too easy.

## Testing

`nLWMAWindow` is read from params everywhere, so `pow_lwma_tests` sweeps the new value without structural changes. Two assertions were pinned to N=45 and needed updating:

- the default check in `lwma_activation_height_configured`;
- `lwma_formula_reference_parity`, which asserted `k == 62100`. Rather than re-freeze it at 626,400, it now cross-checks the closed form `N(N+1)T/2` against a direct summation of the weights, so it stays meaningful if N moves again.

Local run, CI-parity configure: `pow_lwma_tests`, `pow_tests`, `miner_tests`, `validation_tests`, `validation_block_tests`, `chainparams_seeds_tests` all pass.

Also refreshed the window figure in `doc/audit-briefing.md`, which still said 45.
