### PR TITLE
rpc: fix client conversion table entries for Dilithium and P2MR RPCs

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -309,7 +309,10 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "sendtop2mr", 5, "subtractfeefromamount" },
     { "createp2mrspend", 2, "amount" },
     { "createp2mrspend", 3, "fee" },
-    { "signp2mrtransaction", 2, "witness_args" },
+    // Dilithium wallet RPCs
+    { "importdilithiumkey", 2, "rescan" },
+    { "signtransactionwithdilithium", 1, "prevtxs" },
+    { "signtransactionwithdilithium", 3, "force_dilithium" },
 };
 // clang-format on
 


### PR DESCRIPTION
`rpc_help.py` compares `src/rpc/client.cpp`'s conversion table against the server's named arguments, and has been failing on four entries. It is one of the tests in the #104 set, and this closes it out.

| entry | problem |
|---|---|
| `importdilithiumkey` 2 `rescan` | missing |
| `signtransactionwithdilithium` 1 `prevtxs` | missing |
| `signtransactionwithdilithium` 3 `force_dilithium` | missing |
| `signp2mrtransaction` 2 `witness_args` | stale, no such parameter |

Without a table entry, `btq-cli` sends the argument as a JSON string and the RPC rejects it on type. For `importdilithiumkey` that meant passing `rescan` at all broke the call, so the workaround has been to omit it and accept the default. I hit this while testing Dilithium key persistence for #152.

`signp2mrtransaction` takes `hexstring` and `p2mr_id`, both strings, and has no third parameter, so that entry describes an argument that no longer exists.

### Testing

- `rpc_help.py` passes; it failed before
- Over `btq-cli`, `importdilithiumkey` now accepts `rescan=false` both positionally and named, returning an address where it previously raised a JSON type error
- Full functional suite against master: `rpc_help.py` moves to passing and nothing regresses. Two tests surfaced in the diff, `feature_anchors.py` and `p2p_dns_seeds.py`; both are flaky under parallel load and unrelated. `p2p_dns_seeds.py` fails 3 of 5 runs on unmodified master and 3 of 5 with this change, and `feature_anchors.py` passes 3 of 3 in isolation.