### PR TITLE
CVE-2025-46598 parts 2 and 3: sighash midstate cache, single script run, no tx peer punishment

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -557,14 +557,6 @@ private:
                                  bool via_compact_block, const std::string& message = "")
         EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
 
-    /**
-     * Potentially disconnect and discourage a node based on the contents of a TxValidationState object
-     *
-     * @return Returns true if the peer was punished (probably disconnected)
-     */
-    bool MaybePunishNodeForTx(NodeId nodeid, const TxValidationState& state)
-        EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
-
     /** Maybe disconnect a peer and discourage future connections from its address.
      *
      * @param[in]   pnode     The node to check.
@@ -1799,32 +1791,6 @@ bool PeerManagerImpl::MaybePunishNodeForBlock(NodeId nodeid, const BlockValidati
     return false;
 }
 
-bool PeerManagerImpl::MaybePunishNodeForTx(NodeId nodeid, const TxValidationState& state)
-{
-    PeerRef peer{GetPeerRef(nodeid)};
-    switch (state.GetResult()) {
-    case TxValidationResult::TX_RESULT_UNSET:
-        break;
-    // The node is providing invalid data:
-    case TxValidationResult::TX_CONSENSUS:
-        if (peer) Misbehaving(*peer, 100, "");
-        return true;
-    // Conflicting (but not necessarily invalid) data or different policy:
-    case TxValidationResult::TX_RECENT_CONSENSUS_CHANGE:
-    case TxValidationResult::TX_INPUTS_NOT_STANDARD:
-    case TxValidationResult::TX_NOT_STANDARD:
-    case TxValidationResult::TX_MISSING_INPUTS:
-    case TxValidationResult::TX_PREMATURE_SPEND:
-    case TxValidationResult::TX_WITNESS_MUTATED:
-    case TxValidationResult::TX_WITNESS_STRIPPED:
-    case TxValidationResult::TX_CONFLICT:
-    case TxValidationResult::TX_MEMPOOL_POLICY:
-    case TxValidationResult::TX_NO_MEMPOOL:
-        break;
-    }
-    return false;
-}
-
 bool PeerManagerImpl::BlockRequestAllowed(const CBlockIndex* pindex)
 {
     AssertLockHeld(cs_main);
@@ -3032,8 +2998,6 @@ bool PeerManagerImpl::ProcessOrphanTx(Peer& peer)
                     orphan_wtxid.ToString(),
                     peer.m_id,
                     state.ToString());
-                // Maybe punish peer that gave us an invalid orphan tx
-                MaybePunishNodeForTx(peer.m_id, state);
             }
             // Has inputs but not accepted to mempool
             // Probably non-standard or insufficient fee
@@ -4365,7 +4329,6 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
                 tx.GetWitnessHash().ToString(),
                 pfrom.GetId(),
                 state.ToString());
-            MaybePunishNodeForTx(pfrom.GetId(), state);
         }
         return;
     }

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1783,10 +1783,46 @@ bool SignatureHashSchnorr(uint256& hash_out, ScriptExecutionData& execdata, cons
     return true;
 }
 
+int SigHashCache::CacheIndex(int hash_type) noexcept
+{
+    return 3 * !!(hash_type & SIGHASH_ANYONECANPAY) +
+           2 * ((hash_type & 0x1f) == SIGHASH_SINGLE) +
+           1 * ((hash_type & 0x1f) == SIGHASH_NONE);
+}
+
+bool SigHashCache::Load(int hash_type, SigVersion sigversion, const CScript& script_code, HashWriter& writer) const
+{
+    const auto& entry = m_cache_entries[CacheIndex(hash_type)];
+    if (!entry.has_value()) return false;
+    if (entry->sigversion != sigversion) return false;
+    if (entry->script_code != script_code) return false;
+    writer = HashWriter(entry->writer);
+    return true;
+}
+
+void SigHashCache::Store(int hash_type, SigVersion sigversion, const CScript& script_code, const HashWriter& writer)
+{
+    m_cache_entries[CacheIndex(hash_type)] = Entry{script_code, sigversion, writer};
+}
+
 template <class T>
-uint256 SignatureHash(const CScript& scriptCode, const T& txTo, unsigned int nIn, int nHashType, const CAmount& amount, SigVersion sigversion, const PrecomputedTransactionData* cache)
+uint256 SignatureHash(const CScript& scriptCode, const T& txTo, unsigned int nIn, int nHashType, const CAmount& amount, SigVersion sigversion, const PrecomputedTransactionData* cache, SigHashCache* sighash_cache)
 {
     assert(nIn < txTo.vin.size());
+
+    // Hoisted above the cache lookup: this returns a sentinel rather than a
+    // hash, so it has to be reached before any cached midstate can short-circuit.
+    if (sigversion != SigVersion::WITNESS_V0 && (nHashType & 0x1f) == SIGHASH_SINGLE && nIn >= txTo.vout.size()) {
+        //  nOut out of range
+        return uint256::ONE;
+    }
+
+    HashWriter ss{};
+
+    if (sighash_cache && sighash_cache->Load(nHashType, sigversion, scriptCode, ss)) {
+        ss << nHashType;
+        return ss.GetHash();
+    }
 
     if (sigversion == SigVersion::WITNESS_V0) {
         uint256 hashPrevouts;
@@ -1806,12 +1842,11 @@ uint256 SignatureHash(const CScript& scriptCode, const T& txTo, unsigned int nIn
         if ((nHashType & 0x1f) != SIGHASH_SINGLE && (nHashType & 0x1f) != SIGHASH_NONE) {
             hashOutputs = cacheready ? cache->hashOutputs : SHA256Uint256(GetOutputsSHA256(txTo));
         } else if ((nHashType & 0x1f) == SIGHASH_SINGLE && nIn < txTo.vout.size()) {
-            HashWriter ss{};
-            ss << txTo.vout[nIn];
-            hashOutputs = ss.GetHash();
+            HashWriter ss_output{};
+            ss_output << txTo.vout[nIn];
+            hashOutputs = ss_output.GetHash();
         }
 
-        HashWriter ss{};
         // Version
         ss << txTo.nVersion;
         // Input prevouts/nSequence (none/all, depending on flags)
@@ -1828,26 +1863,18 @@ uint256 SignatureHash(const CScript& scriptCode, const T& txTo, unsigned int nIn
         ss << hashOutputs;
         // Locktime
         ss << txTo.nLockTime;
-        // Sighash type
-        ss << nHashType;
-
-        return ss.GetHash();
+    } else {
+        // Wrapper to serialize only the necessary parts of the transaction being signed
+        CTransactionSignatureSerializer<T> txTmp(txTo, scriptCode, nIn, nHashType);
+        ss << txTmp;
     }
 
-    // Check for invalid use of SIGHASH_SINGLE
-    if ((nHashType & 0x1f) == SIGHASH_SINGLE) {
-        if (nIn >= txTo.vout.size()) {
-            //  nOut out of range
-            return uint256::ONE;
-        }
-    }
+    // Everything above this point is what the midstate covers; only the sighash
+    // type is appended afterwards, so one entry serves all types in its mode.
+    if (sighash_cache) sighash_cache->Store(nHashType, sigversion, scriptCode, ss);
 
-    // Wrapper to serialize only the necessary parts of the transaction being signed
-    CTransactionSignatureSerializer<T> txTmp(txTo, scriptCode, nIn, nHashType);
-
-    // Serialize and hash
-    HashWriter ss{};
-    ss << txTmp << nHashType;
+    // Sighash type
+    ss << nHashType;
     return ss.GetHash();
 }
 
@@ -1880,7 +1907,7 @@ bool GenericTransactionSignatureChecker<T>::CheckECDSASignature(const std::vecto
     // Witness sighashes need the amount.
     if (sigversion == SigVersion::WITNESS_V0 && amount < 0) return HandleMissingData(m_mdb);
 
-    uint256 sighash = SignatureHash(scriptCode, *txTo, nIn, nHashType, amount, sigversion, this->txdata);
+    uint256 sighash = SignatureHash(scriptCode, *txTo, nIn, nHashType, amount, sigversion, this->txdata, &m_sighash_cache);
 
     if (!VerifyECDSASignature(vchSig, pubkey, sighash))
         return false;
@@ -1940,7 +1967,7 @@ bool GenericTransactionSignatureChecker<T>::CheckDilithiumSignature(const std::v
         if (!this->txdata || !execdata) return HandleMissingData(m_mdb);
         if (!SignatureHashSchnorr(sighash, *execdata, *txTo, nIn, static_cast<uint8_t>(nHashType), sigversion, *this->txdata, m_mdb)) return false;
     } else {
-        sighash = SignatureHash(scriptCode, *txTo, nIn, nHashType, amount, sigversion, this->txdata);
+        sighash = SignatureHash(scriptCode, *txTo, nIn, nHashType, amount, sigversion, this->txdata, &m_sighash_cache);
     }
 
     // Verify the Dilithium signature

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -258,8 +258,41 @@ extern const HashWriter HASHER_TAPSIGHASH; //!< Hasher with tag "TapSighash" pre
 extern const HashWriter HASHER_TAPLEAF;    //!< Hasher with tag "TapLeaf" pre-fed to it.
 extern const HashWriter HASHER_TAPBRANCH;  //!< Hasher with tag "TapBranch" pre-fed to it.
 
+/** Caches SHA256 midstates for the non-taproot sighash calculations (bare, P2SH,
+ *  P2WPKH, P2WSH, and the Dilithium spends that share those paths).
+ *
+ *  Within a single input, the sighash depends only on the script code, the
+ *  signature hash type and the sig version. Legacy sighash re-serialises the
+ *  whole transaction each time, so a script that forces many sighashes over one
+ *  input -- via OP_CODESEPARATOR, or simply many signatures -- costs quadratic
+ *  work. Remembering the hash state from just before the type byte is appended
+ *  collapses that back to linear whenever the script code repeats.
+ *
+ *  Keyed on sig version as well as script code, which upstream does not do; see
+ *  the comment on CacheIndex. */
+class SigHashCache
+{
+    struct Entry {
+        CScript script_code;
+        SigVersion sigversion;
+        HashWriter writer;
+    };
+
+    /** One slot per sighash mode: ALL, NONE, SINGLE, and each with ANYONECANPAY. */
+    std::optional<Entry> m_cache_entries[6];
+
+    /** Which of the six slots a hash type belongs to. */
+    static int CacheIndex(int hash_type) noexcept;
+
+public:
+    /** Load the midstate for this key into writer, if one is cached. */
+    [[nodiscard]] bool Load(int hash_type, SigVersion sigversion, const CScript& script_code, HashWriter& writer) const;
+    /** Remember the midstate for this key. */
+    void Store(int hash_type, SigVersion sigversion, const CScript& script_code, const HashWriter& writer);
+};
+
 template <class T>
