### PR TITLE
wallet: fix imported Dilithium keys bricking the wallet on restart

### DIFF
--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -551,20 +551,22 @@ bool LoadCryptedDilithiumKey(CWallet* pwallet, DataStream& ssKey, DataStream& ss
             }
         }
 
-        for (auto& spk_man : pwallet->GetAllScriptPubKeyMans()) {
-            if (auto* desc_spk_man = dynamic_cast<DescriptorScriptPubKeyMan*>(spk_man)) {
-                if (desc_spk_man->LoadCryptedDilithiumKey(keyID, vchCryptedSecret, checksum_valid)) {
+        // See LoadDilithiumKey for why the legacy side asks for its manager.
+        if (pwallet->IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS)) {
+            for (auto& spk_man : pwallet->GetAllScriptPubKeyMans()) {
+                auto* desc_spk_man = dynamic_cast<DescriptorScriptPubKeyMan*>(spk_man);
+                if (desc_spk_man && desc_spk_man->LoadCryptedDilithiumKey(keyID, vchCryptedSecret, checksum_valid)) {
                     return true;
                 }
             }
-            if (auto* legacy_spk_man = dynamic_cast<LegacyScriptPubKeyMan*>(spk_man)) {
-                if (legacy_spk_man->LoadCryptedDilithiumKey(keyID, vchCryptedSecret, checksum_valid)) {
-                    return true;
-                }
-            }
+            strErr = "Error reading wallet database: no descriptor ScriptPubKeyMan accepted encrypted Dilithium key";
+            return false;
         }
-        strErr = "Error reading wallet database: no ScriptPubKeyMan accepted encrypted Dilithium key";
-        return false;
+        if (!pwallet->GetOrCreateLegacyScriptPubKeyMan()->LoadCryptedDilithiumKey(keyID, vchCryptedSecret, checksum_valid)) {
+            strErr = "Error reading wallet database: Failed to load encrypted Dilithium key into the legacy key manager";
+            return false;
+        }
+        return true;
     } catch (const std::exception& e) {
         if (strErr.empty()) {
             strErr = e.what();
@@ -595,28 +597,23 @@ bool LoadDilithiumKey(CWallet* pwallet, DataStream& ssKey, DataStream& ssValue, 
         // Set the key data using the Set method
         dilithiumKey.Set(vchDilithiumKey.begin(), vchDilithiumKey.end());
         
-        // Try to load the key into all script pub key managers
-        bool loaded = false;
-        for (auto& spk_man : pwallet->GetAllScriptPubKeyMans()) {
-            // Try descriptor wallet first
-            DescriptorScriptPubKeyMan* desc_spk_man = dynamic_cast<DescriptorScriptPubKeyMan*>(spk_man);
-            if (desc_spk_man) {
-                if (desc_spk_man->LoadDilithiumKey(dilithiumKey, CPubKey())) {
-                    loaded = true;
-                    break;
+        // A descriptor wallet has its managers built before records load, so
+        // searching them is safe. A legacy wallet creates its manager on demand, and
+        // an imported Dilithium key can be the first record to need one, so ask for
+        // the manager instead of searching whatever exists yet. Searching found
+        // nothing and reported corruption, failing the whole wallet over one record.
+        if (pwallet->IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS)) {
+            for (auto& spk_man : pwallet->GetAllScriptPubKeyMans()) {
+                auto* desc_spk_man = dynamic_cast<DescriptorScriptPubKeyMan*>(spk_man);
+                if (desc_spk_man && desc_spk_man->LoadDilithiumKey(dilithiumKey, CPubKey())) {
+                    return true;
                 }
             }
-            LegacyScriptPubKeyMan* legacy_spk_man = dynamic_cast<LegacyScriptPubKeyMan*>(spk_man);
-            if (legacy_spk_man) {
-                if (legacy_spk_man->LoadDilithiumKey(dilithiumKey, CPubKey())) {
-                    loaded = true;
-                    break;
-                }
-            }
+            strErr = "Error reading wallet database: Failed to load Dilithium key into any descriptor key manager";
+            return false;
         }
-        
-        if (!loaded) {
-            strErr = "Error reading wallet database: Failed to load Dilithium key into any script pub key manager";
+        if (!pwallet->GetOrCreateLegacyScriptPubKeyMan()->LoadDilithiumKey(dilithiumKey, CPubKey())) {
+            strErr = "Error reading wallet database: Failed to load Dilithium key into the legacy key manager";
             return false;
         }
     } catch (const std::exception& e) {

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -102,6 +102,7 @@ BASE_SCRIPTS = [
     'feature_dilithium_sigops.py',
     'wallet_dilithium_hd_restore.py --legacy-wallet',
     'wallet_dilithium_encrypted_restart.py --legacy-wallet',
+    'wallet_dilithium_import_restart.py --legacy-wallet',
     'wallet_dilithium_legacy_spend.py --legacy-wallet',
     'wallet_dilithium_encrypted_restart_descriptors.py --descriptors',
     'wallet_p2sh_segwit_spend.py --descriptors',

--- a/test/functional/wallet_dilithium_import_restart.py
+++ b/test/functional/wallet_dilithium_import_restart.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The BTQ Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Imported Dilithium keys must survive a restart.
+
+An HD-derived Dilithium key is recoverable from the seed, so losing its database
+record costs nothing. An imported key has no seed behind it: the wallet record is
+the only copy, and losing it loses the coins. That makes this the one Dilithium
+persistence path where the database round-trip is load-bearing, and it was the
+one with no coverage.
+
+Regression test for the loader failing an entire wallet as corrupt when a
+Dilithium record arrived before any script pub key manager existed.
+"""
+
+from test_framework.test_framework import BTQTestFramework
+from test_framework.util import assert_equal
+
+
+class WalletDilithiumImportRestartTest(BTQTestFramework):
+    def add_options(self, parser):
+        self.add_wallet_options(parser, descriptors=False)
+
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+        self.extra_args = [["-deprecatedrpc=create_bdb", "-fallbackfee=0.0002"]]
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+        self.skip_if_no_bdb()
+
+    def dilithium_secret_from_dump(self, wallet, path):
+        """Pull the Dilithium secret out of a dumpwallet file.
+
+        Dilithium secrets are far longer than any WIF, which is enough to pick
+        them out without depending on the dump's column layout."""
+        wallet.dumpwallet(path)
+        with open(path, encoding="utf8") as f:
+            for line in f:
+                first = line.split(" ")[0]
+                if len(first) > 1000:
+                    return first
+        raise AssertionError("no Dilithium secret found in dumpwallet output")
+
+    def run_test(self):
+        node = self.nodes[0]
+        msg = "imported dilithium restart test"
+
+        self.log.info("Create a source wallet and give it a Dilithium P2MR address")
+        node.createwallet(wallet_name="source", descriptors=False)
+        source = node.get_wallet_rpc("source")
+        self.generatetoaddress(node, 110, source.getnewaddress())
+        source_addr = source.getnewdilithiumaddress()["address"]
+
+        secret = self.dilithium_secret_from_dump(
+            source, self.nodes[0].datadir_path / "dump.txt")
+
+        self.log.info("Import that key into a blank wallet, which has no seed to re-derive it from")
+        node.createwallet(wallet_name="target", descriptors=False, blank=True)
+        target = node.get_wallet_rpc("target")
+        imported = target.importdilithiumkey(secret, "imported")
+
+        # Same key in, same P2MR address out.
+        assert_equal(imported["address"], source_addr)
+        addr = imported["address"]
+
+        sig_before = target.signmessagewithdilithium(addr, msg)
+        assert target.verifydilithiumsignature(msg, addr, sig_before)
+
+        self.log.info("Restart; the wallet must still load and the key must still be there")
+        self.restart_node(0, extra_args=["-deprecatedrpc=create_bdb", "-fallbackfee=0.0002"])
+        node = self.nodes[0]
+        node.loadwallet("source")
+        node.loadwallet("target")
+        source = node.get_wallet_rpc("source")
+        target = node.get_wallet_rpc("target")
+
+        # Before the fix the wallet did not get this far: the load aborted with
+        # "Wallet corrupted", stranding every other key in the file as well.
+        info = target.getaddressinfo(addr)
+        assert_equal(info["ismine"], True)
+        assert_equal(info["iswatchonly"], False)
+
+        sig_after = target.signmessagewithdilithium(addr, msg)
+        assert target.verifydilithiumsignature(msg, addr, sig_after)
+
+        self.log.info("The reloaded key can still spend, not just sign")
+        source.sendtoaddress(addr, 1)
+        self.generate(node, 1)
+        balance = target.getbalance()
+        assert balance > 0
+
+        # Sweep the whole balance: the wallet is deliberately blank, so it has no
+        # keypool to draw a change address from.
+        txid = target.sendtoaddress(address=source.getnewaddress(), amount=balance,
+                                    subtractfeefromamount=True)
+        assert txid in node.getrawmempool()
+        self.generate(node, 1)
+        assert_equal(target.gettransaction(txid)["confirmations"], 1)
+
+
+if __name__ == "__main__":
+    WalletDilithiumImportRestartTest().main()


### PR DESCRIPTION
Fixes #152. Found while re-verifying AUDIT-153 for BTQ-151.

## The bug

Import a Dilithium key into a legacy wallet, restart the node, and that wallet
never loads again:

```
loadwallet target
error: Wallet loading failed. Error loading wallet.dat: Wallet corrupted (-4)
```

The wallet is not corrupt. Nothing is recoverable through `loadwallet` though,
so every other key in that file goes with it. Imported keys are the worst case
for this: an HD-derived key can be re-derived from the seed, but an imported
key has no seed behind it, so the wallet record is the only copy.

## Cause

The record is written correctly. The loader rejects it.

`LoadDilithiumKey` searched the wallet's existing script pub key managers for
one that would take the key. A legacy wallet creates its manager on demand as
records load, so when a Dilithium record is the first one to need it, there is
nothing to search yet. The loader then reported the wallet corrupt instead of
creating the manager.

HD-derived Dilithium keys happen to escape this because other records create
the manager first. That is why the existing restart tests
(`wallet_dilithium_hd_restore.py`, `wallet_dilithium_encrypted_restart.py`)
stayed green: none of them import.

## Fix

Ask for the legacy manager rather than searching for it. Descriptor wallets
have their managers built before records load, so that path keeps searching,
now without the dead legacy branch. The two error strings also now say which
path failed.

## Test

`wallet_dilithium_import_restart.py` imports a key into a blank wallet,
restarts, then signs and spends with the reloaded key. Blank is deliberate:
it removes every other record that could create the manager first.

Reverting just the `walletdb.cpp` change and rebuilding makes it fail on the
post-restart load with `Wallet corrupted`, so it is testing the fix and not
the surroundings.

## Verification

- `wallet_tests`, `walletdb_tests`, `coinselector_tests`, `psbt_wallet_tests`: pass
- All 12 Dilithium wallet tests plus `wallet_backup` and `wallet_multiwallet`
  (legacy, descriptor and cli variants): pass
- Full wallet functional suite, 116 runs, with and without the change: identical
  results, 67 pass / 49 fail. The 49 are the pre-existing subsidy mismatch
  tracked in #104, unchanged by this PR.

## Note for review

While reproducing this I hit a second, smaller problem: `importdilithiumkey`
is missing from the conversion table in `src/rpc/client.cpp`, so
`rescan=false` arrives over `btq-cli` as the string `"false"` and is rejected.
Left out of this PR to keep it to the one bug; say the word and I will file it.