### PR TITLE
bench: fix two benchmarks that abort under BTQ consensus rules

### DIFF
--- a/src/bench/checkblock.cpp
+++ b/src/bench/checkblock.cpp
@@ -7,6 +7,8 @@
 
 #include <chainparams.h>
 #include <common/args.h>
+#include <consensus/consensus.h>
+#include <consensus/merkle.h>
 #include <consensus/validation.h>
 #include <streams.h>
 #include <util/chaintype.h>
@@ -30,9 +32,38 @@ static void DeserializeBlockTest(benchmark::Bench& bench)
     });
 }
 
+// The bundled block is a 1 MB upstream Bitcoin block. BTQ scales witness data by
+// 16 rather than 4, so under an 8 MW cap a block holds at most 500 kB of
+// non-witness data and that block weighs 16 MW here. CheckBlock rejects it as
+// bad-blk-length, and it does so before the per-transaction work this benchmark
+// exists to measure. Drop transactions from the end until it fits, so the
+// benchmark reaches that work again.
+static CDataStream BlockThatFitsTheWeightLimit()
+{
+    CDataStream source(benchmark::data::block413567, SER_NETWORK, PROTOCOL_VERSION);
+    CBlock block;
+    source >> block;
+
+    // Track the running weight rather than re-measuring the block each time, so
+    // this stays linear. Dropping a transaction also shrinks the count varint, so
+    // the running figure is an upper bound and the result always clears the cap.
+    int64_t weight = GetBlockWeight(block);
+    while (block.vtx.size() > 1 && weight > MAX_BLOCK_WEIGHT) {
+        weight -= GetTransactionWeight(*block.vtx.back());
+        block.vtx.pop_back();
+    }
+    assert(GetBlockWeight(block) <= MAX_BLOCK_WEIGHT);
+    block.hashMerkleRoot = BlockMerkleRoot(block);
+
+    CDataStream trimmed(SER_NETWORK, PROTOCOL_VERSION);
+    trimmed << block;
+    return trimmed;
+}
+
 static void DeserializeAndCheckBlockTest(benchmark::Bench& bench)
 {
-    CDataStream stream(benchmark::data::block413567, SER_NETWORK, PROTOCOL_VERSION);
+    CDataStream stream = BlockThatFitsTheWeightLimit();
+    const size_t block_size = stream.size();
     std::byte a{0};
     stream.write({&a, 1}); // Prevent compaction
 
@@ -42,11 +73,14 @@ static void DeserializeAndCheckBlockTest(benchmark::Bench& bench)
     bench.unit("block").run([&] {
         CBlock block; // Note that CBlock caches its checked state, so we need to recreate it here
         stream >> block;
-        bool rewound = stream.Rewind(benchmark::data::block413567.size());
+        bool rewound = stream.Rewind(block_size);
         assert(rewound);
 
         BlockValidationState validationState;
-        bool checked = CheckBlock(block, validationState, chainParams->GetConsensus());
+        // Re-deriving the merkle root invalidated the header's proof of work.
+        // Checking it is one hash either way, so nothing measurable is lost.
+        bool checked = CheckBlock(block, validationState, chainParams->GetConsensus(),
+                                  /*fCheckPOW=*/false);
         assert(checked);
     });
 }

--- a/src/bench/wallet_balance.cpp
+++ b/src/bench/wallet_balance.cpp
@@ -20,7 +20,7 @@ static void WalletBalance(benchmark::Bench& bench, const bool set_dirty, const b
 {
     const auto test_setup = MakeNoLogFileContext<const TestingSetup>();
 
-    const auto& ADDRESS_WATCHONLY = ADDRESS_BCRT1_UNSPENDABLE;
+    const auto& ADDRESS_WATCHONLY = ADDRESS_QCRT1_UNSPENDABLE;
 
     // Set clock to genesis block, so the descriptors/keys creation time don't interfere with the blocks scanning process.
     // The reason is 'generatetoaddress', which creates a chain with deterministic timestamps in the past.

--- a/src/wallet/test/util.h
+++ b/src/wallet/test/util.h
@@ -32,7 +32,9 @@ static const DatabaseFormat DATABASE_FORMATS[] = {
 #endif
 };
 
-const std::string ADDRESS_BCRT1_UNSPENDABLE = "bcrt1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3xueyj";
+// Witness v0, 32-byte all-zero program, under regtest's "qcrt" prefix. The
+// upstream constant kept Bitcoin's "bcrt" prefix, which no BTQ chain decodes.
+const std::string ADDRESS_QCRT1_UNSPENDABLE = "qcrt1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqen882c";
 
 std::unique_ptr<CWallet> CreateSyncedWallet(interfaces::Chain& chain, CChain& cchain, const CKey& key);
 


### PR DESCRIPTION
Fixes #154. Unblocks #149, whose `test each commit` job fails on this.

`make check` runs `bench_btq -sanity-check`, so a benchmark that aborts fails the build. Two do, and both are upstream fixtures that were never adapted to BTQ.

### `DeserializeAndCheckBlockTest`

It validates `block413567`, a 1 MB Bitcoin mainnet block. BTQ's `WITNESS_SCALE_FACTOR` is 16 rather than 4, so an 8 MW cap leaves room for 500 kB of non-witness data:

| | value |
|---|---|
| block weight under BTQ | 15,998,192 |
| `MAX_BLOCK_WEIGHT` | 8,000,000 |

`CheckBlock` rejects it as `bad-blk-length`, and does so before reaching the per-transaction work the benchmark exists to measure, so `assert(checked)` fires.

The fix drops transactions from the end until the block fits, leaving 635 of the original 1557 at 7,716,944 weight, then re-derives the merkle root. That invalidates the header's proof of work, so the PoW check is skipped — it is one hash, and not what is being measured. `DeserializeBlockTest` is untouched and still deserializes the full-size block.

### `WalletBalance`

It mines to `ADDRESS_BCRT1_UNSPENDABLE`, which carries Bitcoin's `bcrt` prefix. BTQ regtest uses `qcrt`, so `DecodeDestination` returns nothing and `generatetoaddress` asserts on an invalid destination. Re-encoded the same witness v0 all-zero program under `qcrt` and renamed the constant to match.

### Why now

Both were masked. `make check` aborted earlier in the run on the `sigopcount_tests` failure fixed in #151; with that gone, the run reaches the benchmarks.

### Testing

- `bench_btq -sanity-check -priority-level=high` exits 0 (was aborting)
- `make check` exits 0, full unit suite reports no errors
- `DeserializeAndCheckBlockTest` still runs real work at ~624 µs/block over 635 transactions