-uint256 SignatureHash(const CScript& scriptCode, const T& txTo, unsigned int nIn, int nHashType, const CAmount& amount, SigVersion sigversion, const PrecomputedTransactionData* cache = nullptr);
+uint256 SignatureHash(const CScript& scriptCode, const T& txTo, unsigned int nIn, int nHashType, const CAmount& amount, SigVersion sigversion, const PrecomputedTransactionData* cache = nullptr, SigHashCache* sighash_cache = nullptr);
 
 class BaseSignatureChecker
 {
@@ -313,6 +346,9 @@ private:
     unsigned int nIn;
     const CAmount amount;
     const PrecomputedTransactionData* txdata;
+    /** Scoped to this checker, so it lives exactly as long as one input's
+     *  script execution -- which is the span over which its key is valid. */
+    mutable SigHashCache m_sighash_cache;
 
 protected:
     virtual bool VerifyECDSASignature(const std::vector<unsigned char>& vchSig, const CPubKey& vchPubKey, const uint256& sighash) const;

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -206,4 +206,83 @@ BOOST_AUTO_TEST_CASE(sighash_from_data)
         BOOST_CHECK_MESSAGE(sh.GetHex() == sigHashHex, strTest);
     }
 }
+
+//! The cache must key on everything the midstate depends on. Upstream omits the
+//! sig version, on the grounds that no input can reach both the BASE and the
+//! WITNESS_V0 path; that does not hold here, because CheckDilithiumSignature
+//! dispatches on sigversion within a single input, so we key on it too. A cache
+//! that ignored it would hand a BASE midstate to a WITNESS_V0 signature and
+//! validate a signature over the wrong message.
+BOOST_AUTO_TEST_CASE(sighash_cache_keying)
+{
+    const CScript script_a = CScript() << OP_1;
+    const CScript script_b = CScript() << OP_2;
+
+    HashWriter stored{};
+    stored << uint256::ONE;
+    const uint256 expected{HashWriter{stored}.GetHash()};
+
+    SigHashCache cache;
+    cache.Store(SIGHASH_ALL, SigVersion::BASE, script_a, stored);
+
+    HashWriter out{};
+    BOOST_CHECK(cache.Load(SIGHASH_ALL, SigVersion::BASE, script_a, out));
+    BOOST_CHECK_EQUAL(out.GetHash().GetHex(), expected.GetHex());
+
+    // The midstate stops short of the type byte, so any type in the same mode is
+    // a hit. That is the whole point: one entry serves all 256 of them.
+    out = HashWriter{};
+    BOOST_CHECK(cache.Load(SIGHASH_ALL | 0x40, SigVersion::BASE, script_a, out));
+    BOOST_CHECK_EQUAL(out.GetHash().GetHex(), expected.GetHex());
+
+    // Anything else must miss.
+    BOOST_CHECK(!cache.Load(SIGHASH_ALL, SigVersion::BASE, script_b, out));
+    BOOST_CHECK(!cache.Load(SIGHASH_ALL, SigVersion::WITNESS_V0, script_a, out));
+    BOOST_CHECK(!cache.Load(SIGHASH_NONE, SigVersion::BASE, script_a, out));
+    BOOST_CHECK(!cache.Load(SIGHASH_SINGLE, SigVersion::BASE, script_a, out));
+    BOOST_CHECK(!cache.Load(SIGHASH_ALL | SIGHASH_ANYONECANPAY, SigVersion::BASE, script_a, out));
+}
+
+//! A cached run must produce byte-identical sighashes to an uncached one.
+BOOST_AUTO_TEST_CASE(sighash_caching)
+{
+    for (int i = 0; i < 300; i++) {
+        CMutableTransaction tx;
+        RandomTransaction(tx, /*fSingle=*/InsecureRandBool());
+        const unsigned int nIn = InsecureRandRange(tx.vin.size());
+        const CAmount amount{InsecureRandMoneyAmount()};
+
+        std::vector<CScript> script_codes(3);
+        for (auto& script_code : script_codes) RandomScript(script_code);
+
+        // One cache per input, matching the lifetime the checker gives it.
+        SigHashCache cache;
+
+        auto check = [&](const CScript& script_code, int nHashType, SigVersion sigversion) {
+            const uint256 uncached{SignatureHash(script_code, tx, nIn, nHashType, amount, sigversion, nullptr, nullptr)};
+            const uint256 cached{SignatureHash(script_code, tx, nIn, nHashType, amount, sigversion, nullptr, &cache)};
+            BOOST_CHECK_EQUAL(uncached.GetHex(), cached.GetHex());
+        };
+
+        for (const SigVersion sigversion : {SigVersion::BASE, SigVersion::WITNESS_V0}) {
+            // Walk every mode with a fixed script code, varying only the bits
+            // that do not select the mode. Every call after the first in each
+            // group is a guaranteed hit, so this exercises reuse rather than
+            // just repeatedly missing.
+            for (const int base : {int{SIGHASH_ALL}, int{SIGHASH_NONE}, int{SIGHASH_SINGLE}}) {
+                for (const int acp : {0, int{SIGHASH_ANYONECANPAY}}) {
+                    for (const int spare : {0x00, 0x20, 0x40, 0x60}) {
+                        check(script_codes[0], base | acp | spare, sigversion);
+                    }
+                }
+            }
+        }
+
+        // Now churn the key so entries are evicted and refilled out of order.
+        for (int round = 0; round < 20; round++) {
+            const SigVersion sigversion{InsecureRandBool() ? SigVersion::BASE : SigVersion::WITNESS_V0};
+            check(script_codes[InsecureRandRange(script_codes.size())], int(InsecureRand32()), sigversion);
+        }
+    }
+}
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -22,7 +22,8 @@ struct Dersig100Setup : public TestChain100Setup {
 bool CheckInputScripts(const CTransaction& tx, TxValidationState& state,
                        const CCoinsViewCache& inputs, unsigned int flags, bool cacheSigStore,
                        bool cacheFullScriptStore, PrecomputedTransactionData& txdata,
-                       std::vector<CScriptCheck>* pvChecks) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+                       std::vector<CScriptCheck>* pvChecks,
+                       bool policy_flags = false) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 BOOST_AUTO_TEST_SUITE(txvalidationcache_tests)
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -132,7 +132,8 @@ const CBlockIndex* Chainstate::FindForkInGlobalIndex(const CBlockLocator& locato
 bool CheckInputScripts(const CTransaction& tx, TxValidationState& state,
                        const CCoinsViewCache& inputs, unsigned int flags, bool cacheSigStore,
                        bool cacheFullScriptStore, PrecomputedTransactionData& txdata,
-                       std::vector<CScriptCheck>* pvChecks = nullptr)
+                       std::vector<CScriptCheck>* pvChecks = nullptr,
+                       bool policy_flags = false)
                        EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 bool CheckFinalTxAtTip(const CBlockIndex& active_chain_tip, const CTransaction& tx)
