### PR TITLE
node: make -blocksonly=1 start under BTQ's mempool floor

### DIFF
--- a/src/kernel/mempool_options.h
+++ b/src/kernel/mempool_options.h
@@ -17,8 +17,13 @@ class CBlockPolicyEstimator;
 
 /** Default for -maxmempool, maximum megabytes of mempool memory usage */
 static constexpr unsigned int DEFAULT_MAX_MEMPOOL_SIZE_MB{2000}; // 2 GB
-/** Default for -maxmempool when blocksonly is set */
-static constexpr unsigned int DEFAULT_BLOCKSONLY_MAX_MEMPOOL_SIZE_MB{5};
+/** Default for -maxmempool when blocksonly is set.
+ *  AppInitMain requires maxmempool >= descendant_size_vbytes * 40. BTQ raised
+ *  DEFAULT_DESCENDANT_SIZE_LIMIT_KVB with MAX_BLOCK_WEIGHT, so that floor is
+ *  80 MB here; the upstream 5 MB soft-set no longer starts the node (#146). */
+static constexpr unsigned int DEFAULT_BLOCKSONLY_MAX_MEMPOOL_SIZE_MB{
+    (DEFAULT_DESCENDANT_SIZE_LIMIT_KVB * 1'000 * 40 + 999'999) / 1'000'000};
+static_assert(DEFAULT_BLOCKSONLY_MAX_MEMPOOL_SIZE_MB >= 80);
 /** Default for -mempoolexpiry, expiration time for mempool transactions in hours */
 static constexpr unsigned int DEFAULT_MEMPOOL_EXPIRY_HOURS{336};
 /** Default for -mempoolfullrbf, if the transaction replaceability signaling is ignored */

--- a/test/functional/mempool_limit.py
+++ b/test/functional/mempool_limit.py
@@ -368,9 +368,11 @@ class MempoolLimitTest(BTQTestFramework):
         assert_greater_than((parent_fee + child_fee) / (tx_parent_just_below["tx"].get_vsize() + tx_child_just_above["tx"].get_vsize()), mempoolmin_feerate / 1000)
         assert_raises_rpc_error(-26, "mempool full", node.submitpackage, [tx_parent_just_below["hex"], tx_child_just_above["hex"]])
 
-        self.log.info('Test passing a value below the minimum (5 MB) to -maxmempool throws an error')
+        self.log.info('Test passing a value below the minimum (80 MB) to -maxmempool throws an error')
         self.stop_node(0)
-        self.nodes[0].assert_start_raises_init_error(["-maxmempool=4"], "Error: -maxmempool must be at least 5 MB")
+        # Floor is descendant_size_vbytes * 40. BTQ's raised descendant limit makes
+        # that 80 MB; upstream's equivalent message said 5 MB.
+        self.nodes[0].assert_start_raises_init_error(["-maxmempool=4"], "Error: -maxmempool must be at least 80 MB")
 
         self.test_mid_package_replacement()
         self.test_mid_package_eviction()


### PR DESCRIPTION
Fixes #146.

`btqd -blocksonly=1` refused to start on every network:

```
InitParameterInteraction: -blocksonly=1 -> setting -maxmempool=5
Error: -maxmempool must be at least 80 MB
```

`-blocksonly` soft-sets `-maxmempool` to `DEFAULT_BLOCKSONLY_MAX_MEMPOOL_SIZE_MB`, which was still upstream's 5 MB. `AppInitMain` then requires the mempool to hold 40 descendant packages, and BTQ raised `DEFAULT_DESCENDANT_SIZE_LIMIT_KVB` with `MAX_BLOCK_WEIGHT`, so that floor is 80 MB. Upstream is fine because 5 > ~4; we were not.

### Fix

Derive the blocksonly default from the descendant floor so the two cannot drift apart again, rather than hardcoding 80:

```cpp
static constexpr unsigned int DEFAULT_BLOCKSONLY_MAX_MEMPOOL_SIZE_MB{
    (DEFAULT_DESCENDANT_SIZE_LIMIT_KVB * 1'000 * 40 + 999'999) / 1'000'000};
```

Also update `mempool_limit.py`'s assertion that hardcoded the old "at least 5 MB" message. That test's own `-maxmempool=5` extra_arg is a separate #104 problem and is left alone.

### Testing

- `btqd -regtest -blocksonly=1` starts; `getmempoolinfo` reports `maxmempool: 80000000`
- Soft-set log line is now `-maxmempool=80`
- `p2p_blocksonly.py` and `p2p_compactblocks_blocksonly.py` pass (both use bare `-blocksonly`)