### PR TITLE
test: fix dangling pubkey range in sigopcount_tests

### DIFF
--- a/src/test/sigopcount_tests.cpp
+++ b/src/test/sigopcount_tests.cpp
@@ -285,10 +285,13 @@ BOOST_AUTO_TEST_CASE(dilithium_witness_v0_sigop_weighting)
     // Classical P2WPKH with compressed pubkey witness must remain weight 1.
     CKey ecdsa_key;
     ecdsa_key.MakeNewKey(true);
-    scriptPubKey = GetScriptForDestination(WitnessV0KeyHash(ecdsa_key.GetPubKey()));
+    // GetPubKey() returns by value, so calling it twice would take begin() and
+    // end() from two unrelated temporaries.
+    const CPubKey ecdsa_pubkey{ecdsa_key.GetPubKey()};
+    scriptPubKey = GetScriptForDestination(WitnessV0KeyHash(ecdsa_pubkey));
     scriptWitness.stack.clear();
     scriptWitness.stack.push_back(std::vector<unsigned char>(72, 0x01));
-    scriptWitness.stack.push_back(std::vector<unsigned char>(ecdsa_key.GetPubKey().begin(), ecdsa_key.GetPubKey().end()));
+    scriptWitness.stack.push_back(std::vector<unsigned char>(ecdsa_pubkey.begin(), ecdsa_pubkey.end()));
 
     BuildTxs(spendingTx, coins, creationTx, scriptPubKey, CScript{}, scriptWitness);
     BOOST_CHECK_EQUAL(GetTransactionSigOpCost(CTransaction(spendingTx), coins, flags), 1);


### PR DESCRIPTION
## What

`sigopcount_tests/dilithium_witness_v0_sigop_weighting` builds a witness element with

```cpp
std::vector<unsigned char>(ecdsa_key.GetPubKey().begin(), ecdsa_key.GetPubKey().end())
```

`CKey::GetPubKey()` returns by value, so those are two separate temporaries: `begin()` points into one, `end()` into the other. The distance between them is whatever the compiler's stack layout gives, and the range constructor throws `std::length_error: cannot create std::vector larger than max_size()` when it is negative or huge.

## Why it matters now

This is why the `test each commit` CI job fails on PRs that cannot possibly have caused it, [including docs-only ones](https://github.com/btq-ag/btq-core/pull/148). That job builds with `CC=clang CXX=clang++`; our local builds are gcc, which happens to place the two temporaries adjacently here and pass. Anyone reading CI has been looking at a red mark unrelated to their change.

Found while validating #149, whose CI failed on this test despite the PR not touching the file.

## Evidence

Reduced to a standalone program so the mechanism is visible without clang:

| build | two temporaries | one named value |
|---|---|---|
| gcc -O2 | distance **81** | distance 33 |
| gcc -O0 | distance 33 | distance 33 |

The pubkey is 33 bytes. Even gcc gets it wrong at `-O2`; the passing local build is luck, not correctness.

## The fix

Hold the pubkey in a named local, which is what the Dilithium half of the same test already does a few lines above (and why that half is unaffected).

I checked the rest of the tree for the same shape. `GetInputSet()`, `getAllNetMessageTypes()` and `getValues()` all return by const reference, so they are single objects and fine. This is the only instance.

## Test plan

- [x] Full unit suite passes locally (gcc).
- [x] `sigopcount_tests` passes.
- [ ] `test each commit` goes green — that is the actual check here, since it is the clang build that reproduces it.