@@ -1041,7 +1042,8 @@ bool MemPoolAccept::PolicyScriptChecks(const ATMPArgs& args, Workspace& ws)
 
     // Check input scripts and signatures.
     // This is done last to help prevent CPU exhaustion denial-of-service attacks.
-    if (!CheckInputScripts(tx, state, m_view, scriptVerifyFlags, true, false, ws.m_precomputed_txdata)) {
+    if (!CheckInputScripts(tx, state, m_view, scriptVerifyFlags, true, false, ws.m_precomputed_txdata,
+                           /*pvChecks=*/nullptr, /*policy_flags=*/true)) {
         // Detect a stripped witness, so p2p code knows not to cache the
         // rejection against a txid that a witness would have made valid.
         //
@@ -1857,15 +1859,18 @@ bool InitScriptExecutionCache(size_t max_size_bytes)
  * which are matched. This is useful for checking blocks where we will likely never need the cache
  * entry again.
  *
- * Note that we may set state.reason to NOT_STANDARD for extra soft-fork flags in flags, block-checking
- * callers should probably reset it to CONSENSUS in such cases.
+ * Set policy_flags when flags carry mempool policy on top of consensus, so that a
+ * failure is reported as TX_NOT_STANDARD rather than TX_CONSENSUS. Do not infer this
+ * from flags: SCRIPT_VERIFY_DILITHIUM_P2MR_ONLY is standard-but-not-mandatory and yet
+ * blocks enforce it once DEPLOYMENT_DILITHIUM_P2MR activates, so the presence of a
+ * standard-not-mandatory flag does not by itself mean we are validating for the mempool.
  *
  * Non-static (and re-declared) in src/test/txvalidationcache_tests.cpp
  */
 bool CheckInputScripts(const CTransaction& tx, TxValidationState& state,
                        const CCoinsViewCache& inputs, unsigned int flags, bool cacheSigStore,
                        bool cacheFullScriptStore, PrecomputedTransactionData& txdata,
-                       std::vector<CScriptCheck>* pvChecks)
+                       std::vector<CScriptCheck>* pvChecks, bool policy_flags)
 {
     if (tx.IsCoinBase()) return true;
 
@@ -1913,36 +1918,21 @@ bool CheckInputScripts(const CTransaction& tx, TxValidationState& state,
         if (pvChecks) {
             pvChecks->emplace_back(std::move(check));
         } else if (!check()) {
-            if (flags & STANDARD_NOT_MANDATORY_VERIFY_FLAGS) {
-                // Check whether the failure was caused by a
-                // non-mandatory script verification check, such as
-                // non-standard DER encodings or non-null dummy
-                // arguments; if so, ensure we return NOT_STANDARD
-                // instead of CONSENSUS to avoid downstream users
-                // splitting the network between upgraded and
-                // non-upgraded nodes by banning CONSENSUS-failing
-                // data providers.
-                //
-                // BTQ: SCRIPT_VERIFY_DILITHIUM is in MANDATORY_SCRIPT_VERIFY_FLAGS
-                // so it survives this mask. That is required for the testnet
-                // policy-ahead SCRIPT_VERIFY_DILITHIUM_P2MR_ONLY regime: a
-                // consensus-valid legacy Dilithium spend must soft-fail as
-                // TX_NOT_STANDARD here, not lose Dilithium on the retry and
-                // come back as TX_CONSENSUS (Misbehaving).
-                CScriptCheck check2(txdata.m_spent_outputs[i], tx, i,
-                        flags & ~STANDARD_NOT_MANDATORY_VERIFY_FLAGS, cacheSigStore, &txdata);
-                if (check2())
-                    return state.Invalid(TxValidationResult::TX_NOT_STANDARD, strprintf("non-mandatory-script-verify-flag (%s)", ScriptErrorString(check.GetScriptError())));
+            // A failing script used to be re-run with the non-mandatory flags
+            // masked off, purely to tell a policy failure from a consensus one
+            // so that peers relaying the latter could be discouraged. Nothing
+            // discourages peers over transactions any more, so that second run
+            // buys nothing and doubles the CPU an attacker can make us spend on
+            // a transaction we are going to reject regardless.
+            //
+            // Dropping it also removes a trap for BTQ's testnet policy-ahead
+            // Dilithium regime, which relied on SCRIPT_VERIFY_DILITHIUM being
+            // mandatory so the retry could not reclassify a policy-only failure
+            // as TX_CONSENSUS. Mempool failures are now unconditionally
+            // TX_NOT_STANDARD, so that no longer rests on flag placement.
+            if (policy_flags) {
+                return state.Invalid(TxValidationResult::TX_NOT_STANDARD, strprintf("mempool-script-verify-flag-failed (%s)", ScriptErrorString(check.GetScriptError())));
             }
-            // MANDATORY flag failures correspond to
-            // TxValidationResult::TX_CONSENSUS. Because CONSENSUS
-            // failures are the most serious case of validation
-            // failures, we may need to consider using
-            // RECENT_CONSENSUS_CHANGE for any script failure that
-            // could be due to non-upgraded nodes which we may want to
-            // support, to avoid splitting the network (but this
-            // depends on the details of how net_processing handles
-            // such errors).
             return state.Invalid(TxValidationResult::TX_CONSENSUS, strprintf("mandatory-script-verify-flag-failed (%s)", ScriptErrorString(check.GetScriptError())));
         }
     }

--- a/test/functional/data/invalid_txs.py
+++ b/test/functional/data/invalid_txs.py
@@ -69,9 +69,6 @@ class BadTxTemplate:
     # Only specified if it differs from mempool acceptance error.
     block_reject_reason = ""
 
-    # Do we expect to be disconnected after submitting this tx?
-    expect_disconnect = False
-
     # Is this tx considered valid when included in a block, but not for acceptance into
     # the mempool (i.e. does it violate policy but not consensus)?
     valid_in_block = False
@@ -89,7 +86,6 @@ class BadTxTemplate:
 
 class OutputMissing(BadTxTemplate):
     reject_reason = "bad-txns-vout-empty"
-    expect_disconnect = True
 
     def get_tx(self):
         tx = CTransaction()
@@ -100,7 +96,6 @@ class OutputMissing(BadTxTemplate):
 
 class InputMissing(BadTxTemplate):
     reject_reason = "bad-txns-vin-empty"
-    expect_disconnect = True
 
     # We use a blank transaction here to make sure
     # it is interpreted as a non-witness transaction.
@@ -117,7 +112,6 @@ class InputMissing(BadTxTemplate):
 # tree depth commitment (CVE-2017-12842)
 class SizeTooSmall(BadTxTemplate):
     reject_reason = "tx-size-small"
-    expect_disconnect = False
     valid_in_block = True
 
     def get_tx(self):
@@ -134,7 +128,6 @@ class BadInputOutpointIndex(BadTxTemplate):
     # Won't be rejected - nonexistent outpoint index is treated as an orphan since the coins
     # database can't distinguish between spent outpoints and outpoints which never existed.
     reject_reason = None
-    expect_disconnect = False
 
     def get_tx(self):
         num_indices = len(self.spend_tx.vin)
@@ -149,7 +142,6 @@ class BadInputOutpointIndex(BadTxTemplate):
 
 class DuplicateInput(BadTxTemplate):
     reject_reason = 'bad-txns-inputs-duplicate'
-    expect_disconnect = True
 
     def get_tx(self):
         tx = CTransaction()
@@ -162,7 +154,6 @@ class DuplicateInput(BadTxTemplate):
 
 class PrevoutNullInput(BadTxTemplate):
     reject_reason = 'bad-txns-prevout-null'
-    expect_disconnect = True
 
     def get_tx(self):
         tx = CTransaction()
@@ -175,7 +166,6 @@ class PrevoutNullInput(BadTxTemplate):
 
 class NonexistentInput(BadTxTemplate):
     reject_reason = None  # Added as an orphan tx.
-    expect_disconnect = False
 
     def get_tx(self):
         tx = CTransaction()
@@ -188,7 +178,6 @@ class NonexistentInput(BadTxTemplate):
 
 class SpendTooMuch(BadTxTemplate):
     reject_reason = 'bad-txns-in-belowout'
-    expect_disconnect = True
 
     def get_tx(self):
         return create_tx_with_script(
@@ -197,7 +186,6 @@ class SpendTooMuch(BadTxTemplate):
 
 class CreateNegative(BadTxTemplate):
     reject_reason = 'bad-txns-vout-negative'
-    expect_disconnect = True
 
     def get_tx(self):
         return create_tx_with_script(self.spend_tx, 0, amount=-1)
@@ -205,7 +193,6 @@ class CreateNegative(BadTxTemplate):
 
 class CreateTooLarge(BadTxTemplate):
     reject_reason = 'bad-txns-vout-toolarge'
-    expect_disconnect = True
 
     def get_tx(self):
         return create_tx_with_script(self.spend_tx, 0, amount=MAX_MONEY + 1)
@@ -213,7 +200,6 @@ class CreateTooLarge(BadTxTemplate):
 
 class CreateSumTooLarge(BadTxTemplate):
     reject_reason = 'bad-txns-txouttotal-toolarge'
-    expect_disconnect = True
 
     def get_tx(self):
         tx = create_tx_with_script(self.spend_tx, 0, amount=MAX_MONEY)
@@ -223,8 +209,8 @@ class CreateSumTooLarge(BadTxTemplate):
 
 
 class InvalidOPIFConstruction(BadTxTemplate):
-    reject_reason = "mandatory-script-verify-flag-failed (Invalid OP_IF construction)"
-    expect_disconnect = True
+    reject_reason = "mempool-script-verify-flag-failed (Invalid OP_IF construction)"
+    block_reject_reason = "mandatory-script-verify-flag-failed (Invalid OP_IF construction)"
     valid_in_block = True
 
     def get_tx(self):
@@ -236,7 +222,6 @@ class InvalidOPIFConstruction(BadTxTemplate):
 class TooManySigops(BadTxTemplate):
     reject_reason = "bad-txns-too-many-sigops"
     block_reject_reason = "bad-blk-sigops, out-of-bounds SigOpCount"
-    expect_disconnect = False
 
     def get_tx(self):
         lotsa_checksigs = CScript([OP_CHECKSIG] * (MAX_BLOCK_SIGOPS))
@@ -258,7 +243,6 @@ def getDisabledOpcodeTemplate(opcode):
 
     return type('DisabledOpcode_' + str(opcode), (BadTxTemplate,), {
         'reject_reason': "disabled opcode",
-        'expect_disconnect': True,
         'get_tx': get_tx,
         'valid_in_block' : True
         })

--- a/test/functional/feature_cltv.py
+++ b/test/functional/feature_cltv.py
@@ -150,12 +150,15 @@ class BIP65Test(BTQTestFramework):
             spendtx = wallet.create_self_transfer()['tx']
             cltv_invalidate(spendtx, i)
 
-            expected_cltv_reject_reason = [
-                "mandatory-script-verify-flag-failed (Operation not valid with the current stack size)",
-                "mandatory-script-verify-flag-failed (Negative locktime)",
-                "mandatory-script-verify-flag-failed (Locktime requirement not satisfied)",
-                "mandatory-script-verify-flag-failed (Locktime requirement not satisfied)",
-                "mandatory-script-verify-flag-failed (Locktime requirement not satisfied)",
+            # The same script error is reported with a different prefix depending
+            # on where validation happened: the mempool no longer distinguishes
+            # policy from consensus failures, blocks still do.
+            cltv_script_error = [
+                "Operation not valid with the current stack size",
+                "Negative locktime",
+                "Locktime requirement not satisfied",
+                "Locktime requirement not satisfied",
+                "Locktime requirement not satisfied",
             ][i]
             # First we show that this tx is valid except for CLTV by getting it
             # rejected from the mempool for exactly that reason.
@@ -164,7 +167,7 @@ class BIP65Test(BTQTestFramework):
                     'txid': spendtx.hash,
                     'wtxid': spendtx.getwtxid(),
                     'allowed': False,
-                    'reject-reason': expected_cltv_reject_reason,
+                    'reject-reason': f'mempool-script-verify-flag-failed ({cltv_script_error})',
                 }],
                 self.nodes[0].testmempoolaccept(rawtxs=[spendtx.serialize().hex()], maxfeerate=0),
             )
@@ -174,7 +177,7 @@ class BIP65Test(BTQTestFramework):
             block.hashMerkleRoot = block.calc_merkle_root()
             block.solve()
 
-            with self.nodes[0].assert_debug_log(expected_msgs=[f'CheckInputScripts on {block.vtx[-1].hash} failed with {expected_cltv_reject_reason}']):
+            with self.nodes[0].assert_debug_log(expected_msgs=[f'CheckInputScripts on {block.vtx[-1].hash} failed with mandatory-script-verify-flag-failed ({cltv_script_error})']):
                 peer.send_and_ping(msg_block(block))
                 assert_equal(int(self.nodes[0].getbestblockhash(), 16), tip)
                 peer.sync_with_ping()

--- a/test/functional/feature_dersig.py
+++ b/test/functional/feature_dersig.py
@@ -120,7 +120,7 @@ class BIP66Test(BTQTestFramework):
                 'txid': spendtx.hash,
                 'wtxid': spendtx.getwtxid(),
                 'allowed': False,
-                'reject-reason': 'mandatory-script-verify-flag-failed (Non-canonical DER signature)',
+                'reject-reason': 'mempool-script-verify-flag-failed (Non-canonical DER signature)',
             }],
             self.nodes[0].testmempoolaccept(rawtxs=[spendtx.serialize().hex()], maxfeerate=0),
         )

--- a/test/functional/feature_nulldummy.py
+++ b/test/functional/feature_nulldummy.py
@@ -37,7 +37,10 @@ from test_framework.util import (
 from test_framework.wallet import getnewdestination
 from test_framework.wallet_util import generate_keypair
 
-NULLDUMMY_ERROR = "mandatory-script-verify-flag-failed (Dummy CHECKMULTISIG argument must be zero)"
+NULLDUMMY_SCRIPT_ERROR = "Dummy CHECKMULTISIG argument must be zero"
+# The mempool and block paths report the same script error differently.
+NULLDUMMY_MEMPOOL_ERROR = f"mempool-script-verify-flag-failed ({NULLDUMMY_SCRIPT_ERROR})"
+NULLDUMMY_BLOCK_ERROR = f"mandatory-script-verify-flag-failed ({NULLDUMMY_SCRIPT_ERROR})"
 
 
 def invalidate_nulldummy_tx(tx):
@@ -106,7 +109,7 @@ class NULLDUMMYTest(BTQTestFramework):
                                           addr=self.ms_address, amount=47,
                                           privkey=self.privkey)
         invalidate_nulldummy_tx(test2tx)
-        assert_raises_rpc_error(-26, NULLDUMMY_ERROR, self.nodes[0].sendrawtransaction, test2tx.serialize_with_witness().hex(), 0)
+        assert_raises_rpc_error(-26, NULLDUMMY_MEMPOOL_ERROR, self.nodes[0].sendrawtransaction, test2tx.serialize_with_witness().hex(), 0)
 
         self.log.info(f"Test 3: Non-NULLDUMMY base transactions should be accepted in a block before activation [{COINBASE_MATURITY + 4}]")
         self.block_submit(self.nodes[0], [test2tx], accept=True)
@@ -117,7 +120,7 @@ class NULLDUMMYTest(BTQTestFramework):
                                           privkey=self.privkey)
         test6txs = [CTransaction(test4tx)]
         invalidate_nulldummy_tx(test4tx)
-        assert_raises_rpc_error(-26, NULLDUMMY_ERROR, self.nodes[0].sendrawtransaction, test4tx.serialize_with_witness().hex(), 0)
+        assert_raises_rpc_error(-26, NULLDUMMY_MEMPOOL_ERROR, self.nodes[0].sendrawtransaction, test4tx.serialize_with_witness().hex(), 0)
         self.block_submit(self.nodes[0], [test4tx], accept=False)
 
         self.log.info("Test 5: Non-NULLDUMMY P2WSH multisig transaction invalid after activation")
@@ -127,7 +130,7 @@ class NULLDUMMYTest(BTQTestFramework):
                                           privkey=self.privkey)
         test6txs.append(CTransaction(test5tx))
         test5tx.wit.vtxinwit[0].scriptWitness.stack[0] = b'\x01'
-        assert_raises_rpc_error(-26, NULLDUMMY_ERROR, self.nodes[0].sendrawtransaction, test5tx.serialize_with_witness().hex(), 0)
+        assert_raises_rpc_error(-26, NULLDUMMY_MEMPOOL_ERROR, self.nodes[0].sendrawtransaction, test5tx.serialize_with_witness().hex(), 0)
         self.block_submit(self.nodes[0], [test5tx], with_witness=True, accept=False)
 
         self.log.info(f"Test 6: NULLDUMMY compliant base/witness transactions should be accepted to mempool and in block after activation [{COINBASE_MATURITY + 5}]")
@@ -143,7 +146,7 @@ class NULLDUMMYTest(BTQTestFramework):
         if with_witness:
             add_witness_commitment(block)
         block.solve()
-        assert_equal(None if accept else NULLDUMMY_ERROR, node.submitblock(block.serialize().hex()))
+        assert_equal(None if accept else NULLDUMMY_BLOCK_ERROR, node.submitblock(block.serialize().hex()))
         if accept:
             assert_equal(node.getbestblockhash(), block.hash)
             self.lastblockhash = block.hash

--- a/test/functional/feature_segwit.py
+++ b/test/functional/feature_segwit.py
@@ -232,8 +232,8 @@ class SegWitTest(BTQTestFramework):
         assert_equal(self.nodes[2].getbalance(), 20 * Decimal("4.999"))
 
         self.log.info("Verify unsigned p2sh witness txs without a redeem script are invalid")
-        self.fail_accept(self.nodes[2], "mandatory-script-verify-flag-failed (Operation not valid with the current stack size)", p2sh_ids[NODE_2][P2WPKH][1], sign=False)
-        self.fail_accept(self.nodes[2], "mandatory-script-verify-flag-failed (Operation not valid with the current stack size)", p2sh_ids[NODE_2][P2WSH][1], sign=False)
+        self.fail_accept(self.nodes[2], "mempool-script-verify-flag-failed (Operation not valid with the current stack size)", p2sh_ids[NODE_2][P2WPKH][1], sign=False)
+        self.fail_accept(self.nodes[2], "mempool-script-verify-flag-failed (Operation not valid with the current stack size)", p2sh_ids[NODE_2][P2WSH][1], sign=False)
 
         self.generate(self.nodes[0], 1)  # block 164
 
@@ -252,13 +252,13 @@ class SegWitTest(BTQTestFramework):
 
         self.log.info("Verify default node can't accept txs with missing witness")
         # unsigned, no scriptsig
-        self.fail_accept(self.nodes[0], "mandatory-script-verify-flag-failed (Witness program hash mismatch)", wit_ids[NODE_0][P2WPKH][0], sign=False)
-        self.fail_accept(self.nodes[0], "mandatory-script-verify-flag-failed (Witness program was passed an empty witness)", wit_ids[NODE_0][P2WSH][0], sign=False)
-        self.fail_accept(self.nodes[0], "mandatory-script-verify-flag-failed (Operation not valid with the current stack size)", p2sh_ids[NODE_0][P2WPKH][0], sign=False)
-        self.fail_accept(self.nodes[0], "mandatory-script-verify-flag-failed (Operation not valid with the current stack size)", p2sh_ids[NODE_0][P2WSH][0], sign=False)
+        self.fail_accept(self.nodes[0], "mempool-script-verify-flag-failed (Witness program hash mismatch)", wit_ids[NODE_0][P2WPKH][0], sign=False)
+        self.fail_accept(self.nodes[0], "mempool-script-verify-flag-failed (Witness program was passed an empty witness)", wit_ids[NODE_0][P2WSH][0], sign=False)
+        self.fail_accept(self.nodes[0], "mempool-script-verify-flag-failed (Operation not valid with the current stack size)", p2sh_ids[NODE_0][P2WPKH][0], sign=False)
+        self.fail_accept(self.nodes[0], "mempool-script-verify-flag-failed (Operation not valid with the current stack size)", p2sh_ids[NODE_0][P2WSH][0], sign=False)
         # unsigned with redeem script
-        self.fail_accept(self.nodes[0], "mandatory-script-verify-flag-failed (Witness program hash mismatch)", p2sh_ids[NODE_0][P2WPKH][0], sign=False, redeem_script=witness_script(False, self.pubkey[0]))
-        self.fail_accept(self.nodes[0], "mandatory-script-verify-flag-failed (Witness program was passed an empty witness)", p2sh_ids[NODE_0][P2WSH][0], sign=False, redeem_script=witness_script(True, self.pubkey[0]))
+        self.fail_accept(self.nodes[0], "mempool-script-verify-flag-failed (Witness program hash mismatch)", p2sh_ids[NODE_0][P2WPKH][0], sign=False, redeem_script=witness_script(False, self.pubkey[0]))
+        self.fail_accept(self.nodes[0], "mempool-script-verify-flag-failed (Witness program was passed an empty witness)", p2sh_ids[NODE_0][P2WSH][0], sign=False, redeem_script=witness_script(True, self.pubkey[0]))
 
         self.log.info("Verify block and transaction serialization rpcs return differing serializations depending on rpc serialization flag")
         assert self.nodes[2].getblock(blockhash, False) != self.nodes[0].getblock(blockhash, False)
@@ -281,10 +281,10 @@ class SegWitTest(BTQTestFramework):
         assert_equal(witnesses[0], '00' * 32)
 
         self.log.info("Verify witness txs without witness data are invalid after the fork")
-        self.fail_accept(self.nodes[2], 'mandatory-script-verify-flag-failed (Witness program hash mismatch)', wit_ids[NODE_2][P2WPKH][2], sign=False)
-        self.fail_accept(self.nodes[2], 'mandatory-script-verify-flag-failed (Witness program was passed an empty witness)', wit_ids[NODE_2][P2WSH][2], sign=False)
-        self.fail_accept(self.nodes[2], 'mandatory-script-verify-flag-failed (Witness program hash mismatch)', p2sh_ids[NODE_2][P2WPKH][2], sign=False, redeem_script=witness_script(False, self.pubkey[2]))
-        self.fail_accept(self.nodes[2], 'mandatory-script-verify-flag-failed (Witness program was passed an empty witness)', p2sh_ids[NODE_2][P2WSH][2], sign=False, redeem_script=witness_script(True, self.pubkey[2]))
+        self.fail_accept(self.nodes[2], 'mempool-script-verify-flag-failed (Witness program hash mismatch)', wit_ids[NODE_2][P2WPKH][2], sign=False)
+        self.fail_accept(self.nodes[2], 'mempool-script-verify-flag-failed (Witness program was passed an empty witness)', wit_ids[NODE_2][P2WSH][2], sign=False)
+        self.fail_accept(self.nodes[2], 'mempool-script-verify-flag-failed (Witness program hash mismatch)', p2sh_ids[NODE_2][P2WPKH][2], sign=False, redeem_script=witness_script(False, self.pubkey[2]))
+        self.fail_accept(self.nodes[2], 'mempool-script-verify-flag-failed (Witness program was passed an empty witness)', p2sh_ids[NODE_2][P2WSH][2], sign=False, redeem_script=witness_script(True, self.pubkey[2]))
 
         self.log.info("Verify default node can now use witness txs")
         self.success_mine(self.nodes[0], wit_ids[NODE_0][P2WPKH][0], True)

--- a/test/functional/p2p_invalid_tx.py
+++ b/test/functional/p2p_invalid_tx.py
@@ -5,7 +5,7 @@
 """Test node responses to invalid transactions.
 
 In this test we connect to one node over p2p, and test tx requests."""
-from test_framework.blocktools import create_block, create_coinbase
+from test_framework.blocktools import block_subsidy_sat, create_block, create_coinbase
 from test_framework.messages import (
     COIN,
     COutPoint,
@@ -73,49 +73,51 @@ class InvalidTxRequestTest(BTQTestFramework):
             tx = template.get_tx()
             node.p2ps[0].send_txs_and_test(
                 [tx], node, success=False,
-                expect_disconnect=template.expect_disconnect,
                 reject_reason=template.reject_reason,
             )
 
-            if template.expect_disconnect:
-                self.log.info("Reconnecting to peer")
-                self.reconnect_p2p()
-
         # Make two p2p connections to provide the node with orphans
         # * p2ps[0] will send valid orphan txs (one with low fee)
-        # * p2ps[1] will send an invalid orphan tx (and is later disconnected for that)
+        # * p2ps[1] will send an invalid orphan tx, and keeps its connection
         self.reconnect_p2p(num_connections=2)
 
         self.log.info('Test orphan transaction handling ... ')
         # Create a root transaction that we withhold until all dependent transactions
         # are sent out and in the orphan cache
         SCRIPT_PUB_KEY_OP_TRUE = b'\x51\x75' * 15 + b'\x51'
+
+        # Everything below splits up block1's coinbase, so derive the amounts
+        # from the consensus subsidy rather than assuming upstream's 50.
+        subsidy = block_subsidy_sat(1)
+        withhold_value = subsidy // 2 - 12000
+        orphan_1_value = withhold_value // 3 - 4000
+
         tx_withhold = CTransaction()
         tx_withhold.vin.append(CTxIn(outpoint=COutPoint(block1.vtx[0].sha256, 0)))
-        tx_withhold.vout = [CTxOut(nValue=25 * COIN - 12000, scriptPubKey=SCRIPT_PUB_KEY_OP_TRUE)] * 2
+        tx_withhold.vout = [CTxOut(nValue=withhold_value, scriptPubKey=SCRIPT_PUB_KEY_OP_TRUE)] * 2
         tx_withhold.calc_sha256()
 
         # Our first orphan tx with some outputs to create further orphan txs
         tx_orphan_1 = CTransaction()
         tx_orphan_1.vin.append(CTxIn(outpoint=COutPoint(tx_withhold.sha256, 0)))
-        tx_orphan_1.vout = [CTxOut(nValue=8 * COIN, scriptPubKey=SCRIPT_PUB_KEY_OP_TRUE)] * 3
+        tx_orphan_1.vout = [CTxOut(nValue=orphan_1_value, scriptPubKey=SCRIPT_PUB_KEY_OP_TRUE)] * 3
         tx_orphan_1.calc_sha256()
 
         # A valid transaction with low fee
         tx_orphan_2_no_fee = CTransaction()
         tx_orphan_2_no_fee.vin.append(CTxIn(outpoint=COutPoint(tx_orphan_1.sha256, 0)))
-        tx_orphan_2_no_fee.vout.append(CTxOut(nValue=8 * COIN, scriptPubKey=SCRIPT_PUB_KEY_OP_TRUE))
+        tx_orphan_2_no_fee.vout.append(CTxOut(nValue=orphan_1_value, scriptPubKey=SCRIPT_PUB_KEY_OP_TRUE))
 
         # A valid transaction with sufficient fee
         tx_orphan_2_valid = CTransaction()
         tx_orphan_2_valid.vin.append(CTxIn(outpoint=COutPoint(tx_orphan_1.sha256, 1)))
-        tx_orphan_2_valid.vout.append(CTxOut(nValue=8 * COIN - 12000, scriptPubKey=SCRIPT_PUB_KEY_OP_TRUE))
+        tx_orphan_2_valid.vout.append(CTxOut(nValue=orphan_1_value - 12000, scriptPubKey=SCRIPT_PUB_KEY_OP_TRUE))
         tx_orphan_2_valid.calc_sha256()
 
         # An invalid transaction with negative fee
         tx_orphan_2_invalid = CTransaction()
         tx_orphan_2_invalid.vin.append(CTxIn(outpoint=COutPoint(tx_orphan_1.sha256, 2)))
-        tx_orphan_2_invalid.vout.append(CTxOut(nValue=11 * COIN, scriptPubKey=SCRIPT_PUB_KEY_OP_TRUE))
+        tx_orphan_2_invalid.vout.append(CTxOut(nValue=orphan_1_value + COIN, scriptPubKey=SCRIPT_PUB_KEY_OP_TRUE))
         tx_orphan_2_invalid.calc_sha256()
 
         self.log.info('Send the orphans ... ')
@@ -141,10 +143,12 @@ class InvalidTxRequestTest(BTQTestFramework):
             ]
         }
         # Transactions that do not end up in the mempool:
-        # tx_orphan_2_no_fee, because it has too low fee (p2ps[0] is not disconnected for relaying that tx)
-        # tx_orphan_2_invalid, because it has negative fee (p2ps[1] is disconnected for relaying that tx)
+        # tx_orphan_2_no_fee, because it has too low fee
+        # tx_orphan_2_invalid, because it has negative fee, which is a consensus
+        #   failure rather than a policy one -- but neither costs p2ps[1] its
+        #   connection, since transactions no longer discourage peers at all.
 
-        self.wait_until(lambda: 1 == len(node.getpeerinfo()), timeout=12)  # p2ps[1] is no longer connected
+        assert_equal(2, len(node.getpeerinfo()))  # both peers are still connected
         assert_equal(expected_mempool, set(node.getrawmempool()))
 
         self.log.info('Test orphan pool overflow')
@@ -165,18 +169,24 @@ class InvalidTxRequestTest(BTQTestFramework):
             node.p2ps[0].send_txs_and_test([rejected_parent], node, success=False)
 
         self.log.info('Test that a peer disconnection causes erase its transactions from the orphan pool')
-        with node.assert_debug_log(['Erased 100 orphan tx from peer=25']):
+        # Ask the node which peer this is rather than hardcoding an id: the
+        # count depends on how many times the test reconnected earlier. The
+        # orphans came from p2ps[0], which connected first and so has the
+        # lower of the two ids.
+        orphan_peer_id = min(p['id'] for p in node.getpeerinfo())
+        with node.assert_debug_log([f'Erased 100 orphan tx from peer={orphan_peer_id}']):
             self.reconnect_p2p(num_connections=1)
 
         self.log.info('Test that a transaction in the orphan pool is included in a new tip block causes erase this transaction from the orphan pool')
         tx_withhold_until_block_A = CTransaction()
+        block_a_value = withhold_value // 2 - 6000
         tx_withhold_until_block_A.vin.append(CTxIn(outpoint=COutPoint(tx_withhold.sha256, 1)))
-        tx_withhold_until_block_A.vout = [CTxOut(nValue=12 * COIN, scriptPubKey=SCRIPT_PUB_KEY_OP_TRUE)] * 2
+        tx_withhold_until_block_A.vout = [CTxOut(nValue=block_a_value, scriptPubKey=SCRIPT_PUB_KEY_OP_TRUE)] * 2
         tx_withhold_until_block_A.calc_sha256()
 
         tx_orphan_include_by_block_A = CTransaction()
         tx_orphan_include_by_block_A.vin.append(CTxIn(outpoint=COutPoint(tx_withhold_until_block_A.sha256, 0)))
-        tx_orphan_include_by_block_A.vout.append(CTxOut(nValue=12 * COIN - 12000, scriptPubKey=SCRIPT_PUB_KEY_OP_TRUE))
+        tx_orphan_include_by_block_A.vout.append(CTxOut(nValue=block_a_value - 12000, scriptPubKey=SCRIPT_PUB_KEY_OP_TRUE))
         tx_orphan_include_by_block_A.calc_sha256()
 
         self.log.info('Send the orphan ... ')
@@ -195,18 +205,19 @@ class InvalidTxRequestTest(BTQTestFramework):
 
         self.log.info('Test that a transaction in the orphan pool conflicts with a new tip block causes erase this transaction from the orphan pool')
         tx_withhold_until_block_B = CTransaction()
+        block_b_value = block_a_value - 12000
         tx_withhold_until_block_B.vin.append(CTxIn(outpoint=COutPoint(tx_withhold_until_block_A.sha256, 1)))
-        tx_withhold_until_block_B.vout.append(CTxOut(nValue=11 * COIN, scriptPubKey=SCRIPT_PUB_KEY_OP_TRUE))
+        tx_withhold_until_block_B.vout.append(CTxOut(nValue=block_b_value, scriptPubKey=SCRIPT_PUB_KEY_OP_TRUE))
         tx_withhold_until_block_B.calc_sha256()
 
         tx_orphan_include_by_block_B = CTransaction()
         tx_orphan_include_by_block_B.vin.append(CTxIn(outpoint=COutPoint(tx_withhold_until_block_B.sha256, 0)))
-        tx_orphan_include_by_block_B.vout.append(CTxOut(nValue=10 * COIN, scriptPubKey=SCRIPT_PUB_KEY_OP_TRUE))
+        tx_orphan_include_by_block_B.vout.append(CTxOut(nValue=block_b_value - 12000, scriptPubKey=SCRIPT_PUB_KEY_OP_TRUE))
         tx_orphan_include_by_block_B.calc_sha256()
 
         tx_orphan_conflict_by_block_B = CTransaction()
         tx_orphan_conflict_by_block_B.vin.append(CTxIn(outpoint=COutPoint(tx_withhold_until_block_B.sha256, 0)))
-        tx_orphan_conflict_by_block_B.vout.append(CTxOut(nValue=9 * COIN, scriptPubKey=SCRIPT_PUB_KEY_OP_TRUE))
+        tx_orphan_conflict_by_block_B.vout.append(CTxOut(nValue=block_b_value - 24000, scriptPubKey=SCRIPT_PUB_KEY_OP_TRUE))
         tx_orphan_conflict_by_block_B.calc_sha256()
         self.log.info('Send the orphan ... ')
         node.p2ps[0].send_txs_and_test([tx_orphan_conflict_by_block_B], node, success=False)

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -706,7 +706,7 @@ class SegWitTest(BTQTestFramework):
         # segwit activation.  Note that older btqd's that are not
         # segwit-aware would also reject this for failing CLEANSTACK.
         with self.nodes[0].assert_debug_log(
-                expected_msgs=[spend_tx.hash, 'was not accepted: mandatory-script-verify-flag-failed (Witness program was passed an empty witness)']):
+                expected_msgs=[spend_tx.hash, 'was not accepted: mempool-script-verify-flag-failed (Witness program was passed an empty witness)']):
             test_transaction_acceptance(self.nodes[0], self.test_node, spend_tx, with_witness=False, accepted=False)
 
         # The rejection above was recognised as a stripped witness, so it was
@@ -721,14 +721,14 @@ class SegWitTest(BTQTestFramework):
         # redeem script out of the scriptSig, which is where it could go wrong
         # without anything else noticing.
         with self.nodes[0].assert_debug_log(
-                expected_msgs=[spend_tx.hash, 'was not accepted: mandatory-script-verify-flag-failed (Witness program was passed an empty witness)']):
+                expected_msgs=[spend_tx.hash, 'was not accepted: mempool-script-verify-flag-failed (Witness program was passed an empty witness)']):
             test_transaction_acceptance(self.nodes[0], self.test_node, spend_tx, with_witness=False, accepted=False)
 
         # Try to put the witness script in the scriptSig, should also fail.
         spend_tx.vin[0].scriptSig = CScript([p2wsh_pubkey, b'a'])
         spend_tx.rehash()
         with self.nodes[0].assert_debug_log(
-                expected_msgs=[spend_tx.hash, 'was not accepted: mandatory-script-verify-flag-failed (Script evaluated without error but finished with a false/empty top stack element)']):
+                expected_msgs=[spend_tx.hash, 'was not accepted: mempool-script-verify-flag-failed (Script evaluated without error but finished with a false/empty top stack element)']):
             test_transaction_acceptance(self.nodes[0], self.test_node, spend_tx, with_witness=False, accepted=False)
 
         # Now put the witness script in the witness, should succeed after
@@ -1494,7 +1494,7 @@ class SegWitTest(BTQTestFramework):
         sign_input_segwitv0(tx2, 0, script, tx.vout[0].nValue, key)
 
         # Should fail policy test.
-        test_transaction_acceptance(self.nodes[0], self.test_node, tx2, True, False, 'non-mandatory-script-verify-flag (Using non-compressed keys in segwit)')
+        test_transaction_acceptance(self.nodes[0], self.test_node, tx2, True, False, 'mempool-script-verify-flag-failed (Using non-compressed keys in segwit)')
         # But passes consensus.
         block = self.build_next_block()
         self.update_witness_block_with_transactions(block, [tx2])
@@ -1513,7 +1513,7 @@ class SegWitTest(BTQTestFramework):
         sign_p2pk_witness_input(witness_script, tx3, 0, SIGHASH_ALL, tx2.vout[0].nValue, key)
 
         # Should fail policy test.
-        test_transaction_acceptance(self.nodes[0], self.test_node, tx3, True, False, 'non-mandatory-script-verify-flag (Using non-compressed keys in segwit)')
+        test_transaction_acceptance(self.nodes[0], self.test_node, tx3, True, False, 'mempool-script-verify-flag-failed (Using non-compressed keys in segwit)')
         # But passes consensus.
         block = self.build_next_block()
         self.update_witness_block_with_transactions(block, [tx3])
@@ -1530,7 +1530,7 @@ class SegWitTest(BTQTestFramework):
         sign_p2pk_witness_input(witness_script, tx4, 0, SIGHASH_ALL, tx3.vout[0].nValue, key)
 
         # Should fail policy test.
-        test_transaction_acceptance(self.nodes[0], self.test_node, tx4, True, False, 'non-mandatory-script-verify-flag (Using non-compressed keys in segwit)')
+        test_transaction_acceptance(self.nodes[0], self.test_node, tx4, True, False, 'mempool-script-verify-flag-failed (Using non-compressed keys in segwit)')
         block = self.build_next_block()
         self.update_witness_block_with_transactions(block, [tx4])
         test_witness_block(self.nodes[0], self.test_node, block, accepted=True)

--- a/test/functional/rpc_packages.py
+++ b/test/functional/rpc_packages.py
@@ -110,7 +110,7 @@ class RPCPackagesTest(BTQTestFramework):
         assert_equal(testres_bad_sig, self.independent_txns_testres + [{
             "txid": tx_bad_sig.rehash(),
             "wtxid": tx_bad_sig.getwtxid(), "allowed": False,
-            "reject-reason": "mandatory-script-verify-flag-failed (Operation not valid with the current stack size)"
+            "reject-reason": "mempool-script-verify-flag-failed (Operation not valid with the current stack size)"
         }])
 
         self.log.info("Check testmempoolaccept reports txns in packages that exceed max feerate")

--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -746,14 +746,16 @@ class P2PDataStore(P2PInterface):
             else:
                 assert node.getbestblockhash() != blocks[-1].hash
 
-    def send_txs_and_test(self, txs, node, *, success=True, expect_disconnect=False, reject_reason=None):
+    def send_txs_and_test(self, txs, node, *, success=True, reject_reason=None):
         """Send txs to test node and test whether they're accepted to the mempool.
 
          - add all txs to our tx_store
          - send tx messages for all txs
          - if success is True/False: assert that the txs are/are not accepted to the mempool
-         - if expect_disconnect is True: Skip the sync with ping
-         - if reject_reason is set: assert that the correct reject message is logged."""
+         - if reject_reason is set: assert that the correct reject message is logged.
+
+        There is no expect_disconnect: an invalid transaction never costs a peer
+        its connection, however invalid it is."""
 
         with p2p_lock:
             for tx in txs:
@@ -764,10 +766,7 @@ class P2PDataStore(P2PInterface):
             for tx in txs:
                 self.send_message(msg_tx(tx))
 
-            if expect_disconnect:
-                self.wait_for_disconnect()
-            else:
-                self.sync_with_ping()
+            self.sync_with_ping()
 
             raw_mempool = node.getrawmempool()
             if success:


### PR DESCRIPTION
Finishes CVE-2025-46598 (BTQ-140). Part 1, witness-stripping detection without re-running scripts (upstream #33105), landed in #139. This is the other two mitigations named in the [Bitcoin Core advisory](https://bitcoincore.org/en/2025/10/24/disclose-cve-2025-46598/).

The CVE is a CPU DoS: specially-crafted unconfirmed transactions take seconds each to validate, get rejected without costing the sender anything, and can be repeated to delay block propagation.

## Part 2 — sighash midstate cache (upstream #32473)

Legacy sighash re-serialises the entire transaction on every call, so a script forcing many sighashes over one input, via `OP_CODESEPARATOR` or simply many signatures, costs quadratic work. `SigHashCache` keeps the SHA256 state from just before the sighash type byte is appended, so a repeated script code within one input serialises the transaction once.

Measured on a 200-input transaction taking 20k sighashes over one script code: **147ms -> 2.4ms, 61x**.

**Divergence from upstream, deliberate.** Upstream keys the cache on sighash mode and script code only, on the grounds that no input can reach both the `BASE` and `WITNESS_V0` paths. That does not hold here: `CheckDilithiumSignature` dispatches on `sigversion` at runtime inside a single input's checker. We key on sig version too. Getting this wrong would validate a signature against a sighash computed for the other sig version, so `sighash_cache_keying` fails if the sig version is dropped from the key.

## Part 3 — one script run, no peer punishment (upstream #33050)

A failing input script was validated twice: once with policy flags, then again with them masked off, solely to decide whether to discourage the relaying peer. That doubles the CPU an attacker can make us spend on a transaction we reject either way, and the punishment bought little, since an attacker can place a non-standard input first and evade it entirely while an honest peer running slightly different relay policy gets disconnected. `MaybePunishNodeForTx` and the second run are both gone. Block-based discouragement (`MaybePunishNodeForBlock`) is untouched.

**Divergence from upstream, and this one is load-bearing.** Upstream picks the error vocabulary by testing `flags & STANDARD_NOT_MANDATORY_VERIFY_FLAGS`, treating a standard-not-mandatory flag as proof of mempool context. In BTQ `SCRIPT_VERIFY_DILITHIUM_P2MR_ONLY` is standard-but-not-mandatory and yet `GetBlockScriptFlags` sets it once `DEPLOYMENT_DILITHIUM_P2MR` activates, so a literal port made **block** validation report consensus failures as mempool ones. `feature_csv_activation` caught it. Fixed by passing the context explicitly, which cannot rot as flags move between the sets.

Worth noting separately: this also removes a trap the old code had documented in `policy.h`. The retry masked off `SCRIPT_VERIFY_DILITHIUM_P2MR_ONLY` even during block validation, so a block transaction failing only that consensus rule could be reported `TX_NOT_STANDARD`. With no retry, mempool failures are unconditionally `TX_NOT_STANDARD` and block failures unconditionally `TX_CONSENSUS`, and neither rests on flag placement any more.

Mempool script failures are now reported as `mempool-script-verify-flag-failed`, matching upstream.

## Testing

All 769 unit tests pass.

Three mutations of the sighash cache, each caught: ignoring sig version (8017 failing assertions), ignoring script code (1944), storing the midstate after the type byte (11639).

Functional tests this touches, before and after:

| Test | Before | After |
|---|---|---|
| `rpc_packages` | pass | pass |
| `feature_dersig` | pass | pass |
| `feature_csv_activation` | pass | pass |
| `feature_block` | pass | pass |
| `p2p_invalid_tx` | fail | **pass** |
| `p2p_segwit` | fail | fail |
| `feature_segwit` | fail | fail |
| `feature_cltv` | fail | fail |
| `feature_nulldummy` | fail | fail |
| `mempool_accept` | fail | fail |

The five still failing were already failing on master for the #104 subsidy mismatch and fail at exactly the same line as before. Their reject strings are updated for the rename, but I could not exercise those assertions, so they are the part of this PR to look at hardest.

`p2p_invalid_tx` went green because I fixed its #104 amounts to derive from `block_subsidy_sat` — needed to reach the peer-connection assertion this PR changes. Its orphan-peer id now comes from `getpeerinfo` rather than a hardcoded 25, which shifted once the reconnects went away.

## Review notes

- Consensus behaviour is unchanged: in block validation the branch taken and the resulting `TX_CONSENSUS` are the same as before, only the second script run is gone.
- The policy change is real and worth a deliberate ack: a peer relaying a consensus-invalid transaction is no longer disconnected. Upstream's reasoning is in #33050; the short version is that this protection was already evadable and cost us double CPU to enforce.

Closes BTQ-140.