### PR TITLE
psbt: carry Dilithium P2MR signing material across wallets

### DIFF
--- a/contrib/btq/dilithium-psbt.sh
+++ b/contrib/btq/dilithium-psbt.sh
@@ -1,0 +1,363 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 The BTQ Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+# Operator wrapper around the Dilithium P2MR PSBT RPCs. Every command is a
+# thin call to btq-cli; nothing here signs except walletprocesspsbt.
+#
+# A 2-of-3 PSBT is ~16 KB. Keep it in a file, not a QR code.
+#
+# Usage:
+#   dilithium-psbt.sh --cli="<btq-cli invocation>" <command> [args]
+#   e.g. dilithium-psbt.sh --cli="src/btq-cli -testnet" pubkey alice
+#
+# Commands print JSON or a PSBT/hex payload on stdout. Diagnostics go to stderr.
+# See doc/psbt.md ("Dilithium P2MR") for the equivalent raw btq-cli recipe.
+
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+usage: dilithium-psbt.sh --cli="<btq-cli invocation>" <command> [args]
+
+Commands (each is one btq-cli RPC, or a short sequence of them):
+
+  pubkey   <wallet> [label]
+      New Dilithium key in <wallet>. Prints address, p2mr_id, pubkey.
+      RPCs: getnewdilithiumaddress, getdilithiumpubkey
+
+  register <wallet> <m> <pubkey> [<pubkey>...]
+      Register the same m-of-n P2MR destination in <wallet>.
+      Every co-signer must pass the same m and the same pubkeys in the same order.
+      RPC: createdilithiummultisig
+
+  create   <wallet> <txid:vout> <address> <amount>
+      Unsigned funded PSBT spending that outpoint to <address>.
+      RPC: walletcreatefundedpsbt
+
+  sign     <wallet> <psbt>
+      Add this wallet's Dilithium signature(s). <psbt> is a file or base64.
+      RPC: walletprocesspsbt
+
+  combine  <psbt> <psbt> [<psbt>...]
+      Merge independently signed copies of the same unsigned PSBT.
+      RPC: combinepsbt
+
+  status   <psbt>
+      Per-input Dilithium signing progress (use this, not analyzepsbt).
+      RPC: decodepsbt
+
+  finalize <psbt>
+      Build the witness. Prints the raw hex when complete.
+      RPC: finalizepsbt
+
+  broadcast <hex>
+      RPC: sendrawtransaction
+
+Pass a PSBT as a file path (preferred) or as a base64 string.
+EOF
+}
+
+CLI=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        --cli=*)
+            # shellcheck disable=SC2206
+            CLI=(${1#--cli=})
+            shift
+            ;;
+        --cli)
+            # shellcheck disable=SC2206
+            CLI=($2)
+            shift 2
+            ;;
+        --)
+            shift
+            break
+            ;;
+        -*)
+            echo "unknown option: $1 (btq-cli flags belong inside --cli)" >&2
+            exit 1
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+if [[ ${#CLI[@]} -eq 0 ]]; then
+    if [[ -n "${BTQ_CLI:-}" ]]; then
+        # shellcheck disable=SC2206
+        CLI=($BTQ_CLI)
+    else
+        CLI=(btq-cli)
+    fi
+fi
+
+if [[ $# -lt 1 ]]; then
+    usage >&2
+    exit 1
+fi
+
+need_python() {
+    command -v python3 >/dev/null 2>&1 || {
+        echo "python3 is required to parse RPC JSON" >&2
+        exit 1
+    }
+}
+
+# If btq-cli printed a JSON value, unwrap a top-level string so stdout is
+# the raw PSBT / txid / hex rather than a quoted JSON string.
+unwrap() {
+    need_python
+    python3 -c '
+import json, sys
+raw = sys.stdin.read()
+try:
+    value = json.loads(raw)
+except json.JSONDecodeError:
+    sys.stdout.write(raw)
+    raise SystemExit(0)
+if isinstance(value, str):
+    sys.stdout.write(value)
+    if not value.endswith("\n"):
+        sys.stdout.write("\n")
+else:
+    json.dump(value, sys.stdout)
+    sys.stdout.write("\n")
+'
+}
+
+# Read a dotted path out of JSON on stdin. Numeric path segments index arrays.
+jget() {
+    need_python
+    python3 -c '
+import json, sys
+data = json.load(sys.stdin)
+cur = data
+for part in sys.argv[1].split("."):
+    if part == "":
+        continue
+    if isinstance(cur, list):
+        cur = cur[int(part)]
+    else:
+        cur = cur[part]
+if isinstance(cur, (dict, list)):
+    json.dump(cur, sys.stdout)
+    sys.stdout.write("\n")
+elif isinstance(cur, bool):
+    print("true" if cur else "false")
+else:
+    print(cur)
+' "$1"
+}
+
+btq() {
+    "${CLI[@]}" "$@"
+}
+
+wallet() {
+    local name="$1"
+    shift
+    "${CLI[@]}" -rpcwallet="$name" "$@"
+}
+
+read_psbt() {
+    local arg="$1"
+    if [[ -f "$arg" ]]; then
+        tr -d '\n' < "$arg"
+    else
+        printf '%s' "$arg"
+    fi
+}
+
+cmd_pubkey() {
+    local name="${1:?wallet name}"
+    local label="${2:-}"
+    local created pk
+    if [[ -n "$label" ]]; then
+        created=$(wallet "$name" getnewdilithiumaddress "$label")
+    else
+        created=$(wallet "$name" getnewdilithiumaddress)
+    fi
+    local id address
+    id=$(printf '%s' "$created" | jget p2mr_id)
+    address=$(printf '%s' "$created" | jget address)
+    pk=$(wallet "$name" getdilithiumpubkey "$id")
+    need_python
+    python3 -c '
+import json, sys
+created = json.loads(sys.argv[1])
+info = json.loads(sys.argv[2])
+pubkeys = info["pubkeys"]
+if len(pubkeys) != 1:
+    sys.stderr.write("expected a single-key Dilithium address, got %d pubkeys\n" % len(pubkeys))
+    sys.exit(1)
+out = {
+    "wallet": sys.argv[3],
+    "address": created["address"],
+    "p2mr_id": created["p2mr_id"],
+    "pubkey": pubkeys[0]["pubkey"],
+    "ismine": pubkeys[0]["ismine"],
+}
+json.dump(out, sys.stdout, indent=2)
+sys.stdout.write("\n")
+' "$created" "$pk" "$name"
+}
+
+cmd_register() {
+    local name="${1:?wallet name}"
+    local m="${2:?m (signatures required)}"
+    shift 2
+    if [[ $# -lt 1 ]]; then
+        echo "register: need at least one pubkey" >&2
+        exit 1
+    fi
+    need_python
+    local pubkeys_json
+    pubkeys_json=$(python3 -c 'import json,sys; print(json.dumps(sys.argv[1:]))' "$@")
+    wallet "$name" createdilithiummultisig "$m" "$pubkeys_json"
+}
+
+cmd_create() {
+    local name="${1:?wallet name}"
+    local outpoint="${2:?txid:vout}"
+    local dest="${3:?destination address}"
+    local amount="${4:?amount}"
+    local txid="${outpoint%:*}"
+    local vout="${outpoint##*:}"
+    if [[ "$txid" == "$outpoint" || -z "$vout" ]]; then
+        echo "create: outpoint must be txid:vout" >&2
+        exit 1
+    fi
+    need_python
+    local inputs outputs funded
+    inputs=$(python3 -c 'import json,sys; print(json.dumps([{"txid":sys.argv[1],"vout":int(sys.argv[2])}]))' "$txid" "$vout")
+    outputs=$(python3 -c 'import json,sys; print(json.dumps([{sys.argv[1]: sys.argv[2]}]))' "$dest" "$amount")
+    funded=$(wallet "$name" walletcreatefundedpsbt "$inputs" "$outputs")
+    printf '%s' "$funded" | jget psbt
+}
+
+cmd_sign() {
+    local name="${1:?wallet name}"
+    local psbt
+    psbt=$(read_psbt "${2:?psbt file or base64}")
+    local result
+    result=$(wallet "$name" walletprocesspsbt "$psbt")
+    printf '%s' "$result" | jget psbt
+    {
+        echo "complete: $(printf '%s' "$result" | jget complete)"
+        # Progress is on stderr so stdout stays a clean PSBT for piping.
+        local decoded
+        decoded=$(btq decodepsbt "$(printf '%s' "$result" | jget psbt)")
+        printf '%s' "$decoded" | python3 -c '
+import json, sys
+decoded = json.load(sys.stdin)
+for i, inp in enumerate(decoded.get("inputs", [])):
+    progress = inp.get("p2mr_dilithium")
+    if progress is None:
+        print("input %d: not a Dilithium P2MR input" % i)
+    else:
+        print("input %d: %s  %s/%s signatures" % (
+            i, progress.get("status"), progress.get("signatures"), progress.get("required")))
+'
+    } >&2
+}
+
+cmd_combine() {
+    if [[ $# -lt 2 ]]; then
+        echo "combine: need at least two PSBTs" >&2
+        exit 1
+    fi
+    need_python
+    local arr='['
+    local first=1
+    local p
+    for p in "$@"; do
+        if [[ $first -eq 1 ]]; then
+            first=0
+        else
+            arr+=','
+        fi
+        arr+=$(python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$(read_psbt "$p")")
+    done
+    arr+=']'
+    btq combinepsbt "$arr" | unwrap
+}
+
+cmd_status() {
+    local psbt
+    psbt=$(read_psbt "${1:?psbt file or base64}")
+    local decoded
+    decoded=$(btq decodepsbt "$psbt")
+    need_python
+    printf '%s' "$decoded" | python3 -c '
+import json, sys
+decoded = json.load(sys.stdin)
+out = []
+for i, inp in enumerate(decoded.get("inputs", [])):
+    row = {"index": i}
+    if "p2mr_dilithium" in inp:
+        row.update(inp["p2mr_dilithium"])
+    else:
+        row["status"] = "not_p2mr"
+    if "p2mr_scripts" in inp and inp["p2mr_scripts"]:
+        leaf = inp["p2mr_scripts"][0]
+        row["dilithium_policy"] = leaf.get("dilithium_policy")
+        row["dilithium_required"] = leaf.get("dilithium_required")
+        row["dilithium_total"] = leaf.get("dilithium_total")
+    out.append(row)
+json.dump(out if len(out) != 1 else out[0], sys.stdout, indent=2)
+sys.stdout.write("\n")
+'
+}
+
+cmd_finalize() {
+    local psbt
+    psbt=$(read_psbt "${1:?psbt file or base64}")
+    local result
+    result=$(btq finalizepsbt "$psbt")
+    local complete
+    complete=$(printf '%s' "$result" | jget complete)
+    if [[ "$complete" == "true" ]]; then
+        printf '%s' "$result" | jget hex
+    else
+        echo "not complete; need more signatures" >&2
+        printf '%s' "$result" | jget psbt >&2 || true
+        exit 2
+    fi
+}
+
+cmd_broadcast() {
+    local hex="$1"
+    if [[ -f "$hex" ]]; then
+        hex=$(tr -d '\n' < "$hex")
+    fi
+    btq sendrawtransaction "$hex" | unwrap
+}
+
+cmd="${1}"
+shift || true
+
+case "$cmd" in
+    pubkey)    cmd_pubkey "$@" ;;
+    register)  cmd_register "$@" ;;
+    create)    cmd_create "$@" ;;
+    sign)      cmd_sign "$@" ;;
+    combine)   cmd_combine "$@" ;;
+    status)    cmd_status "$@" ;;
+    finalize)  cmd_finalize "$@" ;;
+    broadcast) cmd_broadcast "$@" ;;
+    help)      usage ;;
+    *)
+        echo "unknown command: $cmd" >&2
+        usage >&2
+        exit 1
+        ;;
+esac

--- a/contrib/btq/testnet_dilithium_psbt_proof.sh
+++ b/contrib/btq/testnet_dilithium_psbt_proof.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 The BTQ Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+# Proves the BTQ-PSBT Dilithium extension end to end against a live chain.
+#
+# Three wallets each hold one Dilithium key, register the same 2-of-3 P2MR
+# multisig, and then spend from it by passing base64 PSBTs between themselves.
+# Nothing but the PSBT string moves between wallets, so the spend can only
+# succeed if the PSBT itself carries the leaf script, control block and
+# Dilithium partial signatures.
+#
+# Usage: testnet_dilithium_psbt_proof.sh <btq-cli invocation...>
+#   e.g. testnet_dilithium_psbt_proof.sh src/btq-cli -testnet -rpcport=18355 ...
+
+set -euo pipefail
+
+if [ "$#" -lt 1 ]; then
+    echo "usage: $0 <btq-cli invocation...>" >&2
+    exit 1
+fi
+
+CLI=("$@")
+btq() { "${CLI[@]}" "$@"; }
+wallet() { local name="$1"; shift; "${CLI[@]}" "-rpcwallet=$name" "$@"; }
+
+FUNDER=psbtproof_funder
+SIGNERS=(psbtproof_alice psbtproof_bob psbtproof_carol)
+REQUIRED=2
+
+log() { printf '\n=== %s\n' "$*"; }
+
+ensure_wallet() {
+    local name="$1"
+    if btq listwallets | grep -q "\"$name\""; then return; fi
+    btq loadwallet "$name" >/dev/null 2>&1 || btq createwallet "$name" false false "" false true true >/dev/null
+}
+
+log "chain status"
+btq getblockchaininfo | grep -E '"chain"|"blocks"|"difficulty"'
+
+log "wallets"
+for name in "$FUNDER" "${SIGNERS[@]}"; do
+    ensure_wallet "$name"
+    echo "  $name"
+done
+
+log "each co-signer publishes one Dilithium pubkey"
+PUBKEYS=()
+for name in "${SIGNERS[@]}"; do
+    id=$(wallet "$name" getnewdilithiumaddress "psbt-proof" | jq -r .p2mr_id)
+    pk=$(wallet "$name" getdilithiumpubkey "$id" | jq -r '.pubkeys[0].pubkey')
+    PUBKEYS+=("$pk")
+    echo "  $name ${pk:0:32}... (${#pk} hex chars)"
+done
+
+log "every co-signer registers the same ${REQUIRED}-of-${#SIGNERS[@]} multisig"
+PUBKEY_JSON=$(printf '%s\n' "${PUBKEYS[@]}" | jq -R . | jq -sc .)
+ADDRESS=""
+for name in "${SIGNERS[@]}"; do
+    out=$(wallet "$name" createdilithiummultisig "$REQUIRED" "$PUBKEY_JSON" "psbt-proof")
+    addr=$(echo "$out" | jq -r .address)
+    echo "  $name -> $addr (can sign with $(echo "$out" | jq -r .signers_available) key)"
+    if [ -z "$ADDRESS" ]; then
+        ADDRESS="$addr"
+        LEAF_SCRIPT=$(echo "$out" | jq -r .leaf_script)
+        SCRIPT_PUBKEY=$(echo "$out" | jq -r .scriptPubKey)
+    elif [ "$addr" != "$ADDRESS" ]; then
+        echo "co-signers derived different addresses" >&2
+        exit 1
+    fi
+done
+echo "  address:      $ADDRESS"
+echo "  scriptPubKey: $SCRIPT_PUBKEY"
+echo "  leaf script:  ${#LEAF_SCRIPT} hex chars"
+
+log "funding the multisig"
+BALANCE=$(wallet "$FUNDER" getbalance)
+echo "  funder balance: $BALANCE"
+if [ "$(echo "$BALANCE < 0.001" | bc -l)" = "1" ]; then
+    echo "funder has no spendable coins; mine to $(wallet "$FUNDER" getnewaddress) first" >&2
+    exit 1
+fi
+FUND_TXID=$(wallet "$FUNDER" sendtoaddress "$ADDRESS" 0.001)
+echo "  funding txid: $FUND_TXID"
+
+log "waiting for the funding transaction to confirm"
+until [ "$(wallet "$FUNDER" gettransaction "$FUND_TXID" | jq -r .confirmations)" -ge 1 ]; do
+    sleep 15
+done
+VOUT=$(wallet "$FUNDER" gettransaction "$FUND_TXID" true true |
+       jq --arg a "$ADDRESS" '.decoded.vout[] | select(.scriptPubKey.address == $a) | .n')
+echo "  confirmed at ${FUND_TXID}:${VOUT}"
+
+log "alice builds the unsigned PSBT"
+DEST=$(wallet "$FUNDER" getnewaddress)
+PSBT=$(wallet "${SIGNERS[0]}" walletcreatefundedpsbt \
+        "[{\"txid\":\"$FUND_TXID\",\"vout\":$VOUT}]" "[{\"$DEST\":0.0005}]" | jq -r .psbt)
+btq decodepsbt "$PSBT" | jq '.inputs[0] | {p2mr_merkle_root, leaf: .p2mr_scripts[0] | {leaf_ver, dilithium_policy, dilithium_required, dilithium_total}, p2mr_dilithium}'
+
+log "alice signs (below threshold)"
+PSBT_A=$(wallet "${SIGNERS[0]}" walletprocesspsbt "$PSBT" | jq -r .psbt)
+btq decodepsbt "$PSBT_A" | jq '.inputs[0].p2mr_dilithium'
+
+log "bob signs the base64 PSBT alice handed over"
+RESULT=$(wallet "${SIGNERS[1]}" walletprocesspsbt "$PSBT_A")
+PSBT_AB=$(echo "$RESULT" | jq -r .psbt)
+echo "  complete: $(echo "$RESULT" | jq -r .complete)"
+btq decodepsbt "$PSBT_AB" | jq '.inputs[0].p2mr_dilithium'
+
+log "finalize and broadcast"
+FINAL=$(btq finalizepsbt "$PSBT_AB")
+echo "  complete: $(echo "$FINAL" | jq -r .complete)"
+RAW=$(echo "$FINAL" | jq -r .hex)
+btq testmempoolaccept "[\"$RAW\"]" | jq -c '.[0] | {txid, allowed, "reject-reason"}'
+SPEND_TXID=$(btq sendrawtransaction "$RAW")
+echo "  spend txid: $SPEND_TXID"
+
+log "waiting for the spend to confirm"
+until [ "$(wallet "${SIGNERS[0]}" gettransaction "$SPEND_TXID" | jq -r .confirmations)" -ge 1 ]; do
+    sleep 15
+done
+CONF=$(wallet "${SIGNERS[0]}" gettransaction "$SPEND_TXID" true true)
+echo "  confirmations: $(echo "$CONF" | jq -r .confirmations)"
+echo "  blockhash:     $(echo "$CONF" | jq -r .blockhash)"
+echo "  witness items: $(echo "$CONF" | jq -r '.decoded.vin[0].txinwitness | length')"
+echo "  witness sizes: $(echo "$CONF" | jq -c '[.decoded.vin[0].txinwitness[] | (length / 2)]')"
+
+log "PROVEN: 2-of-3 Dilithium multisig spent via PSBT interchange"
+echo "  funding: $FUND_TXID"
+echo "  spend:   $SPEND_TXID"

--- a/doc-btq/DILITHIUM_PSBT_DESIGN.md
+++ b/doc-btq/DILITHIUM_PSBT_DESIGN.md
@@ -317,7 +317,7 @@ REQUIRE stream consumed exactly value_len bytes
 
 | Component | Content |
 |-----------|---------|
-| PSBT key | `[type=0x19] \|\| control_block` (raw bytes, 1–513 bytes) |
+| PSBT key | `[type=0x19] \|\| control_block` (raw bytes, `P2MR_CONTROL_BASE_SIZE`–`P2MR_CONTROL_MAX_SIZE`, i.e. 1–4097 bytes) |
 | PSBT value | `leaf_script_bytes \|\| leaf_version` (version is **last** byte of value) |
 
 **v1 cardinality:** Exactly **one** `(leaf_script, leaf_version)` pair per distinct `control_block` key. If the same `control_block` key appears twice (duplicate PSBT key) → **REJECT** at parse.
@@ -419,11 +419,13 @@ For input `i` spending P2MR via script path:
 | `MAX_DILITHIUM_PARTIAL_SIG_VALUE_SIZE` | 2421 | PSBT value: `sig_raw + sighash_type` |
 | `MAX_DILITHIUM_PARTIAL_SIGS_PER_INPUT` | 20 | Count of `PSBT_IN_P2MR_DILITHIUM_SCRIPT_SIG` entries |
 | `MAX_DILITHIUM_PARTIAL_SIG_PAYLOAD_PER_INPUT` | 1_500_000 bytes (~1.5 MB) | Sum of partial sig value sizes |
-| `MAX_P2MR_LEAF_SCRIPT_SIZE` | 10000 | Leaf script bytes |
-| `MAX_CONTROL_BLOCK_SIZE` | 513 | `P2MR_CONTROL_MAX_SIZE` |
+| `MAX_P2MR_LEAF_SCRIPT_SIZE` | 100000 (`MAX_SCRIPT_SIZE`) | Leaf script bytes |
+| `P2MR_CONTROL_MAX_SIZE` | 4097 | Control block bytes; the consensus limit, reused verbatim |
 | `MAX_PSBT_SIZE` | 100 MB | Entire PSBT blob |
 
 Per-input partial-sig payload is the sum over all `PSBT_IN_P2MR_DILITHIUM_SCRIPT_SIG` value sizes on that input. Exceeding any limit → reject entire PSBT load.
+
+**The control block cap MUST be the consensus constant itself, never an independent value.** A PSBT parse cap below `P2MR_CONTROL_MAX_SIZE` would reject control blocks for leaves at depth 17 and beyond, which are consensus-valid and reachable through `createp2mr`. That would make an on-chain-spendable output unspendable through any conformant implementation, and would split interop against implementations that use the consensus bound. Derive this limit from `P2MR_CONTROL_BASE_SIZE`, `P2MR_CONTROL_NODE_SIZE` and `P2MR_CONTROL_MAX_NODE_COUNT` so the two cannot drift apart.
 
 ### 4.6 Sighash type matrix (v1)
 
@@ -450,7 +452,7 @@ ValidatePSBTInput(i):
   1. Resolve utxo = witness_utxo or non_witness_utxo prevout output
   2. Assert utxo.scriptPubKey classifies as WITNESS_V2_P2MR; extract program (32-byte root)
   3. For each PSBT_IN_P2MR_LEAF_SCRIPT (control_block → leaf_script, leaf_version):
-       a. control_block size ∈ [P2MR_CONTROL_BASE_SIZE, MAX_CONTROL_BLOCK_SIZE]
+       a. control_block size ∈ [P2MR_CONTROL_BASE_SIZE, P2MR_CONTROL_MAX_SIZE]
        b. (control_block.size - P2MR_CONTROL_BASE_SIZE) % P2MR_CONTROL_NODE_SIZE == 0
        c. (control_block[0] & 1) == 1   // parity bit MUST be set (BIP360)
        d. leaf_script size ≤ MAX_P2MR_LEAF_SCRIPT_SIZE
@@ -489,8 +491,7 @@ Proves that `(leaf_script, leaf_version)` commits to the P2MR `program` (32-byte
 P2MR_CONTROL_BASE_SIZE       = 1
 P2MR_CONTROL_NODE_SIZE       = 32
 P2MR_CONTROL_MAX_NODE_COUNT  = 128
-P2MR_CONTROL_MAX_SIZE        = 1 + 32 * 128 = 4129   // consensus maximum
-MAX_CONTROL_BLOCK_SIZE       = 513                    // PSBT v1 parse cap (§4.5)
+P2MR_CONTROL_MAX_SIZE        = 1 + 32 * 128 = 4097   // consensus maximum, and the PSBT parse cap (§4.5)
 TAPROOT_LEAF_MASK            = 0xFE
 TAPROOT_LEAF_TAPSCRIPT       = 0xC0
 ```
@@ -979,6 +980,10 @@ Dilithium PSBT to any caller.
 | `createdilithiummultisig <nrequired> <pubkeys> [label]` | Register an m-of-n threshold accumulator P2MR destination. Co-signers passing the same arguments derive the same address. |
 | `getdilithiumpubkey <p2mr_id>` | Report the Dilithium pubkeys a wallet destination names, and which of them the wallet can sign for. This is how a co-signer publishes its key. |
 
+**CLI recipe:** `doc/psbt.md` (section “Dilithium P2MR”) is the copy-paste
+`btq-cli` flow. `contrib/btq/dilithium-psbt.sh` wraps those same RPCs so the
+~16 KB PSBT does not have to be pasted as a shell argument.
+
 **Deferred:** `btqconvertpsbt <btqms-file>` (§16.3).
 
 ### 7.2 Descriptor alignment
@@ -1211,6 +1216,7 @@ RPC layer maps to `RPC_DESERIALIZATION_ERROR` (parse) or `RPC_INVALID_PARAMETER`
 | §10.1 unit tests | `src/test/psbt_dilithium_tests.cpp` |
 | §10.2 functional tests | `test/functional/wallet_dilithium_psbt_multisig.py` |
 | Live-chain proof | `contrib/btq/testnet_dilithium_psbt_proof.sh` |
+| Operator CLI wrapper | `contrib/btq/dilithium-psbt.sh`; recipe in `doc/psbt.md` |
 
 ### 16.2 Deviations from the draft
 
@@ -1277,12 +1283,27 @@ Witness stack on the confirmed input, byte lengths in push order:
 
 ```
 [0, 2421, 2421, 3960, 1]
- │   │     │     │     └─ control block (leaf version only; single-leaf tree)
+ │   │     │     │     └─ control block, single-leaf tree, the byte 0xc1
  │   │     │     └─────── leaf script
  │   │     └───────────── alice's signature (key 0)
  │   └─────────────────── bob's signature  (key 1)
  └─────────────────────── empty slot for carol (key 2, did not sign)
 ```
+
+Cross-checked against the public block explorer, which shows the same five items in the same
+order and both signatures ending in the `0x01` `SIGHASH_ALL` byte. Its reported serialized
+size of 8 930 bytes reconciles exactly, leaving nothing unaccounted for in the witness:
+
+| Part | Bytes |
+|------|-------|
+| Base transaction (version, 1 input, 2 outputs, locktime) | 113 |
+| Segwit marker and flag | 2 |
+| Witness: stack count, 2×(3 + 2421) sigs, 3 + 3960 leaf, 1 + 1 control, 1 empty | 8 815 |
+| **Total** | **8 930** |
+
+The explorer also reports 665 vB and a fee of 816 satoshis, so the witness is being discounted
+well below the BIP141 rate. That discount is pre-existing BTQ policy, not something this change
+introduces, but it is the reason a 2-of-3 post-quantum spend is affordable at all.
 
 This matches Appendix A: slots are pushed in reverse key order, so key 0 ends up on top,
 and a non-signing key contributes an empty push rather than being omitted.
@@ -1395,8 +1416,12 @@ stack[4] = control_block
 Roughly 12 KB binary, 16 KB base64 — comfortable for a file, an email attachment or a
 paste, but far too large for a QR code (§13 non-goal 3).
 
-A P2MR control block has no internal key, so for a single-leaf tree it is one byte (the
-leaf version); each additional merkle path node adds 32 bytes.
+A P2MR control block has no internal key, so for a single-leaf tree it is one byte and each
+additional merkle path node adds 32 bytes. That byte is the leaf version with BIP360's
+parity bit set, which is always 1 in the absence of an internal key: `0xc0 | 1 = 0xc1`
+(`P2MRBuilder::GetSpendData` in `src/script/signingprovider.cpp`). Note the asymmetry — the
+`PSBT_IN_P2MR_LEAF_SCRIPT` *value* ends with the bare leaf version `0xc0`, while its *key*
+is the control block beginning `0xc1`.
 
 ---
 

--- a/doc-btq/DILITHIUM_PSBT_DESIGN.md
+++ b/doc-btq/DILITHIUM_PSBT_DESIGN.md
@@ -1,0 +1,1479 @@
+# Partially Signed BTQ Transactions (Dilithium PSBT)
+
+**Status:** v1 implemented in btq-core and proven on the public testnet (§16 maps the spec to
+the code and lists what was deferred; §17 records the live 2-of-3 spends)  
+**Authors:** BTQ Core wallet/protocol working group  
+**Date:** 2026-08-06  
+**Related:** BIP174, BIP370, BIP341, BIP342, BIP360 (P2MR), `btq-multisig` `.btqms` format  
+**Target implementation:** btq-core wallet + `btq-multisig` convergence
+
+---
+
+## Abstract
+
+This document specifies **BTQ-PSBT**, an extension to BIP174 Partially Signed Bitcoin Transaction (PSBT) format enabling multi-party signing workflows for **Dilithium** signatures on **P2MR (witness v2)** outputs. The extension is strictly an **off-chain interchange format**. It requires **no consensus change, no hardfork, and no activation height**.
+
+Consensus already validates Dilithium P2MR spends (`SigVersion::P2MR_TAPSCRIPT`, `OP_CHECKSIGDILITHIUM`, `OP_CHECKMULTISIGDILITHIUM`). Today, btq-core's PSBT stack round-trips only ECDSA `partial_sigs` and BIP341 Taproot fields. Dilithium material lives in `SignatureData` (`dilithium_signatures`, `p2mr_dilithium_script_sigs`, `p2mr_spenddata`) but is **dropped** at PSBT serialization boundaries. The interim `.btqms` JSON format in `btq-multisig` exists solely because of this gap.
+
+BTQ-PSBT closes the gap with first-class typed fields, normative finalization for production multisig (accumulator leaves), fail-closed parsing/merge/verification, wallet/RPC integration, and a migration path from `.btqms`.
+
+**Implementer note:** Two independent teams MUST be able to produce byte-compatible PSBTs using **only this document** (plus BIP174/BIP341/BIP360 references cited herein). No btq-core source inspection is required.
+
+---
+
+## 1. Problem statement
+
+### 1.1 Current state
+
+| Capability | On-chain (consensus) | In-wallet signing (`SignatureData`) | PSBT serialization | `.btqms` |
+|------------|---------------------|-------------------------------------|-------------------|----------|
+| ECDSA P2PKH/P2WPKH/P2TR | Yes | Yes | Yes (BIP174/371) | N/A |
+| Dilithium P2MR single-key | Yes | Yes (RPC) | **No** | Partial (single policy) |
+| Dilithium P2MR m-of-n multisig | Yes | Yes (`btq-multisig`) | **No** | Yes |
+| P2MR leaf/control-block metadata | Yes | Yes (`P2MRSpendData`) | **No** | Yes (embedded in multisig ctx) |
+| Hardware / air-gapped co-signing | N/A | N/A | **Blocked** | JSON workaround |
+| Mixed-input txs (ECDSA + Dilithium) | Yes | Yes | **Partial** (ECDSA only in PSBT) | No |
+
+### 1.2 Requirements
+
+**Functional (MUST):**
+
+1. Serialize and deserialize Dilithium partial signatures without loss.
+2. Serialize P2MR script-path spend metadata (leaf script, leaf version, control block, merkle root).
+3. Support multi-signer workflows: creator → signer A → signer B → finalizer → broadcaster.
+4. Support transactions with **multiple inputs**, each independently Dilithium or ECDSA.
+5. Verify each imported partial signature against the BIP341-style sighash for `SigVersion::P2MR_TAPSCRIPT` before accepting it.
+6. Integrate with existing RPCs: `walletcreatefundedpsbt`, `walletprocesspsbt`, `utxoupdatepsbt`, `finalizepsbt`, `decodepsbt`.
+7. Remain backward-compatible with unextended BIP174 parsers (unknown fields preserved per BIP174 §1.1.5).
+8. Finalize production `btq-multisig` **accumulator** leaves (not only `OP_CHECKMULTISIGDILITHIUM`).
+
+**Non-functional (MUST):**
+
+1. Fail-closed parsing: malformed keys/values reject the entire PSBT load (audit item W-05).
+2. Bounded resource use: explicit maxima on signature/pubkey sizes and per-input field counts.
+3. Deterministic merge semantics when combining PSBTs from multiple signers.
+4. No new trusted third parties; no new on-chain data.
+
+**Explicit non-goals (WILL NOT in v1):**
+
+1. Dilithium in legacy P2PKH/P2SH/P2WPKH script types (consensus-forbidden for new receives).
+2. Falcon/SPHINCS+ PSBT fields (future extension).
+3. QR-based co-signing for multisig PSBTs (size makes this unsafe; see §13).
+4. In-place fee-bump that preserves existing partial signatures (requires re-sign; see §12).
+5. HWI / hardware wallet transport (Phase 5 backlog).
+6. Proprietary `"btq.org"` PSBT fields in production (see §3).
+
+---
+
+## 2. Background
+
+### 2.1 BTQ Dilithium on-chain model
+
+- **Algorithm:** CRYSTALS-Dilithium2 (default `PUBLIC_KEY_SIZE=1312`, `SIGNATURE_SIZE=2420` bytes).
+- **Home for Dilithium scripts:** P2MR (SegWit v2, `WitnessV2P2MR`), BIP360-style Merkle tree of tapscript leaves (`leaf_version` typically `0xc0`).
+- **Signature version:** `SigVersion::P2MR_TAPSCRIPT` (distinct from BIP342 `TAPSCRIPT`; Dilithium opcodes are rejected outside P2MR).
+- **Sighash:** BIP341 `SignatureHashSchnorr` transcript with `execdata.m_tapleaf_hash` set. Full normative algorithm: **§2.5**.
+- **On-wire witness layout (script path):** `[stack items…] | leaf_script | control_block`.
+
+Partial Dilithium signatures in wallet memory are keyed by:
+
+```cpp
+// script/sign.h (abridged)
+std::map<std::pair<DilithiumPKHash, uint256>,
+         std::pair<CDilithiumPubKey, std::vector<unsigned char>>> p2mr_dilithium_script_sigs;
+P2MRSpendData p2mr_spenddata; // merkle_root + scripts map
+```
+
+P2MR script-path spends **must** use `p2mr_dilithium_script_sigs` (pubkey hash + leaf hash → sig), not bare `dilithium_signatures`.
+
+**Wire vs internal key encoding:** PSBT keys carry the full 1312-byte `CDilithiumPubKey`. Internal maps use `DilithiumPKHash` (20-byte `Hash160` of the pubkey). Conversion: `DilithiumPKHash keyid = DilithiumPKHash(pubkey.GetID())` where `GetID()` returns `Hash160(pubkey_bytes)`. See §4.2 and §5.1.
+
+### 2.2 Production multisig: accumulator leaves (critical)
+
+`btq-multisig` deliberately does **not** use `OP_CHECKMULTISIGDILITHIUM` for m-of-n. It uses a **threshold accumulator leaf** so unsigned keys contribute empty signature slots (BIP342 `OP_CHECKSIGADD` semantics):
+
+```
+OP_0                                    # acc = 0 (alt stack)
+for each pubkey pk[k] in script order:
+  OP_TOALTSTACK <pk[k]> OP_CHECKSIGDILITHIUM OP_FROMALTSTACK OP_ADD
+<m> OP_GREATERTHANOREQUAL
+```
+
+Source: `btq-multisig/src/multisig.cpp` (`GetScriptForDilithiumThreshold`).
+
+**Witness stack (normative, from `finalize.cpp`):**
+
+```
+[sig[n-1], …, sig[1], sig[0], leaf_script, control_block]
+```
+
+where `sig[k]` is either:
+- `2421` bytes (`2420` sig + `1` sighash byte) if key `k` signed, or
+- empty vector if key `k` did not sign.
+
+Key `0` is processed first by the script, so its slot is **on top** of the stack → slots are pushed in **reverse key order**.
+
+`ProduceSignature` / miniscript **does not** finalize accumulator scripts today. BTQ-PSBT finalization MUST implement explicit template handlers (§6.5).
+
+### 2.3 Why BIP174 `PSBT_IN_PARTIAL_SIG` is insufficient
+
+| | BIP174 partial sig | Dilithium partial sig |
+|--|-------------------|----------------------|
+| Key | `0x02 \|\| secp256k1_pubkey` (33/65 B) | `dilithium_pubkey (1312 B) \|\| leaf_hash (32 B)` |
+| Value | ECDSA/DER (~72 B) | `2420 B sig + 1 B sighash_type` |
+
+Reusing `PSBT_IN_PARTIAL_SIG` breaks parser key-length validation and conflates algorithms. BTQ-PSBT follows the BIP371 precedent (`PSBT_IN_TAP_SCRIPT_SIG`).
+
+### 2.4 Interim `.btqms` format
+
+JSON container with global `MultisigContext`, `unsigned_tx`, per-input `partial_sigs`. Limitations: single global policy, no merge tooling, hex bloat. BTQ-PSBT subsumes it (§8).
+
+### 2.5 Normative Dilithium P2MR sighash (MUST)
+
+This section is normative. Implementers MUST produce identical sighash digests without reading btq-core source.
+
+#### 2.5.1 Overview
+
+Dilithium P2MR script-path signatures use `SignatureHashSchnorr` with `SigVersion::P2MR_TAPSCRIPT`. The transcript is BIP341 TapSighash with BIP342 extension fields (`tapleaf_hash`, `key_version`, `codeseparator_pos`). There is **no** separate Dilithium sighash function.
+
+#### 2.5.2 PrecomputedTransactionData (MUST)
+
+Before calling `SignatureHashSchnorr`, build `PrecomputedTransactionData txdata` as follows:
+
+```
+BuildPrecomputedData(unsigned_tx, spent_outputs):
+  REQUIRE spent_outputs.size() == unsigned_tx.vin.size()
+  REQUIRE every spent_outputs[i].nValue > 0   // amount mandatory
+  txdata.Init(unsigned_tx, spent_outputs, force=true)
+  REQUIRE txdata.m_spent_outputs_ready == true
+  REQUIRE txdata.m_bip341_taproot_ready == true
+```
+
+**`spent_outputs` source (in priority order):**
+
+1. `witness_utxo` for each input index (preferred).
+2. `non_witness_utxo` prevout at `unsigned_tx.vin[i].prevout.n`.
+
+If any input amount is unknown, sighash computation MUST fail (`MissingDataBehavior::FAIL`). PSBT creators MUST supply amounts for all inputs before signing.
+
+**`force=true`:** Required for unsigned PSBTs (empty witnesses). Forces BIP341 precomputation even when input witnesses are null.
+
+#### 2.5.3 ScriptExecutionData (MUST)
+
+For P2MR script-path Dilithium signing/verification of a partial signature:
+
+```
+execdata.m_annex_init           = true
+execdata.m_annex_present        = false
+execdata.m_codeseparator_pos_init = true
+execdata.m_codeseparator_pos    = 0xFFFFFFFF
+execdata.m_tapleaf_hash_init    = true
+execdata.m_tapleaf_hash         = ComputeTapleafHash(leaf_version, leaf_script)
+```
+
+**Annex:** PSBT v1 does not support annexes. `m_annex_present` MUST be `false`.
+
+**Codeseparator:** No `OP_CODESEPARATOR` in production v1 leaves. Position MUST be `0xFFFFFFFF` (BIP342 "none executed").
+
+**Leaf hash:** MUST match the leaf identified by the spend path's `PSBT_IN_P2MR_LEAF_SCRIPT` entry.
+
+#### 2.5.4 SignatureHashSchnorr call (MUST)
+
+```
+// Input: partial sig value OR PSBT_IN_SIGHASH
+hashtype_wire = sighash_type_byte from partial sig value (last byte)
+              OR PSBT_IN_SIGHASH if no per-sig byte yet
+
+// Normalize for sighash computation (MUST):
+hashtype = (hashtype_wire == 0x00) ? 0x01 : hashtype_wire   // DEFAULT → ALL
+
+// Call:
+SignatureHashSchnorr(sighash, execdata, tx, input_index,
+                     hashtype, SigVersion::P2MR_TAPSCRIPT, txdata,
+                     MissingDataBehavior::FAIL)
+```
+
+**`SigVersion::P2MR_TAPSCRIPT` transcript flags:**
+
+| Field | Value |
+|-------|-------|
+| `ext_flag` | `1` |
+| `key_version` | `0` |
+| `spend_type` | `(ext_flag << 1) + annex_present` = `2` (no annex) |
+| Additional fields appended | `m_tapleaf_hash`, `key_version`, `m_codeseparator_pos` |
+
+The hash uses tagged SHA256 with tag `"TapSighash"` (BIP341). Full field order matches BIP341 §Common signature message + BIP342 §Common signature message extension.
+
+**Unsupported hash types:** Reject `hashtype` not in `{0x01}` after normalization (v1). See §4.6.
+
+#### 2.5.5 sig_raw vs sig_with_hashtype (MUST)
+
+| Artifact | Length | Use |
+|----------|--------|-----|
+| `sig_raw` | 2420 bytes | First 2420 bytes of partial sig value. Passed to `CDilithiumPubKey::Verify(sighash, sig_raw)`. |
+| `sig_with_hashtype` | 2421 bytes | `sig_raw \|\| sighash_type_byte`. Stored as PSBT value; appended to witness stack on finalize. |
+
+**Verification steps:**
+
+```
+sig_raw   = partial_sig_value[0:2420]
+hashtype  = partial_sig_value[2420]
+hashtype_for_sighash = (hashtype == 0x00) ? 0x01 : hashtype
+sighash   = SignatureHashSchnorr(..., hashtype_for_sighash, ...)
+ACCEPT iff pubkey.Verify(sighash, sig_raw) == true
+```
+
+**On-chain note:** Consensus `CheckDilithiumSignature` for `P2MR_TAPSCRIPT` **rejects** `SIGHASH_DEFAULT` (`0x00`) in the witness sighash byte. Finalizers MUST ensure finalized witness signatures use `0x01`, not `0x00`. PSBT parsers MAY accept `0x00` at parse time (normalized for sighash verification) but SHOULD warn; finalizer MUST rewrite to `0x01`.
+
+#### 2.5.6 ComputeTapleafHash (MUST)
+
+```
+leaf_hash = TaggedHash("TapLeaf", leaf_version || compact_size(script) || script)
+```
+
+where `leaf_version` is the single-byte leaf version (typically `div` 0xc0) and `script` is the raw leaf script bytes (not including the version byte).
+
+---
+
+## 3. Design decision
+
+**Option B — first-class typed fields** (BIP-BTQ-PSBT), mirroring BIP371.
+
+### 3.1 Proprietary `"btq.org"` fields — OUT OF v1 production scope
+
+Early prototypes used `PSBT_*_PROPRIETARY` with identifier `"btq.org"` as an alternate encoding. **This is deprecated and excluded from v1 production scope.**
+
+| Rule | v1 production behavior |
+|------|------------------------|
+| Producers | MUST NOT emit `"btq.org"` proprietary Dilithium fields |
+| Readers | MAY reject PSBTs containing **only** proprietary Dilithium fields (no typed `0x19`–`0x1D`) |
+| Mixed encoding | MUST reject PSBTs with both typed (`0x19`–`0x1D`) and proprietary Dilithium fields on the same input |
+| Migration | Use `btqconvertpsbt` (§8) to convert legacy proprietary PSBTs to typed fields |
+
+Typed fields (`0x19`–`0x1D`) are the **sole** normative v1 encoding. Independent implementers MUST NOT depend on proprietary fields.
+
+---
+
+## 4. Wire format specification (BTQ-PSBT v1)
+
+### 4.1 Global extensions
+
+| Type | Name | Key | Value |
+|------|------|-----|-------|
+| `0xFC` | `PSBT_GLOBAL_PROPRIETARY` | `identifier \|\| subtype` | opaque |
+
+Optional capability advertisement (non-normative): identifier `"btq.org"`, subtype `0x01` = reader supports BTQ-PSBT v1 typed fields. PSBT version remains BIP174/BIP370 (`0` or `2`).
+
+**Magic bytes:** unchanged (`psbt\xff`).
+
+### 4.2 Input type bytes
+
+| Type | Name | Key | Value | v1 |
+|------|------|-----|-------|----|
+| `0x19` | `PSBT_IN_P2MR_LEAF_SCRIPT` | `control_block` (variable) | `leaf_script \|\| leaf_version` (`CScript` + `uint8`) | Implemented |
+| `0x1A` | `PSBT_IN_P2MR_MERKLE_ROOT` | *(empty)* | `uint256` | Implemented |
+| `0x1B` | `PSBT_IN_P2MR_DILITHIUM_SCRIPT_SIG` | `dilithium_pubkey (1312) \|\| leaf_hash (32)` | `dilithium_sig (2420) \|\| sighash_type (1)` | Implemented |
+| `0x1C` | `PSBT_IN_P2MR_DILITHIUM_BIP32_DERIVATION` | `dilithium_pubkey (1312)` | BIP174 derivation format | Deferred (§16.3) |
+| `0x1D` | `PSBT_IN_P2MR_DILITHIUM_PUBKEY` | `dilithium_pubkey (1312)` | `leaf_hash_set \|\| KeyOriginInfo` (BIP371-style; §4.2.1) | Deferred (§16.3) |
+
+The three implemented type bytes are sufficient for the full creator → signer → finalizer
+workflow. `0x1C` and `0x1D` only carry derivation hints; a co-signer that already knows
+its own keys does not need them, and reserving the bytes now keeps the door open. `0x1C`
+and `0x1D` are therefore currently parsed as unknown fields and preserved verbatim per
+BIP174 §1.1.5.
+
+#### 4.2.1 `PSBT_IN_P2MR_DILITHIUM_PUBKEY` value layout (MUST)
+
+Mirrors BIP371 `PSBT_IN_TAP_BIP32_DERIVATION` value encoding (`m_tap_bip32_paths` in btq-core `psbt.h`):
+
+```
+value = Serialize(leaf_hash_set) || SerializeKeyOrigin(origin)
+
+Serialize(leaf_hash_set):
+  compact_size(count) || for each h in set (sorted ascending): h (32 bytes)
+
+SerializeKeyOrigin(origin):
+  origin.fingerprint (4 bytes, little-endian uint32)
+  for each index in origin.path: index (4 bytes, little-endian uint32)
+```
+
+**Deserialize:**
+
+```
+value_len = ReadCompactSize(stream)
+before = stream.remaining()
+leaf_hash_set = DeserializeSet<uint256>(stream)   // BIP174 set encoding
+hashes_len = before - stream.remaining()
+origin_len = value_len - hashes_len
+origin = DeserializeKeyOrigin(stream, origin_len)
+REQUIRE stream consumed exactly value_len bytes
+```
+
+**KeyOriginInfo path length:** `(origin_len - 4)` MUST be divisible by 4; otherwise reject.
+
+#### 4.2.2 `PSBT_IN_P2MR_LEAF_SCRIPT` wire rules (MUST)
+
+**Wire encoding:**
+
+| Component | Content |
+|-----------|---------|
+| PSBT key | `[type=0x19] \|\| control_block` (raw bytes, 1–513 bytes) |
+| PSBT value | `leaf_script_bytes \|\| leaf_version` (version is **last** byte of value) |
+
+**v1 cardinality:** Exactly **one** `(leaf_script, leaf_version)` pair per distinct `control_block` key. If the same `control_block` key appears twice (duplicate PSBT key) → **REJECT** at parse.
+
+**Multiple leaves:** Multiple `PSBT_IN_P2MR_LEAF_SCRIPT` entries are allowed when `control_block` keys differ (different Merkle paths to different leaves).
+
+#### 4.2.3 Leaf hash tie-break (MUST)
+
+After parsing all `PSBT_IN_P2MR_LEAF_SCRIPT` entries, compute `leaf_hash = ComputeTapleafHash(leaf_version, leaf_script)` for each.
+
+| Situation | Result |
+|-----------|--------|
+| Two entries yield same `leaf_hash` with **different** `control_block` OR **different** `(leaf_script, leaf_version)` | **REJECT** at parse (`PSBT_P2MR_METADATA_MISMATCH`) |
+| Two entries yield same `leaf_hash` with **identical** `(control_block, leaf_script, leaf_version)` | **REJECT** at parse (duplicate key rule) |
+| One `leaf_hash`, one entry | OK |
+
+v1 partial signatures on an input MUST all reference this unique `leaf_hash` (§5.3.6).
+
+#### 4.2.4 Partial signature key encoding (MUST)
+
+**Wire (PSBT key for `PSBT_IN_P2MR_DILITHIUM_SCRIPT_SIG`):**
+
+```
+key = [type=0x1B] || dilithium_pubkey (1312 bytes) || leaf_hash (32 bytes)
+```
+
+Total key data length (excluding compact-size prefix): `1 + 1312 + 32 = 1345` bytes.
+
+**Internal map (`SignatureData::p2mr_dilithium_script_sigs`, `PSBTInput::m_p2mr_dilithium_script_sigs`):**
+
+```
+map_key = (DilithiumPKHash, leaf_hash)
+map_value = (CDilithiumPubKey, sig_with_hashtype)
+```
+
+**Conversion (MUST, both directions):**
+
+```
+// Deserialize wire → internal:
+pubkey = CDilithiumPubKey(key[1:1313])
+leaf_hash = key[1313:1345]
+keyid = DilithiumPKHash(pubkey.GetID())   // GetID() = Hash160(pubkey_bytes)
+map[keyid, leaf_hash] = (pubkey, value)
+
+// Serialize internal → wire:
+pubkey = map_value.first
+key = [0x1B] || pubkey (1312) || leaf_hash (32)
+value = sig_with_hashtype (2421 bytes)
+```
+
+Implementations MUST NOT use `DilithiumPKHash` on the wire; MUST NOT use full pubkey as internal map key.
+
+#### 4.2.5 Field rules (numbered)
+
+1. `PSBT_IN_P2MR_LEAF_SCRIPT` key is the witness **control block** bytes. Value is the revealed `(leaf_script, leaf_version)`. See §4.2.2–§4.2.3.
+2. `leaf_hash` in `PSBT_IN_P2MR_DILITHIUM_SCRIPT_SIG` MUST equal `ComputeTapleafHash(leaf_version, leaf_script)` for the leaf identified by a `PSBT_IN_P2MR_LEAF_SCRIPT` entry with matching spend path.
+3. Duplicate `(pubkey, leaf_hash)` keys with **different** sig bytes → parse failure (`PSBT_DILITHIUM_SIG_INVALID`).
+4. Duplicate `(pubkey, leaf_hash)` keys with **identical** sig bytes → parse failure at deserialize time. Exception: idempotent re-insert during **merge** only (§5.3.3).
+5. All partial sigs on one input MUST share one `leaf_hash` (§5.3.6).
+6. Dilithium2-only in v1: pubkey MUST be exactly 1312 bytes; partial sig value MUST be exactly 2421 bytes. Dilithium5 requires a future capability bit (§15 Q1).
+
+### 4.3 Output type bytes
+
+| Type | Name | Key | Value | v1 |
+|------|------|-----|-------|----|
+| `0x08` | `PSBT_OUT_P2MR_TREE` | *(empty)* | `tree_encoding` | Deferred (§16.3) |
+
+**`tree_encoding`:** Same structure as BIP371 `PSBT_OUT_TAP_TREE`: DFS tuples `(depth, leaf_version, script)`.
+
+**Parse-time validation (`PSBT_OUT_P2MR_TREE`):**
+
+1. Each script length ≤ `MAX_P2MR_LEAF_SCRIPT_SIZE`.
+2. Depths strictly increase per BIP371 DFS rules; reject malformed encodings.
+3. Recompute Merkle root from tuples via `ComputeTapleafHash` / `ComputeTapbranchHash`.
+4. If output `scriptPubKey` is P2MR (`OP_2 <32-byte root>`), recomputed root MUST equal embedded program. Mismatch → parse failure.
+
+P2MR has **no internal key**; validation is root equality only.
+
+### 4.4 Field presence rules
+
+For input `i` spending P2MR via script path:
+
+| Field | Signer | Finalizer |
+|-------|--------|-----------|
+| `witness_utxo` (preferred) or `non_witness_utxo` | Required | Required |
+| `PSBT_IN_P2MR_LEAF_SCRIPT` | Required | Required |
+| `PSBT_IN_P2MR_DILITHIUM_SCRIPT_SIG` | Optional | ≥ `m` valid partials (policy-dependent) |
+| `PSBT_IN_SIGHASH` | Optional | Optional |
+| `final_script_witness` | Must be absent | Required when complete |
+
+**Mixed transactions:** Non-P2MR inputs MUST NOT carry `0x19`–`0x1D` or `PSBT_IN_TAP_*` fields. P2MR inputs MUST NOT carry Taproot fields.
+
+### 4.5 Size limits (fail-closed)
+
+| Constant | Value | Meaning |
+|----------|-------|---------|
+| `MAX_DILITHIUM_PUBKEY_SIZE` | 1312 | Raw pubkey bytes |
+| `MAX_DILITHIUM_SIG_RAW_SIZE` | 2420 | Raw signature bytes (`sig_raw`) |
+| `MAX_DILITHIUM_PARTIAL_SIG_VALUE_SIZE` | 2421 | PSBT value: `sig_raw + sighash_type` |
+| `MAX_DILITHIUM_PARTIAL_SIGS_PER_INPUT` | 20 | Count of `PSBT_IN_P2MR_DILITHIUM_SCRIPT_SIG` entries |
+| `MAX_DILITHIUM_PARTIAL_SIG_PAYLOAD_PER_INPUT` | 1_500_000 bytes (~1.5 MB) | Sum of partial sig value sizes |
+| `MAX_P2MR_LEAF_SCRIPT_SIZE` | 10000 | Leaf script bytes |
+| `MAX_CONTROL_BLOCK_SIZE` | 513 | `P2MR_CONTROL_MAX_SIZE` |
+| `MAX_PSBT_SIZE` | 100 MB | Entire PSBT blob |
+
+Per-input partial-sig payload is the sum over all `PSBT_IN_P2MR_DILITHIUM_SCRIPT_SIG` value sizes on that input. Exceeding any limit → reject entire PSBT load.
+
+### 4.6 Sighash type matrix (v1)
+
+| `sighash_type` byte | v1 support | Notes |
+|---------------------|------------|-------|
+| `0x00` (`SIGHASH_DEFAULT`) | **Rejected** | Consensus rejects a zero-length-flag Dilithium signature under `SigVersion::P2MR_TAPSCRIPT`, so a `0x00` partial sig could never be spent. Rejecting it at parse keeps the failure loud and early rather than at broadcast. |
+| `0x01` (`SIGHASH_ALL`) | **Accepted** | The only supported type. Default for `.btqms` and v1 tooling. |
+| `0x02` (`SIGHASH_NONE`) | **Rejected** | At parse if present on partial sig or `PSBT_IN_SIGHASH` |
+| `0x03` (`SIGHASH_SINGLE`) | **Rejected** | |
+| `0x81`/`0x82`/`0x83` (ANYONECANPAY variants) | **Rejected** | |
+
+**Consistency rules:**
+
+1. If `PSBT_IN_SIGHASH` is set on an input carrying Dilithium P2MR fields, it MUST be `0x01`.
+2. Mixed-input txs MAY use any ECDSA sighash type on ECDSA inputs independently of the Dilithium inputs.
+3. v2 of this spec MAY extend the matrix; v1 implementations MUST fail-closed on unsupported types.
+
+### 4.7 Parse-time validation checklist
+
+After deserializing a PSBT, and again after every `Merge`, implementations MUST run `ValidatePSBTInput(i)` for each input with P2MR fields:
+
+```
+ValidatePSBTInput(i):
+  1. Resolve utxo = witness_utxo or non_witness_utxo prevout output
+  2. Assert utxo.scriptPubKey classifies as WITNESS_V2_P2MR; extract program (32-byte root)
+  3. For each PSBT_IN_P2MR_LEAF_SCRIPT (control_block → leaf_script, leaf_version):
+       a. control_block size ∈ [P2MR_CONTROL_BASE_SIZE, MAX_CONTROL_BLOCK_SIZE]
+       b. (control_block.size - P2MR_CONTROL_BASE_SIZE) % P2MR_CONTROL_NODE_SIZE == 0
+       c. (control_block[0] & 1) == 1   // parity bit MUST be set (BIP360)
+       d. leaf_script size ≤ MAX_P2MR_LEAF_SCRIPT_SIZE
+       e. leaf_hash = ComputeTapleafHash(leaf_version, leaf_script)
+       f. VerifyP2MRCommitment(control_block, program, leaf_hash) MUST be true
+  4. Apply leaf_hash tie-break rules (§4.2.3)
+  5. If PSBT_IN_P2MR_MERKLE_ROOT present: MUST equal program
+  6. For each PSBT_IN_P2MR_DILITHIUM_SCRIPT_SIG:
+       a. Pubkey MUST be fully valid Dilithium2 key (1312 bytes, not all-zero)
+       b. sig value length MUST be 2421; sig_raw = first 2420 bytes
+       c. sighash_type byte MUST be supported per §4.6
+       d. leaf_hash MUST match validated leaf from step 3
+       e. Pubkey MUST be authorized by parsed leaf policy (§5.5)
+       f. Cryptographic verify REQUIRED (§2.5.5, §5.4):
+            recompute sighash; reject if !pubkey.Verify(sighash, sig_raw)
+  7. If PSBT_IN_SIGHASH present: MUST be supported per §4.6
+  8. If both witness_utxo and non_witness_utxo: prevout MUST match unsigned tx input i
+  9. Single leaf_hash rule (§5.3.6)
+```
+
+Failure at any step → reject with error code from §14. **Cryptographic verification is mandatory at parse**; there is no optional-only-at-parse mode.
+
+### 4.8 Canonical encoding
+
+1. Producers SHOULD serialize fields in ascending type-byte order.
+2. Signatures stored as raw Dilithium bytes (not hex/DER).
+3. On finalize: set `final_script_witness`; clear partial Dilithium fields for that input.
+
+### 4.9 VerifyP2MRCommitment (normative)
+
+Proves that `(leaf_script, leaf_version)` commits to the P2MR `program` (32-byte witness program) via `control_block`.
+
+#### 4.9.1 Constants (MUST)
+
+```
+P2MR_CONTROL_BASE_SIZE       = 1
+P2MR_CONTROL_NODE_SIZE       = 32
+P2MR_CONTROL_MAX_NODE_COUNT  = 128
+P2MR_CONTROL_MAX_SIZE        = 1 + 32 * 128 = 4129   // consensus maximum
+MAX_CONTROL_BLOCK_SIZE       = 513                    // PSBT v1 parse cap (§4.5)
+TAPROOT_LEAF_MASK            = 0xFE
+TAPROOT_LEAF_TAPSCRIPT       = 0xC0
+```
+
+Control block layout:
+
+```
+control[0]           = leaf_version_with_parity   // (leaf_version & 0xFE) | 0x01
+control[1:33]          = merkle_path_node[0]        // only if path_len >= 1
+control[33:65]         = merkle_path_node[1]
+...
+control[1 + 32*i : 1 + 32*(i+1)] = merkle_path_node[i]
+```
+
+`path_len = (control.size() - P2MR_CONTROL_BASE_SIZE) / P2MR_CONTROL_NODE_SIZE`
+
+#### 4.9.2 Algorithm (MUST)
+
+```
+VerifyP2MRCommitment(control, program, tapleaf_hash):
+  REQUIRE control.size() >= P2MR_CONTROL_BASE_SIZE
+  REQUIRE program.size() >= 32
+  path_len = (control.size() - P2MR_CONTROL_BASE_SIZE) / P2MR_CONTROL_NODE_SIZE
+  k = tapleaf_hash
+  for i in 0 .. path_len-1:
+    node = control[P2MR_CONTROL_BASE_SIZE + P2MR_CONTROL_NODE_SIZE*i :
+                   P2MR_CONTROL_BASE_SIZE + P2MR_CONTROL_NODE_SIZE*(i+1)]
+    k = ComputeTapbranchHash(k, node)
+  return k == uint256(program[0:32])
+```
+
+**ComputeTapbranchHash:**
+
+```
+ComputeTapbranchHash(a, b) = TaggedHash("TapBranch", a || b)
+```
+
+where `a` and `b` are 32-byte branch values sorted lexicographically before hashing (BIP341).
+
+**Control block validation (before commitment check):**
+
+1. `control.size()` in `[1, P2MR_CONTROL_MAX_SIZE]` and `(control.size() - 1) % 32 == 0`.
+2. `(control[0] & 1) == 1` (parity bit set).
+3. `tapleaf_hash == ComputeTapleafHash(control[0] & TAPROOT_LEAF_MASK, leaf_script)`.
+
+---
+
+## 5. Semantic layer
+
+### 5.1 C++ data model and wire round-trip (MUST)
+
+#### 5.1.1 Internal structures
+
+```cpp
+struct PSBTInput {
+    // ... existing BIP174/371 fields ...
+
+    // BTQ-PSBT v1
+    // Wire key = control_block; value = leaf_script || leaf_version
+    // Internal: one (script, version) per control_block (v1)
+    std::map<std::vector<unsigned char>, std::pair<std::vector<unsigned char>, int>>
+        m_p2mr_leaf_scripts;   // control_block → (leaf_script, leaf_version)
+
+    uint256 m_p2mr_merkle_root;
+
+    // Wire key = full pubkey || leaf_hash; internal key uses DilithiumPKHash
+    std::map<std::pair<DilithiumPKHash, uint256>,
+             std::pair<CDilithiumPubKey, std::vector<unsigned char>>>
+        m_p2mr_dilithium_script_sigs;
+
+    std::map<CDilithiumPubKey, KeyOriginInfo> m_p2mr_dilithium_hd_keypaths;
+    std::map<CDilithiumPubKey, std::pair<std::set<uint256>, KeyOriginInfo>>
+        m_p2mr_dilithium_misc_pubkeys;
+};
+```
+
+**Note on Taproot analogy:** BIP371 `m_tap_scripts` maps `(script, version) → set<control_block>`. BTQ-PSBT v1 inverts the wire key/value relationship: **wire key = control_block**, **wire value = script + version**, with exactly one script per control block. Do not copy the Taproot internal map structure literally.
+
+#### 5.1.2 Serialize `PSBT_IN_P2MR_LEAF_SCRIPT`
+
+```
+for each (control_block, (script, leaf_ver)) in m_p2mr_leaf_scripts:
+  key = SerializeToVector(PSBT_IN_P2MR_LEAF_SCRIPT, control_block)
+  value = script_bytes || uint8(leaf_ver)
+  emit key, value
+```
+
+#### 5.1.3 Deserialize `PSBT_IN_P2MR_LEAF_SCRIPT`
+
+```
+on entry (type == 0x19):
+  if key already in key_lookup: REJECT ("duplicate key")
+  control_block = key[1:]   // strip type byte
+  read value_v from stream
+  if value_v.empty(): REJECT
+  leaf_ver = value_v.back()
+  script = value_v[0 : len(value_v)-1]
+  if control_block in m_p2mr_leaf_scripts: REJECT ("duplicate control_block")
+  m_p2mr_leaf_scripts[control_block] = (script, leaf_ver)
+  append post-parse tie-break check (§4.2.3)
+```
+
+#### 5.1.4 Serialize `PSBT_IN_P2MR_DILITHIUM_SCRIPT_SIG`
+
+```
+for each ((keyid, leaf_hash), (pubkey, sig_with_hashtype)) in m_p2mr_dilithium_script_sigs:
+  key = SerializeToVector(PSBT_IN_P2MR_DILITHIUM_SCRIPT_SIG, pubkey_bytes, leaf_hash)
+  value = sig_with_hashtype   // 2421 bytes
+  emit key, value
+```
+
+#### 5.1.5 Deserialize `PSBT_IN_P2MR_DILITHIUM_SCRIPT_SIG`
+
+```
+on entry (type == 0x1B):
+  if key already in key_lookup: REJECT
+  REQUIRE key.size() == 1 + 1312 + 32
+  pubkey = CDilithiumPubKey(key[1:1313])
+  leaf_hash = uint256(key[1313:1345])
+  read sig_with_hashtype from stream
+  REQUIRE sig_with_hashtype.size() == 2421
+  keyid = DilithiumPKHash(pubkey.GetID())
+  m_p2mr_dilithium_script_sigs[(keyid, leaf_hash)] = (pubkey, sig_with_hashtype)
+```
+
+#### 5.1.6 HD / misc pubkey mapping
+
+| PSBT field | C++ field | Round-trip |
+|------------|-----------|------------|
+| `PSBT_IN_P2MR_DILITHIUM_BIP32_DERIVATION` | `m_p2mr_dilithium_hd_keypaths` | Direct |
+| `PSBT_IN_P2MR_DILITHIUM_PUBKEY` | `m_p2mr_dilithium_misc_pubkeys[pk] = ({leaf_hashes}, origin)` | Value layout §4.2.1 |
+| Partial sigs | `m_p2mr_dilithium_script_sigs` | Key: `(DilithiumPKHash, leaf_hash)`; wire §4.2.4 |
+
+`FillSignatureData` copies HD paths into `dilithium_misc_pubkeys` with empty leaf sets; `FromSignatureData` splits by presence of derivation path.
+
+### 5.2 `FillSignatureData` / `FromSignatureData`
+
+**Fill (PSBT → SignatureData):**
+
+```
+m_p2mr_leaf_scripts               → sigdata.p2mr_spenddata.scripts
+                                    // invert to (script,version) → {control_block}
+m_p2mr_merkle_root                → sigdata.p2mr_spenddata.merkle_root
+m_p2mr_dilithium_script_sigs      → sigdata.p2mr_dilithium_script_sigs
+m_p2mr_dilithium_hd_keypaths      → sigdata.dilithium_misc_pubkeys (with origin)
+m_p2mr_dilithium_misc_pubkeys     → sigdata.dilithium_misc_pubkeys (merge leaf sets)
+```
+
+**From (SignatureData → PSBT):** Reverse when `!sigdata.complete`. When complete, write `final_script_witness` only.
+
+**Invariant:** `SD → PSBT → SD'` must be signing-equivalent for all Dilithium/P2MR fields.
+
+### 5.3 Merge semantics (normative)
+
+Applies to `PSBTInput::Merge`, `CombinePSBTs`, and `PartiallySignedTransaction::Merge`.
+
+#### 5.3.1 UTXO fields
+
+| Situation | Result |
+|-----------|--------|
+| `witness_utxo` null ← non-null | Take non-null |
+| Both non-null, same `nValue` and `scriptPubKey` | OK |
+| Both non-null, differ in value or script | **REJECT** (`PSBT_P2MR_METADATA_MISMATCH`) |
+| `non_witness_utxo` both present, different txid for same prevout | **REJECT** |
+
+#### 5.3.2 P2MR metadata
+
+| Field | Rule |
+|-------|------|
+| `PSBT_IN_P2MR_LEAF_SCRIPT` | Merge by `control_block` key. Same key + different `(script, version)` → **REJECT**. New keys → union. Re-run tie-break (§4.2.3). |
+| `PSBT_IN_P2MR_MERKLE_ROOT` | Both present and differ → **REJECT**. One present → take it. |
+| `PSBT_IN_SIGHASH` | Both present and differ (after DEFAULT norm) → **REJECT** |
+
+After merge, run `ValidatePSBTInput(i)` (§4.7).
+
+#### 5.3.3 Partial signatures
+
+| Situation | Result |
+|-----------|--------|
+| New `(pubkey, leaf_hash)` | Insert after cryptographic verify (§5.4) |
+| Same key, same sig bytes | Idempotent (keep existing). **Exception** to §4.2.5 rule 4 (parse-time duplicate rejection). |
+| Same key, different sig bytes | **REJECT** (`PSBT_DILITHIUM_SIG_INVALID`) |
+
+Imported partial sigs MUST pass `VerifyPartialSig` (§6.4) before merge accepts them.
+
+#### 5.3.4 HD keypaths and misc pubkeys
+
+| Field | Rule |
+|-------|--------|
+| `PSBT_IN_P2MR_DILITHIUM_BIP32_DERIVATION` | Merge by pubkey key. Same pubkey + different derivation path → **REJECT**. New pubkeys → union. |
+| `PSBT_IN_P2MR_DILITHIUM_PUBKEY` | Merge by pubkey key. Union `leaf_hash` sets. Conflicting `KeyOriginInfo` for same pubkey → **REJECT**. |
+
+Mirror BIP371 Taproot merge semantics (`m_tap_bip32_paths`, `m_tap_tree`-adjacent pubkey hints).
+
+#### 5.3.5 Proprietary vs typed
+
+If either side has typed Dilithium fields and the other has `"btq.org"` Dilithium proprietary fields on the same input → **REJECT**.
+
+#### 5.3.6 Single leaf hash per input (v1)
+
+All `PSBT_IN_P2MR_DILITHIUM_SCRIPT_SIG` entries on a given input **MUST** share the same `leaf_hash`. Finalization selects the unique `PSBT_IN_P2MR_LEAF_SCRIPT` entry whose `(leaf_script, leaf_version)` yields that hash. `ClassifyP2MRInput` evaluates policy for that leaf only.
+
+Multi-leaf choice (signer picks among several valid leaves on one input) is **out of scope for v1**.
+
+#### 5.3.7 `combinepsbt` vs `joinpsbts`
+
+| Operation | Semantics | Dilithium rule |
+|-----------|-----------|----------------|
+| **`combinepsbt`** | Same unsigned tx; merge inputs at same index from co-signers | Apply §5.3 per input index |
+| **`joinpsbts`** | Concatenate distinct inputs/outputs from different txs | Each appended input brings its own P2MR metadata; no index collision. Run §4.7 on full result. |
+
+**Test coverage (§10):** separate cases for combine (co-signers, same tx) and join (disjoint inputs).
+
+### 5.4 Valid partial signature (normative)
+
+A partial signature entry is **valid** iff ALL of the following hold:
+
+1. Pubkey is valid Dilithium2 (1312 bytes, passes `IsFullyValid()`).
+2. Value length is exactly 2421 bytes.
+3. Sighash type byte is supported per §4.6 (after DEFAULT→ALL normalization for checks).
+4. `leaf_hash` matches a validated `PSBT_IN_P2MR_LEAF_SCRIPT` entry.
+5. Pubkey is authorized by the leaf policy (`IsAuthorizedPartialSig`, §5.5).
+6. **Cryptographic verify:** `pubkey.Verify(sighash, sig_raw) == true` where `sighash` is computed per §2.5.
+
+**Usage:**
+
+| Context | Requirement |
+|---------|-------------|
+| PSBT deserialize / `ValidatePSBTInput` | MUST reject invalid partial sigs |
+| `Merge` / `combinepsbt` / external import | MUST reject invalid partial sigs |
+| `ClassifyP2MRInput` → `FINALIZABLE` | Count only **valid** partial sigs |
+| `walletprocesspsbt` sign path | MUST verify before inserting own sigs |
+
+Invalid partial sigs MUST NOT count toward threshold `m` and MUST NOT be silently dropped.
+
+### 5.5 Leaf script parser (normative)
+
+Implement `ParseP2MRDilithiumLeaf(const CScript& script)` returning:
+
+```cpp
+struct P2MRDilithiumLeafPolicy {
+    P2MRLeafTemplate type;
+    int m;                                    // threshold; 1 for single-key
+    int n;                                    // total keys
+    std::vector<CDilithiumPubKey> pubkeys;    // script order (k=0..n-1)
+};
+```
+
+#### Template A — Single key
+
+```
+<pk (1312 bytes)> OP_CHECKSIGDILITHIUM
+```
+
+→ `type=SINGLE`, `m=1`, `n=1`, `pubkeys=[pk]`.
+
+#### Template B — `OP_CHECKMULTISIGDILITHIUM`
+
+```
+<m> <pk1> … <pkn> <n> OP_CHECKMULTISIGDILITHIUM
+```
+
+→ `type=CHECKMULTISIGDILITHIUM`, `m`, `n`, pubkeys in listed order.
+
+#### Template C — Threshold accumulator (production multisig)
+
+```
+OP_0
+(OP_TOALTSTACK <pk> OP_CHECKSIGDILITHIUM OP_FROMALTSTACK OP_ADD) × n
+<m> OP_GREATERTHANOREQUAL
+```
+
+Parsing algorithm:
+
+1. Consume leading `OP_0`.
+2. Repeat `n` times: `OP_TOALTSTACK`, push exactly 1312 bytes, `OP_CHECKSIGDILITHIUM`, `OP_FROMALTSTACK`, `OP_ADD`.
+3. Consume threshold push `m`, then `OP_GREATERTHANOREQUAL`; no trailing ops.
+4. → `type=THRESHOLD_ACCUMULATOR`, pubkeys in loop order.
+
+**Threshold `m` push encoding (MUST):** When **generating** Template C scripts, push `m` using CScript minimal push semantics (`CScript::push_int64`):
+
+| `m` value | Script bytes |
+|-----------|--------------|
+| `0` | `OP_0` |
+| `1`–`16` | `OP_1` … `OP_16` (i.e. opcode `OP_1 + (m-1)`) |
+| other | minimal signed-magnitude push (`CScriptNum::serialize`) |
+
+When **parsing**, accept any valid script push encoding of `m` (minimal or non-minimal); decode with standard `CScriptNum` rules.
+
+Any other pattern → `UNKNOWN`.
+
+#### Authorization check
+
+`IsAuthorizedPartialSig(policy, pubkey)`:
+
+- SINGLE / CHECKMULTISIG / ACCUMULATOR: pubkey must appear in `policy.pubkeys`.
+- UNKNOWN: reject partial sig (fail-closed).
+
+### 5.6 Input completion classification
+
+```cpp
+// script/dilithium_leaf.h
+enum class P2MRLeafTemplate {
+    SINGLE_CHECKSIGDILITHIUM,
+    CHECKMULTISIGDILITHIUM,
+    THRESHOLD_ACCUMULATOR,  // production btq-multisig
+    UNKNOWN,
+};
+
+// psbt_dilithium.h
+enum class P2MRInputStatus {
+    NOT_P2MR,            // input has no P2MR fields and does not spend a P2MR output
+    FINALIZED,           // final_script_witness set
+    UNKNOWN_LEAF,        // P2MR input whose spend path cannot be pinned down
+    UNSIGNED,
+    PARTIALLY_SIGNED,
+    FINALIZABLE,         // enough valid partials, not yet finalized
+};
+
+// Also reports the leaf being spent, its policy, and the signature counts.
+P2MRInputInfo InspectP2MRInput(const PartiallySignedTransaction& psbt, unsigned int index);
+```
+
+`NOT_P2MR` and `UNKNOWN_LEAF` are additions to the draft classification. `UNKNOWN_LEAF`
+covers the two cases where the spend path is ambiguous — several advertised leaves with no
+partial signature to pin one down, or partial signatures pointing at more than one leaf —
+and is deliberately distinct from `UNSIGNED` so `decodepsbt` can say which it is.
+
+**`FINALIZABLE` thresholds:** Count only **valid** partial sigs (§5.4).
+
+| Template | Required valid partial sigs |
+|----------|----------------------------|
+| `SINGLE_CHECKSIGDILITHIUM` | 1 (authorized pubkey) |
+| `CHECKMULTISIGDILITHIUM` | `m` from script |
+| `THRESHOLD_ACCUMULATOR` | `m` from script (≥ `m` distinct authorized keys) |
+| `UNKNOWN` | Only `FINALIZED` if `final_script_witness` present |
+
+---
+
+## 6. Signing, verification, and finalization
+
+### 6.1 Workflow roles
+
+Unchanged from BIP174: Creator → Updater → Signer(s) → Finalizer → Extractor.
+
+### 6.2 Creator
+
+MUST include `witness_utxo`, `PSBT_IN_P2MR_LEAF_SCRIPT`, and SHOULD include `PSBT_IN_P2MR_DILITHIUM_PUBKEY` for cosigners. SHOULD set `PSBT_IN_SIGHASH=1` (avoid `0x00` in finalized witnesses; §2.5.5).
+
+### 6.3 Updater
+
+When P2MR input lacks leaf fields, fill from wallet `GetP2MRSpendData`. Never guess leaf content.
+
+### 6.4 Signer algorithm
+
+For P2MR input `i`:
+
+```
+1. ValidatePSBTInput(i) — fail-closed (includes crypto verify of existing partials)
+2. Parse leaf policy from PSBT_IN_P2MR_LEAF_SCRIPT
+3. leaf_hash = ComputeTapleafHash(leaf_version, leaf_script)
+4. Build PrecomputedTransactionData per §2.5.2 (all input amounts required)
+5. Setup ScriptExecutionData per §2.5.3
+6. sighash = SignatureHashSchnorr(..., SigVersion::P2MR_TAPSCRIPT, §2.5.4)
+7. For each wallet key K authorized by policy:
+     sig_raw = Sign(K, sighash)   // 2420 bytes
+     assert K.Verify(sighash, sig_raw)
+     sighash_byte = PSBT_IN_SIGHASH or 0x01 (prefer 0x01 over 0x00)
+     sig_with_hashtype = sig_raw || sighash_byte
+     insert PSBT_IN_P2MR_DILITHIUM_SCRIPT_SIG (wire key uses full pubkey)
+8. Do not set final_script_witness unless explicitly finalizing AND FINALIZABLE
+```
+
+**Import verification (mandatory on merge/combine/external sign AND at parse):**
+
+```
+VerifyPartialSig(input, i, pubkey, leaf_hash, sig_with_hashtype):
+  sig_raw = sig_with_hashtype[0:2420]
+  hashtype = sig_with_hashtype[2420]
+  reject if hashtype unsupported (§4.6)
+  reject if hashtype conflicts with PSBT_IN_SIGHASH (after DEFAULT norm)
+  recompute sighash per §2.5 (PrecomputedTransactionData + ScriptExecutionData)
+  reject if !pubkey.Verify(sighash, sig_raw)
+  reject if !IsAuthorizedPartialSig(policy, pubkey)
+```
+
+### 6.5 Finalizer (normative witness construction)
+
+Miniscript does not model BTQ's Dilithium opcodes, so `ProduceSignature` alone cannot
+finalize any of these leaves. Rather than add a second, parallel finalizer, the
+implementation teaches the existing signing path about Dilithium leaves and lets
+`FinalizePSBT` reach them through the ordinary `SignPSBTInput` → `ProduceSignature` →
+`SignP2MR` → `SignTaprootScript` chain:
+
+- `SignTaprootScript` falls back, under `SigVersion::P2MR_TAPSCRIPT` only, to the Solver
+  for the single-key and `OP_CHECKMULTISIGDILITHIUM` templates, and to
+  `SignDilithiumAccumulatorLeaf` for the accumulator template that Solver cannot classify.
+- Signing and finalizing are then the same operation with a different set of available
+  keys: a signer with one key produces one partial and the step reports incomplete; a
+  finalizer with no keys at all reuses the partials the PSBT already carries and the step
+  reports complete. `ProduceSignature` verifies the assembled witness against the
+  transaction before declaring success, so a finalized input is always spendable.
+
+The resulting witness stacks are exactly as specified below.
+
+```
+FinalizeP2MRInput(input, tx, index, utxo):
+  if final_script_witness already set: return OK
+  policy = ParseP2MRDilithiumLeaf(leaf_script)
+  leaf_hash = ComputeTapleafHash(...)
+  collect VALID partial sigs for leaf_hash into map key_index → sig_with_hashtype
+
+  switch (policy.type):
+
+    SINGLE_CHECKSIGDILITHIUM:
+      sig = partial for policy.pubkeys[0]
+      witness.stack = [ sig_with_hashtype, leaf_script, control_block ]
+
+    CHECKMULTISIGDILITHIUM:
+      witness.stack = build per §6.5.1
+
+    THRESHOLD_ACCUMULATOR:
+      slots[k] = valid partial for pubkey[k] or empty vector
+      witness.stack = [ slots[n-1], ..., slots[0], leaf_script, control_block ]
+
+    UNKNOWN:
+      return INVALID_PSBT
+
+  Normalize sighash bytes in stack sigs: 0x00 → 0x01
+  VerifyScript(..., STANDARD_SCRIPT_VERIFY_FLAGS) MUST succeed
+  set final_script_witness; clear partial Dilithium fields
+```
+
+#### 6.5.1 CHECKMULTISIGDILITHIUM witness stack (normative)
+
+Matches `SignStep` / `TxoutType::DILITHIUM_MULTISIG` in `sign.cpp`:
+
+Script template: `<m> <pk1> … <pkn> <n> OP_CHECKMULTISIGDILITHIUM`
+
+**Stack layout (bottom → top, before `leaf_script` and `control_block`):**
+
+```
+stack[0] = empty vector (0 bytes)           // CHECKMULTISIG dummy element (off-by-one)
+stack[1] = sig_with_hashtype for pk1        // vSolutions[1]
+stack[2] = sig_with_hashtype for pk2        // vSolutions[2]
+...
+stack[n] = sig_with_hashtype for pkn        // vSolutions[n]
+stack[n+1] = leaf_script bytes
+stack[n+2] = control_block bytes
+```
+
+**Signature ordering:** Signatures appear in **pubkey script order** (`pk1`, `pk2`, …, `pkn`), **not** reverse order. This differs from the accumulator template (§2.2).
+
+**Partial sig mapping:** For each `k` in `1..n`, if a valid partial sig exists for `policy.pubkeys[k-1]`, include its `sig_with_hashtype`; otherwise signing fails (CHECKMULTISIG requires `m` valid sigs on finalize, not empty slots).
+
+**Empty dummy:** `stack[0]` MUST be an empty byte vector (not `OP_0` as a one-byte push in the witness — the witness element itself is zero-length).
+
+This matches `btq-multisig/src/finalize.cpp` for `THRESHOLD_ACCUMULATOR`. CHECKMULTISIGDILITHIUM follows `sign.cpp` as above.
+
+### 6.6 Extraction
+
+`finalizepsbt` → `extractpsbt`. Extracted tx MUST pass `testmempoolaccept`.
+
+---
+
+## 7. Wallet, descriptor, and RPC integration
+
+### 7.1 RPC changes
+
+| RPC | Change |
+|-----|--------|
+| `decodepsbt` | Adds `p2mr_scripts` (with the recognised leaf policy), `p2mr_merkle_root`, `p2mr_dilithium_script_path_sigs`, and a `p2mr_dilithium` progress object from `InspectP2MRInput` |
+| `walletcreatefundedpsbt` | Attaches P2MR leaf, control block and merkle root for wallet inputs |
+| `walletprocesspsbt` | Dilithium signing; contributes every key it holds in one pass |
+| `finalizepsbt` | §6.5 finalizer |
+| `combinepsbt` / `joinpsbts` / `utxoupdatepsbt` | Work unchanged: validation happens on decode, so every PSBT these RPCs read has already been checked |
+
+Every RPC that reads a PSBT gets validation for free because `DecodeRawPSBT` and
+`DecodeBase64PSBT` run §4.7 before returning. There is no way to hand an unvalidated
+Dilithium PSBT to any caller.
+
+**New wallet RPCs:**
+
+| RPC | Purpose |
+|-----|---------|
+| `createdilithiummultisig <nrequired> <pubkeys> [label]` | Register an m-of-n threshold accumulator P2MR destination. Co-signers passing the same arguments derive the same address. |
+| `getdilithiumpubkey <p2mr_id>` | Report the Dilithium pubkeys a wallet destination names, and which of them the wallet can sign for. This is how a co-signer publishes its key. |
+
+**Deferred:** `btqconvertpsbt <btqms-file>` (§16.3).
+
+### 7.2 Descriptor alignment
+
+Illustrative:
+
+```
+p2mr({{leaf_v:0xc0,script:dilithium_threshold(2,pk1,pk2,pk3)}})
+```
+
+Descriptors carry policy; PSBT carries spend path.
+
+---
+
+## 8. Migration from `.btqms`
+
+### 8.1 Field mapping
+
+| `.btqms` | BTQ-PSBT |
+|----------|----------|
+| `unsigned_tx` | `PSBT_GLOBAL_UNSIGNED_TX` |
+| `multisig.leaf_script`, `leaf_version`, `control_block` | Per-input `PSBT_IN_P2MR_LEAF_SCRIPT` |
+| `multisig.merkle_root` | Per-input `PSBT_IN_P2MR_MERKLE_ROOT` |
+| `inputs[i].partial_sigs` | Per-input `PSBT_IN_P2MR_DILITHIUM_SCRIPT_SIG` |
+| `inputs[i].amount` | `witness_utxo.nValue` |
+| `multisig.pubkeys` | `PSBT_IN_P2MR_DILITHIUM_PUBKEY` |
+
+### 8.2 Multi-input conversion rules
+
+```
+convert_btqms_to_psbt(btqms):
+  1. Decode unsigned_tx
+  2. For each input index i:
+       a. If prevout script is NOT P2MR → copy input fields only (no P2MR metadata)
+       b. If P2MR:
+            - If global multisig.script_pubkey matches prevout → attach leaf/control_block/metadata to input i
+            - Else if wallet knows different P2MRSpendData for prevout → use wallet data
+            - Else → FAIL (cannot infer policy)
+  3. If multiple P2MR inputs require DIFFERENT multisig contexts → FAIL with
+     "btqms global multisig incompatible with multi-policy transaction"
+  4. Convert partial_sigs using leaf_hash from attached leaf
+  5. Run ValidatePSBT on result
+```
+
+**Lossless case:** All P2MR inputs spend the same `MultisigContext` (typical `.btqms` use). **General case:** Requires per-input descriptors in PSBT from the start (no global multisig blob).
+
+### 8.3 Deprecation
+
+1. Ship BTQ-PSBT; `btq-multisig --format psbt` default.
+2. Warn on `.btqms` write.
+3. `.btqms` read-only import via converter.
+
+---
+
+## 9. Security analysis
+
+| Threat | Mitigation |
+|--------|------------|
+| DoS (oversized fields) | §4.5 per-field and per-input caps |
+| Wrong sighash | §2.5 normative sighash + §4.6 matrix + mandatory import verify |
+| Unauthorized partial sig | §5.5 parser + authorization |
+| Leaf / root substitution | §4.9 `VerifyP2MRCommitment` at parse/merge |
+| Fee attack | Signers inspect fee before signing (UI warning) |
+| Algorithm confusion | Separate type bytes; strict pubkey/sig lengths |
+| Dual proprietary/typed encoding | §3 rejection rule |
+| Forged partial sigs | §5.4 cryptographic verify at parse/merge |
+
+**No hardfork.** PSBT never enters consensus.
+
+---
+
+## 10. Test strategy
+
+### 10.1 Unit tests
+
+`src/test/psbt_dilithium_tests.cpp`:
+
+| Test | Covers |
+|------|--------|
+| `threshold_leaf_roundtrips_through_the_parser` | §2.2 builder ↔ §5.5 parser, key ordering |
+| `single_key_leaf_is_recognised` | §5.5 single-key template |
+| `unknown_leaves_are_not_misparsed` | §5.5 `UNKNOWN`; a truncated accumulator is not accepted |
+| `threshold_witness_puts_the_first_key_on_top` | §6.5 accumulator stack order and empty slots; below-threshold refusal |
+| `single_key_psbt_survives_serialization` | §4/§5.2 round-trip; a key-less provider finalizes what the PSBT carries |
+| `threshold_psbt_accumulates_signatures_across_providers` | §5.3 merge of two independently produced partials, then `VerifyScript` |
+| `finalized_input_drops_the_bulky_signing_material` | §6.5 field clearing on finalize |
+| `a_forged_signature_is_rejected_on_decode` | §5.4 cryptographic verify at parse |
+| `a_leaf_not_committed_to_by_the_output_is_rejected` | §4.9 commitment check |
+| `a_merkle_root_disagreeing_with_the_output_is_rejected` | §4.7 step 5 |
+| `duplicate_wire_keys_are_rejected` | §4.2 duplicate-key rule |
+
+### 10.2 Functional tests
+
+`test/functional/wallet_dilithium_psbt_multisig.py` — three separate wallets, each holding
+one key, communicating only in base64 PSBTs:
+
+1. All three derive the same 2-of-3 address from the same arguments.
+2. An unsigned PSBT already advertises the leaf, its policy and the merkle root.
+3. Alice signs; the serialized PSBT carries exactly one 2421-byte signature.
+4. Carol signs the same unsigned PSBT independently; `combinepsbt` merges the two.
+5. `finalizepsbt` → `testmempoolaccept` → broadcast → mined.
+6. Sequential signing (alice, then bob on alice's output) also completes.
+7. Re-signing with a key that already signed does not inflate the count, and a PSBT one
+   signature short does not finalize.
+8. A PSBT with one byte flipped inside a signature is rejected by both `decodepsbt` and
+   `finalizepsbt`.
+
+`test/functional/wallet_dilithium_psbt.py` (pre-existing) covers the single-key and
+mixed ECDSA + Dilithium cases within one wallet.
+
+**Not yet covered:** `joinpsbts` with a Dilithium input in each transaction, and the
+`.btqms` migration equivalence check (§16.3).
+
+### 10.3 Fuzz
+
+`fuzz/psbt_dilithium` with structured seeds from valid templates. Not yet written; the
+existing `psbt` fuzz target does exercise the new parse paths through
+`PartiallySignedTransaction::Unserialize`.
+
+---
+
+## 11. Transport guidance
+
+| Method | Multisig PSBT | Single-key PSBT |
+|--------|---------------|-----------------|
+| File (binary/base64) | **Required** | Recommended |
+| QR / fragmented QR | **Forbidden** (a 2-of-3 is ~16 KB base64; see Appendix A) | Impractical |
+| Clipboard | Discouraged (size) | OK with care |
+
+Co-signers MUST verify `decodepsbt` output (fee, outputs, addresses) before signing.
+
+---
+
+## 12. Fee bumping / RBF (v1 scope)
+
+**Supported:** `bumpfee` / `psbtbumpfee` creates a **new** PSBT with replaced inputs/outputs. All prior Dilithium partial signatures are **invalid** (sighash changes). Signers MUST re-sign from scratch.
+
+**Not supported in v1:** Preserving partial sigs across fee bumps (impossible without identical sighash). Document explicitly in RPC help text.
+
+Wallet weight estimation for P2MR inputs already accounts for Dilithium witness size in `feebumper.cpp`; PSBT creation MUST use the same estimator.
+
+---
+
+## 13. Implementation plan
+
+| Phase | Deliverables | Status |
+|-------|--------------|--------|
+| 0 — Spec freeze | Frozen type bytes `0x19`/`0x1A`/`0x1B` | Done |
+| 1 — Serialization | §4 fields; §5.2 round-trip; parse validation | Done |
+| 2 — Parser + finalizer | §5.5 parser; §6.5 finalizer; import verify | Done |
+| 3 — Wallet RPC | §7 RPC surface; unit + functional tests; live-chain proof | Done |
+| 4 — btq-multisig + migration | `--format psbt`; `btqconvertpsbt` | Deferred (§16.3) |
+| 5 — HWI prep | Protocol draft | Backlog |
+
+See §16 for the spec-to-code map.
+
+---
+
+## 14. Error taxonomy
+
+Extend `TransactionError` (or map to `INVALID_PSBT` sub-messages):
+
+| Code | When |
+|------|------|
+| `INVALID_PSBT` | Generic parse failure; malformed key/value; oversize fields |
+| `PSBT_MISMATCH` | Unsigned tx mismatch on combine |
+| `PSBT_P2MR_METADATA_MISMATCH` | UTXO/leaf/root conflict on merge; leaf_hash tie-break violation (§4.2.3); merkle root mismatch; control block / program mismatch |
+| `PSBT_DILITHIUM_SIG_INVALID` | Failed cryptographic verify; duplicate conflicting sig; wrong sig length |
+| `PSBT_DILITHIUM_SIG_UNAUTHORIZED` | Pubkey not in leaf policy |
+| `PSBT_DILITHIUM_SIGHASH_UNSUPPORTED` | §4.6 violation |
+| `SIGHASH_MISMATCH` | Per-input sighash conflict between partial sigs or vs `PSBT_IN_SIGHASH` |
+
+### 14.1 ValidatePSBTInput step → error code mapping
+
+| ValidatePSBTInput step (§4.7) | Error code |
+|--------------------------------|------------|
+| Step 1–2: missing/bad UTXO; not P2MR | `INVALID_PSBT` |
+| Step 3a–3b: control block size invalid | `INVALID_PSBT` |
+| Step 3c: parity bit not set | `PSBT_P2MR_METADATA_MISMATCH` |
+| Step 3d: leaf script oversize | `INVALID_PSBT` |
+| Step 3f: `VerifyP2MRCommitment` false | `PSBT_P2MR_METADATA_MISMATCH` |
+| Step 4: leaf_hash tie-break | `PSBT_P2MR_METADATA_MISMATCH` |
+| Step 5: merkle root mismatch | `PSBT_P2MR_METADATA_MISMATCH` |
+| Step 6a: invalid pubkey | `INVALID_PSBT` |
+| Step 6b: bad sig length | `PSBT_DILITHIUM_SIG_INVALID` |
+| Step 6c: unsupported sighash | `PSBT_DILITHIUM_SIGHASH_UNSUPPORTED` |
+| Step 6d: leaf_hash not found | `PSBT_P2MR_METADATA_MISMATCH` |
+| Step 6e: unauthorized pubkey | `PSBT_DILITHIUM_SIG_UNAUTHORIZED` |
+| Step 6f: crypto verify fails | `PSBT_DILITHIUM_SIG_INVALID` |
+| Step 7: bad `PSBT_IN_SIGHASH` | `PSBT_DILITHIUM_SIGHASH_UNSUPPORTED` |
+| Step 8: witness/non-witness prevout mismatch | `PSBT_MISMATCH` |
+| Step 9: multiple leaf_hashes on input | `PSBT_P2MR_METADATA_MISMATCH` |
+| Duplicate key at deserialize | `INVALID_PSBT` |
+
+RPC layer maps to `RPC_DESERIALIZATION_ERROR` (parse) or `RPC_INVALID_PARAMETER` (merge/policy) with full diagnostic string. Wallets MUST NOT mutate PSBT state on error.
+
+---
+
+## 15. Resolved open questions
+
+| ID | Decision |
+|----|----------|
+| Q1 Dilithium5 | v2; v1 rejects non-1312/2420/2421 sizes |
+| Q2 non_witness_utxo | Allowed; witness_utxo preferred |
+| Q3 PSBT v2 | Support v0 and v2 |
+| Q4 BIP registration | `doc-btq/bips/bip-btq-psbt.mediawiki` before public release |
+| Q5 Single-key tuple | Always `(pubkey, leaf_hash)` for uniformity; wire uses full pubkey, internal uses `DilithiumPKHash` |
+| Q6 Accumulator vs CHECKMULTISIG | Spec normative for **accumulator**; CHECKMULTISIG supported but not used by `btq-multisig` |
+| Q7 Proprietary + typed | MUST NOT co-exist on same input; proprietary OUT OF v1 production (§3) |
+| Q8 Crypto verify at parse | **Required** (§4.7, §5.4); no optional-only mode |
+
+---
+
+## 16. Implementation status
+
+### 16.1 Spec-to-code map
+
+| Spec section | Code |
+|--------------|------|
+| §4.2 type bytes, wire encoding, size limits | `src/psbt.h` — `PSBT_IN_P2MR_LEAF_SCRIPT`, `PSBT_IN_P2MR_MERKLE_ROOT`, `PSBT_IN_P2MR_DILITHIUM_SCRIPT_SIG`; `PSBTInput::Serialize` / `Unserialize` |
+| §4.7 parse-time validation | `src/psbt_dilithium.cpp` — `ValidateP2MRDilithiumInput`, called from `DecodeRawPSBT` |
+| §4.9 P2MR commitment check | `ComputeP2MRMerkleRoot`, exported from `src/script/interpreter.cpp` (previously private to `VerifyP2MRCommitment`) |
+| §5.2 `FillSignatureData` / `FromSignatureData` | `src/psbt.cpp` |
+| §5.3 merge | `PSBTInput::Merge` in `src/psbt.cpp` |
+| §5.5 leaf parser, §2.2 accumulator builder | `src/script/dilithium_leaf.{h,cpp}` — `ParseP2MRDilithiumLeaf`, `GetScriptForDilithiumThreshold`, `BuildDilithiumLeafWitness` |
+| §5.6 classification | `InspectP2MRInput` in `src/psbt_dilithium.cpp` |
+| §6.4 signer, §6.5 finalizer | `SignDilithiumAccumulatorLeaf` and the `SigVersion::P2MR_TAPSCRIPT` fallback in `SignTaprootScript`, `src/script/sign.cpp` |
+| §7.1 RPC | `src/rpc/rawtransaction.cpp` (`decodepsbt`), `src/wallet/rpc/dilithium.cpp` (`createdilithiummultisig`, `getdilithiumpubkey`) |
+| Wallet key discovery for accumulator leaves | `GetP2MRDilithiumKeyIDs` in `src/wallet/p2mr.cpp` |
+| §10.1 unit tests | `src/test/psbt_dilithium_tests.cpp` |
+| §10.2 functional tests | `test/functional/wallet_dilithium_psbt_multisig.py` |
+| Live-chain proof | `contrib/btq/testnet_dilithium_psbt_proof.sh` |
+
+### 16.2 Deviations from the draft
+
+| Draft | Implemented | Why |
+|-------|-------------|-----|
+| §4.6 accepts `SIGHASH_DEFAULT` (`0x00`), normalized to `0x01` | Only `SIGHASH_ALL` (`0x01`) accepted | Consensus rejects a zero-length sighash flag for Dilithium under `SigVersion::P2MR_TAPSCRIPT`, so a `0x00` partial could never be spent. Accepting then silently rewriting it would hide the mistake until broadcast. |
+| §6.5 a dedicated `FinalizeP2MRInput` separate from `ProduceSignature` | The existing `ProduceSignature` chain is taught about Dilithium leaves | One code path means signing and finalizing cannot disagree, and `ProduceSignature` already verifies the assembled witness against the transaction before reporting success. |
+| §5.6 `PSBTInputStatus` with 4 values | `P2MRInputStatus` with 6, adding `NOT_P2MR` and `UNKNOWN_LEAF` | An ambiguous spend path is a distinct, reportable state rather than something to conflate with `UNSIGNED`. |
+| §4.5 separate `MAX_DILITHIUM_PARTIAL_SIG_PAYLOAD_PER_INPUT` of 1.5 MB | Implied by the per-input count limit | 20 signatures × 2421 bytes caps the payload at ≈ 48 KB, well under the draft's figure, so a second check would be dead code. |
+
+### 16.3 Deferred
+
+None of these block the creator → signer → finalizer workflow:
+
+- `PSBT_IN_P2MR_DILITHIUM_BIP32_DERIVATION` (`0x1C`) and `PSBT_IN_P2MR_DILITHIUM_PUBKEY`
+  (`0x1D`). Derivation hints only. The type bytes stay reserved.
+- `PSBT_OUT_P2MR_TREE` (`0x08`). Needed to *receive* into a P2MR tree described by the
+  PSBT rather than by wallet metadata.
+- `btqconvertpsbt` and `btq-multisig --format psbt` (§8 migration). `.btqms` files still
+  need to be converted by hand.
+- HWI / hardware transport (§13 phase 5).
+
+### 16.4 Live-chain proof
+
+Recorded in §17.
+
+---
+
+## 17. Live-chain proof (public testnet)
+
+Run with `contrib/btq/testnet_dilithium_psbt_proof.sh` against a node on the public BTQ
+testnet (the v0.4.x parameter set, genesis `000000ffba1eed…`), starting at height 215447.
+Coins came from CPU-mining 60 blocks to a fourth, unrelated funding wallet and waiting out
+coinbase maturity.
+
+### 17.1 The 2-of-3
+
+Three wallets in the same node, each holding exactly one 1312-byte Dilithium key and
+never seeing the others' private material. Given the same three pubkeys and threshold,
+each derived the same address independently:
+
+```
+address:      tbtq1zv5frdx000hfzyljdrcdwltj2z3gy36jqucf8y53pju0g5vsn76esg6s0s2
+scriptPubKey: 5220 65123699ef7dd2227e4d1e1aefae4a145048ea40e612725221971e8a3213f6b3
+leaf script:  3960 bytes
+```
+
+Each reported `signers_available: 1`, i.e. no wallet could reach the threshold alone.
+
+### 17.2 The spend
+
+| Step | Result |
+|------|--------|
+| Funding | `a0a8ec548a9d370ce5a7b3397ce3fb673ae975b60e611306e2a0bffe6e5e94f1` vout 0, 0.001 BTQ |
+| Unsigned PSBT (`decodepsbt`) | `dilithium_threshold` 2-of-3, merkle root matches the output, status `unsigned` |
+| Alice signs | status `partially_signed`, 1 of 2 signatures |
+| Base64 PSBT handed to bob | bob signs it → `complete: true`, status `finalized` |
+| `finalizepsbt` | `complete: true` |
+| `testmempoolaccept` | `allowed: true`, `reject-reason: null` |
+| Broadcast | txid `6fc71b6259d6f79a041e592e848e2e125940e55ad9e642e1fcdba80a2e1e0bc9` |
+| Confirmed | block `0000000c9999f0c670794c843ae2716cb4a71304046c4ba9e8ee4aed23f9821e`, height 215455 |
+
+Witness stack on the confirmed input, byte lengths in push order:
+
+```
+[0, 2421, 2421, 3960, 1]
+ │   │     │     │     └─ control block (leaf version only; single-leaf tree)
+ │   │     │     └─────── leaf script
+ │   │     └───────────── alice's signature (key 0)
+ │   └─────────────────── bob's signature  (key 1)
+ └─────────────────────── empty slot for carol (key 2, did not sign)
+```
+
+This matches Appendix A: slots are pushed in reverse key order, so key 0 ends up on top,
+and a non-signing key contributes an empty push rather than being omitted.
+
+### 17.3 Second spend, via `combinepsbt`
+
+The first spend went alice → bob sequentially. A second UTXO on the same address was spent
+by the other route: alice and carol each signed the *same* unsigned PSBT without seeing
+each other's work, and `combinepsbt` merged the two independent partials.
+
+| Step | Result |
+|------|--------|
+| Alice's PSBT | `partially_signed`, 1 of 2 |
+| Carol's PSBT (independent) | `partially_signed`, 1 of 2 |
+| `combinepsbt` of the two | `finalizable`, 2 of 2 |
+| Confirmed | txid `8d31a6cf96ed98967f38debccfe04bc11c5b75e1f0e4ec66b975c37175632ff5`, block `0000000ee33d81c83360dd0fc44dd727f13e72d274790474fb26a54e23209b70`, height 215469 |
+
+Witness lengths `[2421, 0, 2421, 3960, 1]` — carol (key 2) at the bottom, the empty slot in
+the middle for bob, alice (key 0) on top. The empty slot moved to match which key signed.
+
+### 17.4 Negative cases
+
+Run against alice's real partially signed PSBT for the second UTXO, before it was spent:
+
+| Attempt | Result |
+|---------|--------|
+| `finalizepsbt` one signature short | `complete: false`, no `hex` returned |
+| One byte flipped inside the signature, then `decodepsbt` | `-22 … Input 0: Dilithium partial signature does not verify` |
+| Same tampered PSBT, `finalizepsbt` | same error — rejected at parse, before any signing logic runs |
+
+The forgery is caught when the PSBT is read, not when the transaction is broadcast, so a
+co-signer never spends time reviewing or signing a PSBT carrying a bad signature.
+
+### 17.5 Accepted by the rest of the network
+
+Both spends were mined into blocks this node produced, so on its own that only shows the
+node accepted its own work. What settles it is what happened next: a different miner
+(coinbase `tbtq1zlvr4nym…qse07ya`) built 215470, 215471 and 215473–215475 on top, and three
+`/BTQ:0.4.2/` peers report `synced_blocks: 215475` — the same tip.
+
+```
+215469  ours    <- second spend (combinepsbt)
+215470  other miner
+215471  other miner
+215472  ours
+215473  other miner
+215474  other miner
+215475  other miner  <- tip, matched by 3 peers
+```
+
+The first spend sits at height 215455, 21 blocks deep. Independent nodes validated both
+transactions and extended the chain containing them; had either witness been invalid, they
+would have rejected the block instead.
+
+### 17.6 What this establishes
+
+The two signatures on each spend were produced in different wallets that shared nothing but
+a base64 string. Before this change that string carried no leaf script, no control block and
+no Dilithium signature, so the second wallet had nothing to sign against and the finalizer
+had nothing to assemble.
+
+No consensus code was touched. The same `VerifyP2MRCommitment` and `CHECKSIGDILITHIUM`
+that already governed P2MR spends accepted these witnesses, on the public chain, as judged
+by nodes that were not running this branch. The change is confined to how signing material
+travels between wallets before broadcast.
+
+**Reproducing:** `contrib/btq/testnet_dilithium_psbt_proof.sh <btq-cli invocation…>`. It
+needs a synced testnet node and a `psbtproof_funder` wallet with spendable coins; the
+funder here was filled by CPU-mining 60 blocks and waiting out the 100-block coinbase
+maturity.
+
+---
+
+## Appendix A — Worked example: 2-of-3 accumulator multisig
+
+**Leaf script (conceptual):** `OP_0` + 3×(`OP_TOALTSTACK pk OP_CHECKSIGDILITHIUM OP_FROMALTSTACK OP_ADD`) + `OP_2 OP_GREATERTHANOREQUAL`
+
+**Before finalize (input 0):**
+
+```
+PSBT_IN_WITNESS_UTXO = { value, scriptPubKey: OP_2 <merkle_root> }
+PSBT_IN_P2MR_LEAF_SCRIPT = { key: control_block, value: leaf_script || 0xc0 }
+PSBT_IN_P2MR_DILITHIUM_SCRIPT_SIG:
+  (pk_A, leaf_hash) → sig_A (2421 bytes)
+  (pk_B, leaf_hash) → sig_B (2421 bytes)
+```
+
+**After finalize — witness stack (n=3; key 0=A, key 1=B signed; key 2=C unsigned):**
+
+Slots are pushed in reverse key order (key 0 on top). With C unsigned:
+
+```
+stack[0] = empty   (key 2 — unsigned)
+stack[1] = sig_B   (key 1)
+stack[2] = sig_A   (key 0)
+stack[3] = leaf_script bytes
+stack[4] = control_block
+```
+
+**Size (single input, 2-of-3, 2 partial sigs) — measured:**
+
+| Component | Bytes |
+|-----------|-------|
+| 2 × `PSBT_IN_P2MR_DILITHIUM_SCRIPT_SIG` (key 1345 + value 2421 + overhead) | ≈ 7 540 |
+| `PSBT_IN_P2MR_LEAF_SCRIPT` (3 × 1312-byte pubkey + opcodes = 3960, + 1-byte control block key) | ≈ 3 990 |
+| `PSBT_IN_P2MR_MERKLE_ROOT`, UTXO, unsigned tx, outputs | ≈ 250 |
+| **Binary total** | **≈ 11 800** |
+| **Base64** | **≈ 15 700** |
+
+Roughly 12 KB binary, 16 KB base64 — comfortable for a file, an email attachment or a
+paste, but far too large for a QR code (§13 non-goal 3).
+
+A P2MR control block has no internal key, so for a single-leaf tree it is one byte (the
+leaf version); each additional merkle path node adds 32 bytes.
+
+---
+
+## Appendix B — Test vector specification
+
+Fixtures live in `src/test/data/dilithium_psbt/`. Each vector set includes:
+
+| File | Content |
+|------|---------|
+| `README.md` | Generator command (`btq-multisig test/e2e_regtest.sh` + export) |
+| `accumulator_2of3_unsigned.psbt.base64` | Creator output, 0 partial sigs |
+| `accumulator_2of3_signed_a.psbt.base64` | After signer A |
+| `accumulator_2of3_signed_ab.psbt.base64` | After combinepsbt with signer B |
+| `accumulator_2of3_finalized.psbt.base64` | After finalize |
+| `accumulator_2of3_final_tx.hex` | Extracted raw tx |
+| `metadata.json` | `{ leaf_hash, merkle_root, pubkeys[], m, n, txid, vout, amounts[] }` |
+
+**Positive vector invariants (CI asserts):**
+
+1. `metadata.json` leaf_hash matches `ComputeTapleafHash` of embedded leaf.
+2. `VerifyP2MRCommitment` passes for control block + program.
+3. Final tx hex matches mining `testmempoolaccept` on regtest.
+4. `accumulator_2of3_signed_ab` classifies as `FINALIZABLE`; finalized classifies as `FINALIZED`.
+5. Byte length of each `PSBT_IN_P2MR_DILITHIUM_SCRIPT_SIG` value == 2421.
+
+### Appendix B.1 — Negative test vectors (REQUIRED for Phase 0 freeze)
+
+Each negative fixture is a `.psbt.base64` file that MUST fail `ValidatePSBTInput` (or deserialize) with the indicated error code. CI MUST assert the specific error.
+
+| File | Mutation | Expected error |
+|------|----------|----------------|
+| `neg_duplicate_leaf_script_key.psbt.base64` | Same `control_block` key twice | `INVALID_PSBT` |
+| `neg_duplicate_partial_sig_key.psbt.base64` | Identical `(pubkey, leaf_hash)` key twice | `INVALID_PSBT` |
+| `neg_conflicting_partial_sig.psbt.base64` | Same `(pubkey, leaf_hash)`, different sig bytes | `PSBT_DILITHIUM_SIG_INVALID` |
+| `neg_wrong_leaf_hash.psbt.base64` | Partial sig `leaf_hash` does not match any leaf | `PSBT_P2MR_METADATA_MISMATCH` |
+| `neg_leaf_hash_tiebreak.psbt.base64` | Two leaves, same `leaf_hash`, different scripts | `PSBT_P2MR_METADATA_MISMATCH` |
+| `neg_bad_commitment.psbt.base64` | Valid-looking leaf, wrong control block / Merkle path | `PSBT_P2MR_METADATA_MISMATCH` |
+| `neg_bad_parity_bit.psbt.base64` | Control byte parity bit cleared | `PSBT_P2MR_METADATA_MISMATCH` |
+| `neg_unsupported_sighash.psbt.base64` | Partial sig sighash byte `0x02` (NONE) | `PSBT_DILITHIUM_SIGHASH_UNSUPPORTED` |
+| `neg_invalid_signature.psbt.base64` | Valid structure, sig fails `Verify` | `PSBT_DILITHIUM_SIG_INVALID` |
+| `neg_unauthorized_pubkey.psbt.base64` | Sig from key not in leaf policy | `PSBT_DILITHIUM_SIG_UNAUTHORIZED` |
+| `neg_metadata_mismatch.psbt.base64` | `PSBT_IN_P2MR_MERKLE_ROOT` ≠ program | `PSBT_P2MR_METADATA_MISMATCH` |
+| `neg_multi_leaf_hash.psbt.base64` | Partial sigs reference two distinct leaf_hashes on one input | `PSBT_P2MR_METADATA_MISMATCH` |
+| `neg_proprietary_only.psbt.base64` | Dilithium data in `"btq.org"` proprietary fields only | `INVALID_PSBT` (production reader) |
+
+**Phase 0 gate:** Spec freeze is blocked until all positive **and** negative vectors above exist and pass CI.
+
+Vectors regenerated when type bytes or regtest chainparams change; CI checksums `metadata.json`.
+
+---
+
+## Appendix C — Glossary
+
+| Term | Meaning |
+|------|---------|
+| BTQ-PSBT | BIP174 + §4 Dilithium/P2MR extensions |
+| Accumulator leaf | Production m-of-n script using repeated `OP_CHECKSIGDILITHIUM` + add |
+| Leaf hash | `TaggedHash("TapLeaf", leaf_version \|\| compact_size(script) \|\| script)` |
+| FINALIZABLE | Enough **valid** partial sigs (§5.4) to run §6.5 finalizer |
+| Control block | BIP360 P2MR witness suffix proving leaf inclusion (§4.9) |
+| `sig_raw` | 2420-byte Dilithium signature without sighash byte |
+| `sig_with_hashtype` | 2421-byte PSBT value: `sig_raw \|\| sighash_type` |
+| `DilithiumPKHash` | 20-byte `Hash160` of full 1312-byte pubkey; internal map key only |
+| `PrecomputedTransactionData` | BIP341 sighash cache; requires all input amounts (§2.5.2) |
+| `ScriptExecutionData` | Per-input sighash context: leaf hash, codeseparator, annex (§2.5.3) |
+| `VerifyP2MRCommitment` | Merkle path verification algorithm (§4.9) |
+| Valid partial sig | Passes all §5.4 checks including cryptographic verify |
+
+---
+
+## References
+
+1. BIP174 — PSBT  
+2. BIP370 — PSBT Version 2  
+3. BIP341/342 — Taproot / Tapscript  
+4. BIP371 — Taproot PSBT fields  
+5. BIP360 — P2MR (`VerifyP2MRCommitment`, §4.9)  
+6. `btq-multisig/src/multisig.cpp`, `finalize.cpp`, `sighash.cpp`  
+7. `btq-core/MAINNET_AUDIT_MATRIX_2026-06-03.md` — C28  
+8. `btq-core/doc-btq/INTERNAL_SECURITY_AUDIT_PLAN.md` — W-05

--- a/doc/psbt.md
+++ b/doc/psbt.md
@@ -144,3 +144,82 @@ separately. They can then all invoke `walletprocesspsbt "P"`, and end up with
 their individually-signed PSBT structures. They then all send those back to
 Carol (or anyone) who can combine them using `combinepsbt`. The last two steps
 (`finalizepsbt` and `sendrawtransaction`) remain unchanged.
+
+## Dilithium P2MR (BTQ)
+
+ECDSA `addmultisigaddress` cannot describe a Dilithium spend. Dilithium
+multisig lives in a P2MR (witness v2) leaf, and the partial signatures are too
+large for `PSBT_IN_PARTIAL_SIG`. BTQ-PSBT adds typed input fields for the leaf,
+the merkle root and the Dilithium signatures; `walletcreatefundedpsbt` /
+`walletprocesspsbt` / `combinepsbt` / `finalizepsbt` are otherwise the same
+roles as above.
+
+A 2-of-3 is about 12 KB binary, 16 KB base64 — a file, not a QR code.
+`analyzepsbt` does not yet report Dilithium progress; use `decodepsbt` (or the
+wrapper's `status` command) and look at `inputs[0].p2mr_dilithium`.
+
+### Raw `btq-cli` recipe (2-of-3)
+
+Each co-signer has their own wallet. Replace `-rpcwallet=` and the `-datadir` /
+`-testnet` flags to match the node.
+
+```sh
+# 1. Each co-signer publishes one Dilithium pubkey
+btq-cli -rpcwallet=alice getnewdilithiumaddress
+# { "address": "...", "p2mr_id": "..." }
+btq-cli -rpcwallet=alice getdilithiumpubkey "<alice_p2mr_id>"
+# { "pubkeys": [ { "pubkey": "<hex>", "ismine": true } ] }
+# Repeat for bob and carol. Call the three pubkeys Kalice, Kbob, Kcarol.
+
+# 2. Every co-signer registers the same m and the same pubkey list, in the same order
+btq-cli -rpcwallet=alice createdilithiummultisig 2 '["Kalice","Kbob","Kcarol"]'
+btq-cli -rpcwallet=bob   createdilithiummultisig 2 '["Kalice","Kbob","Kcarol"]'
+btq-cli -rpcwallet=carol createdilithiummultisig 2 '["Kalice","Kbob","Kcarol"]'
+# All three must report the same "address". Each reports "signers_available": 1.
+
+# 3. Fund that address, then one co-signer builds the unsigned PSBT
+btq-cli -rpcwallet=alice walletcreatefundedpsbt \
+  '[{"txid":"<txid>","vout":0}]' '{"<destination>":0.0005}'
+# Save the "psbt" field to unsigned.psbt (it is ~16 KB).
+
+# 4a. Sequential: alice signs, hands the file to bob
+btq-cli -rpcwallet=alice walletprocesspsbt "$(cat unsigned.psbt)"
+btq-cli -rpcwallet=bob   walletprocesspsbt "<psbt from alice>"
+# bob's result has "complete": true once two signatures are present.
+
+# 4b. Parallel: alice and carol each sign the *unsigned* PSBT, then merge
+btq-cli -rpcwallet=alice walletprocesspsbt "$(cat unsigned.psbt)"   # -> alice.psbt
+btq-cli -rpcwallet=carol walletprocesspsbt "$(cat unsigned.psbt)"   # -> carol.psbt
+btq-cli combinepsbt '["<alice.psbt>","<carol.psbt>"]'
+
+# 5. Inspect, extract, broadcast
+btq-cli decodepsbt "<psbt>"   # inputs[0].p2mr_dilithium.status, .signatures, .required
+btq-cli finalizepsbt "<psbt>"
+btq-cli sendrawtransaction "<hex>"
+```
+
+`createdilithiummultisig` is what makes the leaf and control block travel with
+the PSBT: without it, `walletcreatefundedpsbt` has no P2MR metadata to attach
+and the next wallet cannot sign.
+
+### Wrapper
+
+`contrib/btq/dilithium-psbt.sh` is the same recipe with less JSON quoting.
+PSBT payloads stay on stdout so they can be redirected to a file:
+
+```sh
+CLI="btq-cli -testnet"
+contrib/btq/dilithium-psbt.sh --cli="$CLI" pubkey alice
+contrib/btq/dilithium-psbt.sh --cli="$CLI" register alice 2 "$PK_A" "$PK_B" "$PK_C"
+contrib/btq/dilithium-psbt.sh --cli="$CLI" create alice "$TXID:0" "$DEST" 0.0005 > unsigned.psbt
+contrib/btq/dilithium-psbt.sh --cli="$CLI" sign alice unsigned.psbt > alice.psbt
+contrib/btq/dilithium-psbt.sh --cli="$CLI" sign carol unsigned.psbt > carol.psbt
+contrib/btq/dilithium-psbt.sh --cli="$CLI" combine alice.psbt carol.psbt > combined.psbt
+contrib/btq/dilithium-psbt.sh --cli="$CLI" status combined.psbt
+contrib/btq/dilithium-psbt.sh --cli="$CLI" finalize combined.psbt > spend.hex
+contrib/btq/dilithium-psbt.sh --cli="$CLI" broadcast spend.hex
+```
+
+The live-chain proof against public testnet is
+`contrib/btq/testnet_dilithium_psbt_proof.sh`. The wire format and the two
+confirmed spends are recorded in `doc-btq/DILITHIUM_PSBT_DESIGN.md` §16–§17.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -249,6 +249,7 @@ BTQ_CORE_H = \
   pow.h \
   protocol.h \
   psbt.h \
+  psbt_dilithium.h \
   random.h \
   randomenv.h \
   rest.h \
@@ -266,6 +267,7 @@ BTQ_CORE_H = \
   rpc/util.h \
   scheduler.h \
   script/descriptor.h \
+  script/dilithium_leaf.h \
   script/keyorigin.h \
   script/miniscript.h \
   script/sigcache.h \
@@ -734,12 +736,14 @@ libbtq_common_a_SOURCES = \
   policy/policy.cpp \
   protocol.cpp \
   psbt.cpp \
+  psbt_dilithium.cpp \
   rpc/external_signer.cpp \
   rpc/rawtransaction_util.cpp \
   rpc/request.cpp \
   rpc/util.cpp \
   scheduler.cpp \
   script/descriptor.cpp \
+  script/dilithium_leaf.cpp \
   script/miniscript.cpp \
   script/sign.cpp \
   script/signingprovider.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -97,6 +97,7 @@ BTQ_TESTS =\
   test/dilithium_descriptor_tests.cpp \
   test/dilithium_basic_tests.cpp \
   test/dilithium_p2mr_only_tests.cpp \
+  test/psbt_dilithium_tests.cpp \
   test/dilithium_mixed_mode_tests.cpp \
   test/dilithium_network_policy_tests.cpp \
   test/cuckoocache_tests.cpp \

--- a/src/psbt.cpp
+++ b/src/psbt.cpp
@@ -5,6 +5,7 @@
 #include <psbt.h>
 
 #include <policy/policy.h>
+#include <psbt_dilithium.h>
 #include <script/signingprovider.h>
 #include <util/check.h>
 #include <util/strencodings.h>
@@ -130,6 +131,15 @@ void PSBTInput::FillSignatureData(SignatureData& sigdata) const
     for (const auto& [leaf_script, control_block] : m_tap_scripts) {
         sigdata.tr_spenddata.scripts.emplace(leaf_script, control_block);
     }
+    if (!m_p2mr_merkle_root.IsNull()) {
+        sigdata.p2mr_spenddata.merkle_root = m_p2mr_merkle_root;
+    }
+    for (const auto& [leaf_script, control_blocks] : m_p2mr_scripts) {
+        sigdata.p2mr_spenddata.scripts.emplace(leaf_script, control_blocks);
+    }
+    for (const auto& [keyid_leaf, pubkey_sig] : m_p2mr_dilithium_script_sigs) {
+        sigdata.p2mr_dilithium_script_sigs.emplace(keyid_leaf, pubkey_sig);
+    }
     for (const auto& [pubkey, leaf_origin] : m_tap_bip32_paths) {
         sigdata.taproot_misc_pubkeys.emplace(pubkey, leaf_origin);
         sigdata.tap_pubkeys.emplace(Hash160(pubkey), pubkey);
@@ -155,6 +165,11 @@ void PSBTInput::FromSignatureData(const SignatureData& sigdata)
         hd_keypaths.clear();
         redeem_script.clear();
         witness_script.clear();
+        // The finalized witness supersedes the P2MR spend path and its partial
+        // signatures, which together dwarf the rest of the input.
+        m_p2mr_scripts.clear();
+        m_p2mr_dilithium_script_sigs.clear();
+        m_p2mr_merkle_root.SetNull();
 
         if (!sigdata.scriptSig.empty()) {
             final_script_sig = sigdata.scriptSig;
@@ -193,6 +208,15 @@ void PSBTInput::FromSignatureData(const SignatureData& sigdata)
     for (const auto& [pubkey, leaf_origin] : sigdata.taproot_misc_pubkeys) {
         m_tap_bip32_paths.emplace(pubkey, leaf_origin);
     }
+    if (!sigdata.p2mr_spenddata.merkle_root.IsNull()) {
+        m_p2mr_merkle_root = sigdata.p2mr_spenddata.merkle_root;
+    }
+    for (const auto& [leaf_script, control_blocks] : sigdata.p2mr_spenddata.scripts) {
+        m_p2mr_scripts.emplace(leaf_script, control_blocks);
+    }
+    for (const auto& [keyid_leaf, pubkey_sig] : sigdata.p2mr_dilithium_script_sigs) {
+        m_p2mr_dilithium_script_sigs.emplace(keyid_leaf, pubkey_sig);
+    }
 }
 
 void PSBTInput::Merge(const PSBTInput& input)
@@ -212,6 +236,8 @@ void PSBTInput::Merge(const PSBTInput& input)
     m_tap_script_sigs.insert(input.m_tap_script_sigs.begin(), input.m_tap_script_sigs.end());
     m_tap_scripts.insert(input.m_tap_scripts.begin(), input.m_tap_scripts.end());
     m_tap_bip32_paths.insert(input.m_tap_bip32_paths.begin(), input.m_tap_bip32_paths.end());
+    m_p2mr_scripts.insert(input.m_p2mr_scripts.begin(), input.m_p2mr_scripts.end());
+    m_p2mr_dilithium_script_sigs.insert(input.m_p2mr_dilithium_script_sigs.begin(), input.m_p2mr_dilithium_script_sigs.end());
 
     if (redeem_script.empty() && !input.redeem_script.empty()) redeem_script = input.redeem_script;
     if (witness_script.empty() && !input.witness_script.empty()) witness_script = input.witness_script;
@@ -220,6 +246,7 @@ void PSBTInput::Merge(const PSBTInput& input)
     if (m_tap_key_sig.empty() && !input.m_tap_key_sig.empty()) m_tap_key_sig = input.m_tap_key_sig;
     if (m_tap_internal_key.IsNull() && !input.m_tap_internal_key.IsNull()) m_tap_internal_key = input.m_tap_internal_key;
     if (m_tap_merkle_root.IsNull() && !input.m_tap_merkle_root.IsNull()) m_tap_merkle_root = input.m_tap_merkle_root;
+    if (m_p2mr_merkle_root.IsNull() && !input.m_p2mr_merkle_root.IsNull()) m_p2mr_merkle_root = input.m_p2mr_merkle_root;
 }
 
 void PSBTOutput::FillSignatureData(SignatureData& sigdata) const
@@ -554,6 +581,13 @@ bool DecodeRawPSBT(PartiallySignedTransaction& psbt, Span<const std::byte> tx_da
         }
     } catch (const std::exception& e) {
         error = e.what();
+        return false;
+    }
+    // Dilithium/P2MR material cannot be checked field by field while parsing --
+    // verifying a partial signature needs the unsigned transaction and every
+    // input amount. Do it here so no caller can act on an unvalidated PSBT.
+    if (!ValidateP2MRDilithiumPSBT(psbt, error)) {
+        psbt = PartiallySignedTransaction{};
         return false;
     }
     return true;

--- a/src/psbt.h
+++ b/src/psbt.h
@@ -46,6 +46,13 @@ static constexpr uint8_t PSBT_IN_TAP_LEAF_SCRIPT = 0x15;
 static constexpr uint8_t PSBT_IN_TAP_BIP32_DERIVATION = 0x16;
 static constexpr uint8_t PSBT_IN_TAP_INTERNAL_KEY = 0x17;
 static constexpr uint8_t PSBT_IN_TAP_MERKLE_ROOT = 0x18;
+// BTQ: Dilithium signing on BIP360 P2MR (witness v2) inputs. Dilithium material
+// does not fit PSBT_IN_PARTIAL_SIG (key length and algorithm both differ), so it
+// gets its own types, following the BIP371 precedent for Taproot.
+static constexpr uint8_t PSBT_IN_P2MR_LEAF_SCRIPT = 0x19;
+static constexpr uint8_t PSBT_IN_P2MR_MERKLE_ROOT = 0x1A;
+static constexpr uint8_t PSBT_IN_P2MR_DILITHIUM_SCRIPT_SIG = 0x1B;
+// 0x1C and 0x1D are reserved for Dilithium BIP32 derivation and pubkey hints.
 static constexpr uint8_t PSBT_IN_PROPRIETARY = 0xFC;
 
 // Output types
@@ -67,6 +74,14 @@ const std::streamsize MAX_FILE_SIZE_PSBT = 100000000; // 100 MB
 
 // PSBT version number
 static constexpr uint32_t PSBT_HIGHEST_VERSION = 0;
+
+// Bounds on the BTQ Dilithium/P2MR input fields, enforced while parsing so a
+// hostile PSBT cannot make us allocate unboundedly. These match consensus
+// rather than tightening it: a PSBT must be able to carry any spend the chain
+// would accept.
+static constexpr size_t MAX_DILITHIUM_PARTIAL_SIG_VALUE_SIZE = CDilithiumPubKey::SIGNATURE_SIZE + 1;
+static constexpr size_t MAX_DILITHIUM_PARTIAL_SIGS_PER_INPUT = MAX_PUBKEYS_PER_MULTISIG;
+static constexpr size_t MAX_P2MR_LEAF_SCRIPT_SIZE = MAX_SCRIPT_SIZE;
 
 /** A structure for PSBT proprietary types */
 struct PSBTProprietary
@@ -211,6 +226,14 @@ struct PSBTInput
     XOnlyPubKey m_tap_internal_key;
     uint256 m_tap_merkle_root;
 
+    // BTQ Dilithium / P2MR fields. Laid out like their Taproot counterparts:
+    // m_p2mr_scripts mirrors m_tap_scripts, and m_p2mr_dilithium_script_sigs
+    // mirrors m_tap_script_sigs. Keeping the shapes identical means the bridge
+    // to SignatureData::p2mr_spenddata is a copy rather than a translation.
+    std::map<std::pair<std::vector<unsigned char>, int>, std::set<std::vector<unsigned char>, ShortestVectorFirstComparator>> m_p2mr_scripts;
+    uint256 m_p2mr_merkle_root;
+    std::map<std::pair<DilithiumPKHash, uint256>, std::pair<CDilithiumPubKey, std::vector<unsigned char>>> m_p2mr_dilithium_script_sigs;
+
     std::map<std::vector<unsigned char>, std::vector<unsigned char>> unknown;
     std::set<PSBTProprietary> m_proprietary;
     std::optional<int> sighash_type;
@@ -331,6 +354,31 @@ struct PSBTInput
             if (!m_tap_merkle_root.IsNull()) {
                 SerializeToVector(s, PSBT_IN_TAP_MERKLE_ROOT);
                 SerializeToVector(s, m_tap_merkle_root);
+            }
+
+            // Write P2MR leaf scripts
+            for (const auto& [leaf, control_blocks] : m_p2mr_scripts) {
+                const auto& [script, leaf_ver] = leaf;
+                for (const auto& control_block : control_blocks) {
+                    SerializeToVector(s, PSBT_IN_P2MR_LEAF_SCRIPT, Span{control_block});
+                    std::vector<unsigned char> value_v(script.begin(), script.end());
+                    value_v.push_back((uint8_t)leaf_ver);
+                    s << value_v;
+                }
+            }
+
+            // Write P2MR merkle root
+            if (!m_p2mr_merkle_root.IsNull()) {
+                SerializeToVector(s, PSBT_IN_P2MR_MERKLE_ROOT);
+                SerializeToVector(s, m_p2mr_merkle_root);
+            }
+
+            // Write P2MR Dilithium script signatures. The wire key carries the
+            // full 1312-byte pubkey; the map is keyed by its hash internally.
+            for (const auto& [keyid_leaf, pubkey_sig] : m_p2mr_dilithium_script_sigs) {
+                const auto& [pubkey, sig] = pubkey_sig;
+                SerializeToVector(s, PSBT_IN_P2MR_DILITHIUM_SCRIPT_SIG, pubkey, keyid_leaf.second);
+                s << sig;
             }
         }
 
@@ -666,6 +714,68 @@ struct PSBTInput
                         throw std::ios_base::failure("Input Taproot merkle root key is more than one byte type");
                     }
                     UnserializeFromVector(s, m_tap_merkle_root);
+                    break;
+                }
+                case PSBT_IN_P2MR_LEAF_SCRIPT:
+                {
+                    if (!key_lookup.emplace(key).second) {
+                        throw std::ios_base::failure("Duplicate Key, input P2MR leaf script already provided");
+                    } else if (key.size() < 1 + P2MR_CONTROL_BASE_SIZE) {
+                        throw std::ios_base::failure("Input P2MR leaf script key is too short to hold a control block");
+                    } else if (key.size() > 1 + P2MR_CONTROL_MAX_SIZE) {
+                        throw std::ios_base::failure("Input P2MR leaf script key's control block is too large");
+                    } else if ((key.size() - 1 - P2MR_CONTROL_BASE_SIZE) % P2MR_CONTROL_NODE_SIZE != 0) {
+                        throw std::ios_base::failure("Input P2MR leaf script key's control block size is not valid");
+                    }
+                    std::vector<unsigned char> script_v;
+                    s >> script_v;
+                    if (script_v.empty()) {
+                        throw std::ios_base::failure("Input P2MR leaf script must be at least 1 byte");
+                    }
+                    if (script_v.size() - 1 > MAX_P2MR_LEAF_SCRIPT_SIZE) {
+                        throw std::ios_base::failure("Input P2MR leaf script is too large");
+                    }
+                    uint8_t leaf_ver = script_v.back();
+                    script_v.pop_back();
+                    const auto leaf_script = std::make_pair(script_v, (int)leaf_ver);
+                    m_p2mr_scripts[leaf_script].insert(std::vector<unsigned char>(key.begin() + 1, key.end()));
+                    break;
+                }
+                case PSBT_IN_P2MR_MERKLE_ROOT:
+                {
+                    if (!key_lookup.emplace(key).second) {
+                        throw std::ios_base::failure("Duplicate Key, input P2MR merkle root already provided");
+                    } else if (key.size() != 1) {
+                        throw std::ios_base::failure("Input P2MR merkle root key is more than one byte type");
+                    }
+                    UnserializeFromVector(s, m_p2mr_merkle_root);
+                    break;
+                }
+                case PSBT_IN_P2MR_DILITHIUM_SCRIPT_SIG:
+                {
+                    if (!key_lookup.emplace(key).second) {
+                        throw std::ios_base::failure("Duplicate Key, input P2MR Dilithium script signature already provided");
+                    } else if (key.size() != 1 + CDilithiumPubKey::SIZE + uint256::size()) {
+                        throw std::ios_base::failure("Input P2MR Dilithium script signature key is not the expected size");
+                    }
+                    if (m_p2mr_dilithium_script_sigs.size() >= MAX_DILITHIUM_PARTIAL_SIGS_PER_INPUT) {
+                        throw std::ios_base::failure("Too many P2MR Dilithium partial signatures for one input");
+                    }
+                    SpanReader s_key{s.GetVersion(), Span{key}.subspan(1)};
+                    CDilithiumPubKey pubkey;
+                    uint256 leaf_hash;
+                    s_key >> pubkey;
+                    s_key >> leaf_hash;
+                    if (!pubkey.IsFullyValid()) {
+                        throw std::ios_base::failure("Invalid Dilithium pubkey");
+                    }
+                    std::vector<unsigned char> sig;
+                    s >> sig;
+                    if (sig.size() != MAX_DILITHIUM_PARTIAL_SIG_VALUE_SIZE) {
+                        throw std::ios_base::failure("Input P2MR Dilithium partial signature has an invalid length");
+                    }
+                    m_p2mr_dilithium_script_sigs.emplace(std::make_pair(DilithiumPKHash(pubkey), leaf_hash),
+                                                         std::make_pair(pubkey, std::move(sig)));
                     break;
                 }
                 case PSBT_IN_PROPRIETARY:

--- a/src/psbt_dilithium.cpp
+++ b/src/psbt_dilithium.cpp
@@ -1,0 +1,242 @@
+// Copyright (c) 2026 The BTQ Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <psbt_dilithium.h>
+
+#include <script/interpreter.h>
+#include <span.h>
+#include <tinyformat.h>
+
+#include <map>
+#include <set>
+
+namespace {
+
+//! Extract the 32-byte Merkle root from a P2MR scriptPubKey.
+bool GetP2MRProgram(const CTxOut& utxo, std::vector<unsigned char>& program)
+{
+    int witversion;
+    std::vector<unsigned char> prog;
+    if (!utxo.scriptPubKey.IsWitnessProgram(witversion, prog)) return false;
+    if (witversion != 2 || prog.size() != WITNESS_V2_P2MR_SIZE) return false;
+    program = std::move(prog);
+    return true;
+}
+
+//! Recompute the BIP341 sighash a Dilithium leaf signature commits to.
+bool ComputeLeafSighash(const CMutableTransaction& tx, unsigned int index,
+                        const PrecomputedTransactionData& txdata, const uint256& leaf_hash,
+                        uint8_t hash_type, uint256& sighash_out)
+{
+    if (!txdata.m_bip341_taproot_ready || !txdata.m_spent_outputs_ready) return false;
+    ScriptExecutionData execdata;
+    execdata.m_annex_init = true;
+    execdata.m_annex_present = false;
+    execdata.m_codeseparator_pos_init = true;
+    execdata.m_codeseparator_pos = 0xFFFFFFFF;
+    execdata.m_tapleaf_hash_init = true;
+    execdata.m_tapleaf_hash = leaf_hash;
+    return SignatureHashSchnorr(sighash_out, execdata, tx, index, hash_type,
+                                SigVersion::P2MR_TAPSCRIPT, txdata, MissingDataBehavior::FAIL);
+}
+
+bool HasP2MRFields(const PSBTInput& input)
+{
+    return !input.m_p2mr_scripts.empty() || !input.m_p2mr_dilithium_script_sigs.empty() ||
+           !input.m_p2mr_merkle_root.IsNull();
+}
+
+} // namespace
+
+std::string P2MRInputStatusName(P2MRInputStatus status)
+{
+    switch (status) {
+    case P2MRInputStatus::NOT_P2MR: return "not_p2mr";
+    case P2MRInputStatus::FINALIZED: return "finalized";
+    case P2MRInputStatus::UNKNOWN_LEAF: return "unknown_leaf";
+    case P2MRInputStatus::UNSIGNED: return "unsigned";
+    case P2MRInputStatus::PARTIALLY_SIGNED: return "partially_signed";
+    case P2MRInputStatus::FINALIZABLE: return "finalizable";
+    } // no default case, so the compiler can warn about missing cases
+    assert(false);
+}
+
+P2MRInputInfo InspectP2MRInput(const PartiallySignedTransaction& psbt, unsigned int index)
+{
+    P2MRInputInfo info;
+    const PSBTInput& input = psbt.inputs.at(index);
+
+    CTxOut utxo;
+    std::vector<unsigned char> program;
+    const bool is_p2mr = psbt.GetInputUTXO(utxo, index) && GetP2MRProgram(utxo, program);
+    if (!is_p2mr && !HasP2MRFields(input)) return info;
+
+    if (PSBTInputSigned(input)) {
+        info.status = P2MRInputStatus::FINALIZED;
+        return info;
+    }
+
+    // Narrow the advertised leaves down to the one being spent. Partial
+    // signatures pin the choice; without them a single leaf is unambiguous.
+    std::set<uint256> sig_leaf_hashes;
+    for (const auto& [keyid_leaf, _] : input.m_p2mr_dilithium_script_sigs) {
+        sig_leaf_hashes.insert(keyid_leaf.second);
+    }
+
+    info.status = P2MRInputStatus::UNKNOWN_LEAF;
+    if (sig_leaf_hashes.size() > 1) return info;
+
+    int candidates = 0;
+    for (const auto& [leaf, control_blocks] : input.m_p2mr_scripts) {
+        const auto& [script, leaf_ver] = leaf;
+        const uint256 leaf_hash = ComputeTapleafHash(static_cast<uint8_t>(leaf_ver), script);
+        if (!sig_leaf_hashes.empty() && sig_leaf_hashes.count(leaf_hash) == 0) continue;
+        ++candidates;
+        info.leaf_script = CScript(script.begin(), script.end());
+        info.leaf_version = leaf_ver;
+        info.leaf_hash = leaf_hash;
+        if (!control_blocks.empty()) info.control_block = *control_blocks.begin();
+    }
+    if (candidates != 1) {
+        info = P2MRInputInfo{};
+        info.status = P2MRInputStatus::UNKNOWN_LEAF;
+        return info;
+    }
+
+    info.policy = ParseP2MRDilithiumLeaf(info.leaf_script);
+    if (!info.policy.IsValid()) return info;
+
+    info.sigs_required = info.policy.m;
+    for (const auto& [keyid_leaf, pubkey_sig] : input.m_p2mr_dilithium_script_sigs) {
+        if (keyid_leaf.second != info.leaf_hash) continue;
+        if (!FindPolicyKeyIndex(info.policy, pubkey_sig.first)) continue;
+        ++info.sigs_present;
+    }
+
+    if (info.sigs_present == 0) {
+        info.status = P2MRInputStatus::UNSIGNED;
+    } else if (info.sigs_present >= info.sigs_required) {
+        info.status = P2MRInputStatus::FINALIZABLE;
+    } else {
+        info.status = P2MRInputStatus::PARTIALLY_SIGNED;
+    }
+    return info;
+}
+
+bool ValidateP2MRDilithiumInput(const PartiallySignedTransaction& psbt, unsigned int index,
+                                const PrecomputedTransactionData* txdata, std::string& error)
+{
+    const PSBTInput& input = psbt.inputs.at(index);
+    if (!HasP2MRFields(input)) return true;
+
+    const auto fail = [&](const std::string& reason) {
+        error = strprintf("Input %u: %s", index, reason);
+        return false;
+    };
+
+    CTxOut utxo;
+    if (!psbt.GetInputUTXO(utxo, index)) {
+        return fail("has Dilithium P2MR fields but no UTXO to check them against");
+    }
+    std::vector<unsigned char> program;
+    if (!GetP2MRProgram(utxo, program)) {
+        return fail("has Dilithium P2MR fields but does not spend a P2MR output");
+    }
+    if (!input.m_p2mr_merkle_root.IsNull() && input.m_p2mr_merkle_root != uint256(program)) {
+        return fail("P2MR merkle root does not match the witness program");
+    }
+    // Consensus rejects SIGHASH_DEFAULT for P2MR tapscript, so SIGHASH_ALL is
+    // the only type a Dilithium leaf signature can usefully commit to.
+    if (input.sighash_type && *input.sighash_type != SIGHASH_ALL) {
+        return fail("Dilithium P2MR inputs only support SIGHASH_ALL");
+    }
+
+    // Every advertised leaf must genuinely commit to the witness program,
+    // otherwise a signer could be tricked into signing an unrelated script.
+    std::map<uint256, CScript> leaves;
+    for (const auto& [leaf, control_blocks] : input.m_p2mr_scripts) {
+        const auto& [script, leaf_ver] = leaf;
+        const uint256 leaf_hash = ComputeTapleafHash(static_cast<uint8_t>(leaf_ver), script);
+        for (const auto& control : control_blocks) {
+            if (control.size() < P2MR_CONTROL_BASE_SIZE || control.size() > P2MR_CONTROL_MAX_SIZE ||
+                (control.size() - P2MR_CONTROL_BASE_SIZE) % P2MR_CONTROL_NODE_SIZE != 0) {
+                return fail("P2MR control block has an invalid size");
+            }
+            if ((control[0] & 1) != 1) {
+                return fail("P2MR control block does not have the parity bit set");
+            }
+            if ((control[0] & TAPROOT_LEAF_MASK) != leaf_ver) {
+                return fail("P2MR control block leaf version does not match the leaf script");
+            }
+            if (ComputeP2MRMerkleRoot(control, leaf_hash) != uint256(program)) {
+                return fail("P2MR leaf script does not commit to the witness program");
+            }
+        }
+        if (!leaves.emplace(leaf_hash, CScript(script.begin(), script.end())).second) {
+            return fail("two P2MR leaf scripts collide on the same leaf hash");
+        }
+    }
+
+    std::set<uint256> sig_leaf_hashes;
+    for (const auto& [keyid_leaf, pubkey_sig] : input.m_p2mr_dilithium_script_sigs) {
+        const uint256& leaf_hash = keyid_leaf.second;
+        const auto& [pubkey, sig] = pubkey_sig;
+
+        const auto leaf_it = leaves.find(leaf_hash);
+        if (leaf_it == leaves.end()) {
+            return fail("Dilithium partial signature refers to a leaf the PSBT does not contain");
+        }
+        sig_leaf_hashes.insert(leaf_hash);
+        if (sig_leaf_hashes.size() > 1) {
+            return fail("Dilithium partial signatures refer to more than one leaf");
+        }
+
+        const P2MRDilithiumLeafPolicy policy = ParseP2MRDilithiumLeaf(leaf_it->second);
+        if (!policy.IsValid()) {
+            return fail("Dilithium partial signature is attached to an unrecognised leaf script");
+        }
+        if (!FindPolicyKeyIndex(policy, pubkey)) {
+            return fail("Dilithium partial signature is from a key the leaf does not authorise");
+        }
+        if (sig.back() != SIGHASH_ALL) {
+            return fail("Dilithium partial signature uses an unsupported sighash type");
+        }
+
+        if (!txdata) {
+            return fail("cannot verify Dilithium partial signatures without every input amount");
+        }
+        uint256 sighash;
+        if (!ComputeLeafSighash(*psbt.tx, index, *txdata, leaf_hash, sig.back(), sighash)) {
+            return fail("cannot compute the P2MR sighash needed to verify Dilithium partial signatures");
+        }
+        if (!pubkey.Verify(sighash, std::vector<unsigned char>(sig.begin(), sig.end() - 1))) {
+            return fail("Dilithium partial signature does not verify");
+        }
+    }
+
+    return true;
+}
+
+bool ValidateP2MRDilithiumPSBT(const PartiallySignedTransaction& psbt, std::string& error)
+{
+    if (!psbt.tx) return true;
+
+    bool any = false;
+    for (const PSBTInput& input : psbt.inputs) {
+        if (HasP2MRFields(input)) {
+            any = true;
+            break;
+        }
+    }
+    if (!any) return true;
+
+    const PrecomputedTransactionData txdata = PrecomputePSBTData(psbt);
+    const PrecomputedTransactionData* txdata_ptr =
+        (txdata.m_bip341_taproot_ready && txdata.m_spent_outputs_ready) ? &txdata : nullptr;
+
+    for (unsigned int i = 0; i < psbt.inputs.size(); ++i) {
+        if (!ValidateP2MRDilithiumInput(psbt, i, txdata_ptr, error)) return false;
+    }
+    return true;
+}

--- a/src/psbt_dilithium.h
+++ b/src/psbt_dilithium.h
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 The BTQ Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BTQ_PSBT_DILITHIUM_H
+#define BTQ_PSBT_DILITHIUM_H
+
+#include <psbt.h>
+#include <script/dilithium_leaf.h>
+#include <uint256.h>
+
+#include <string>
+#include <vector>
+
+/** Where an input stands in the Dilithium P2MR signing flow. */
+enum class P2MRInputStatus {
+    //! Not a P2MR input and carries no P2MR fields.
+    NOT_P2MR,
+    //! final_script_witness is set.
+    FINALIZED,
+    //! P2MR input whose spend path we cannot reason about (leaf missing, ambiguous, or unrecognised).
+    UNKNOWN_LEAF,
+    UNSIGNED,
+    PARTIALLY_SIGNED,
+    //! Enough authorised signatures are present to build a witness.
+    FINALIZABLE,
+};
+
+std::string P2MRInputStatusName(P2MRInputStatus status);
+
+/** What we can say about an input's Dilithium P2MR spend path without verifying signatures. */
+struct P2MRInputInfo {
+    P2MRInputStatus status{P2MRInputStatus::NOT_P2MR};
+    P2MRDilithiumLeafPolicy policy;
+    CScript leaf_script;
+    int leaf_version{0};
+    std::vector<unsigned char> control_block;
+    uint256 leaf_hash;
+    //! Signatures present from keys the leaf authorises.
+    int sigs_present{0};
+    //! Signatures the leaf requires.
+    int sigs_required{0};
+};
+
+/**
+ * Describe an input's Dilithium P2MR spend path.
+ *
+ * This is a structural inspection: it selects the leaf being spent and counts
+ * signatures, but does not verify them. Use ValidateP2MRDilithiumInput for that.
+ */
+P2MRInputInfo InspectP2MRInput(const PartiallySignedTransaction& psbt, unsigned int index);
+
+/**
+ * Fail-closed check of one input's Dilithium/P2MR fields.
+ *
+ * Verifies that every advertised leaf commits to the witness program and that
+ * every partial signature is from an authorised key and cryptographically valid
+ * for the recomputed BIP341 sighash. Inputs with no Dilithium/P2MR fields pass
+ * trivially.
+ *
+ * `txdata` may be null only when the input carries no partial signatures;
+ * otherwise verification cannot proceed and the input is rejected.
+ */
+bool ValidateP2MRDilithiumInput(const PartiallySignedTransaction& psbt, unsigned int index,
+                                const PrecomputedTransactionData* txdata, std::string& error);
+
+/** Run ValidateP2MRDilithiumInput over every input. */
+bool ValidateP2MRDilithiumPSBT(const PartiallySignedTransaction& psbt, std::string& error);
+
+#endif // BTQ_PSBT_DILITHIUM_H

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -96,6 +96,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "addmultisigaddress", 1, "keys" },
     { "createmultisig", 0, "nrequired" },
     { "createmultisig", 1, "keys" },
+    { "createdilithiummultisig", 0, "nrequired" },
+    { "createdilithiummultisig", 1, "pubkeys" },
     { "listunspent", 0, "minconf" },
     { "listunspent", 1, "maxconf" },
     { "listunspent", 2, "addresses" },

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -21,6 +21,7 @@
 #include <policy/rbf.h>
 #include <primitives/transaction.h>
 #include <psbt.h>
+#include <psbt_dilithium.h>
 #include <random.h>
 #include <rpc/blockchain.h>
 #include <rpc/rawtransaction_util.h>
@@ -939,6 +940,40 @@ const RPCResult decodepsbt_inputs{
             }},
             {RPCResult::Type::STR_HEX, "taproot_internal_key", /*optional=*/ true, "The hex-encoded Taproot x-only internal key"},
             {RPCResult::Type::STR_HEX, "taproot_merkle_root", /*optional=*/ true, "The hex-encoded Taproot merkle root"},
+            {RPCResult::Type::ARR, "p2mr_scripts", /*optional=*/ true, "",
+            {
+                {RPCResult::Type::OBJ, "", "",
+                {
+                    {RPCResult::Type::STR_HEX, "script", "A P2MR leaf script"},
+                    {RPCResult::Type::NUM, "leaf_ver", "The version number for the leaf script"},
+                    {RPCResult::Type::ARR, "control_blocks", "The control blocks for this script",
+                    {
+                        {RPCResult::Type::STR_HEX, "control_block", "A hex-encoded control block for this script"},
+                    }},
+                    {RPCResult::Type::STR, "dilithium_policy", /*optional=*/ true, "The recognised Dilithium leaf template"},
+                    {RPCResult::Type::NUM, "dilithium_required", /*optional=*/ true, "Signatures the leaf requires"},
+                    {RPCResult::Type::NUM, "dilithium_total", /*optional=*/ true, "Keys the leaf names"},
+                }},
+            }},
+            {RPCResult::Type::STR_HEX, "p2mr_merkle_root", /*optional=*/ true, "The hex-encoded P2MR merkle root"},
+            {RPCResult::Type::ARR, "p2mr_dilithium_script_path_sigs", /*optional=*/ true, "",
+            {
+                {RPCResult::Type::OBJ, "", "",
+                {
+                    {RPCResult::Type::STR_HEX, "pubkey", "The Dilithium pubkey for this signature"},
+                    {RPCResult::Type::STR_HEX, "pubkey_hash", "The hash of that pubkey"},
+                    {RPCResult::Type::STR_HEX, "leaf_hash", "The leaf hash for this signature"},
+                    {RPCResult::Type::STR_HEX, "sig", "The signature itself"},
+                }},
+            }},
+            {RPCResult::Type::OBJ, "p2mr_dilithium", /*optional=*/ true, "Signing progress for a Dilithium P2MR input",
+            {
+                {RPCResult::Type::STR, "status", "One of unsigned, partially_signed, finalizable, finalized, unknown_leaf"},
+                {RPCResult::Type::STR, "policy", /*optional=*/ true, "The recognised Dilithium leaf template"},
+                {RPCResult::Type::STR_HEX, "leaf_hash", /*optional=*/ true, "The leaf being spent"},
+                {RPCResult::Type::NUM, "signatures", /*optional=*/ true, "Signatures collected so far"},
+                {RPCResult::Type::NUM, "required", /*optional=*/ true, "Signatures the leaf requires"},
+            }},
             {RPCResult::Type::OBJ_DYN, "unknown", /*optional=*/ true, "The unknown input fields",
             {
                 {RPCResult::Type::STR_HEX, "key", "(key-value pair) An unknown key-value pair"},
@@ -1325,6 +1360,66 @@ static RPCHelpMan decodepsbt()
         // Write taproot merkle root
         if (!input.m_tap_merkle_root.IsNull()) {
             in.pushKV("taproot_merkle_root", HexStr(input.m_tap_merkle_root));
+        }
+
+        // P2MR leaf scripts
+        if (!input.m_p2mr_scripts.empty()) {
+            UniValue p2mr_scripts(UniValue::VARR);
+            for (const auto& [leaf, control_blocks] : input.m_p2mr_scripts) {
+                const auto& [script, leaf_ver] = leaf;
+                UniValue script_info(UniValue::VOBJ);
+                script_info.pushKV("script", HexStr(script));
+                script_info.pushKV("leaf_ver", leaf_ver);
+                UniValue control_blocks_univ(UniValue::VARR);
+                for (const auto& control_block : control_blocks) {
+                    control_blocks_univ.push_back(HexStr(control_block));
+                }
+                script_info.pushKV("control_blocks", control_blocks_univ);
+                const P2MRDilithiumLeafPolicy policy = ParseP2MRDilithiumLeaf(CScript{script.begin(), script.end()});
+                if (policy.IsValid()) {
+                    script_info.pushKV("dilithium_policy", P2MRLeafTemplateName(policy.type));
+                    script_info.pushKV("dilithium_required", policy.m);
+                    script_info.pushKV("dilithium_total", policy.n());
+                }
+                p2mr_scripts.push_back(script_info);
+            }
+            in.pushKV("p2mr_scripts", p2mr_scripts);
+        }
+
+        // P2MR merkle root
+        if (!input.m_p2mr_merkle_root.IsNull()) {
+            in.pushKV("p2mr_merkle_root", HexStr(input.m_p2mr_merkle_root));
+        }
+
+        // P2MR Dilithium script path signatures
+        if (!input.m_p2mr_dilithium_script_sigs.empty()) {
+            UniValue script_sigs(UniValue::VARR);
+            for (const auto& [keyid_leaf, pubkey_sig] : input.m_p2mr_dilithium_script_sigs) {
+                const auto& [pubkey, sig] = pubkey_sig;
+                UniValue sigobj(UniValue::VOBJ);
+                sigobj.pushKV("pubkey", HexStr(pubkey));
+                sigobj.pushKV("pubkey_hash", HexStr(keyid_leaf.first));
+                sigobj.pushKV("leaf_hash", HexStr(keyid_leaf.second));
+                sigobj.pushKV("sig", HexStr(sig));
+                script_sigs.push_back(sigobj);
+            }
+            in.pushKV("p2mr_dilithium_script_path_sigs", script_sigs);
+        }
+
+        // Aggregate Dilithium/P2MR signing status for this input
+        {
+            const P2MRInputInfo info = InspectP2MRInput(psbtx, i);
+            if (info.status != P2MRInputStatus::NOT_P2MR) {
+                UniValue status(UniValue::VOBJ);
+                status.pushKV("status", P2MRInputStatusName(info.status));
+                if (info.policy.IsValid()) {
+                    status.pushKV("policy", P2MRLeafTemplateName(info.policy.type));
+                    status.pushKV("leaf_hash", HexStr(info.leaf_hash));
+                    status.pushKV("signatures", info.sigs_present);
+                    status.pushKV("required", info.sigs_required);
+                }
+                in.pushKV("p2mr_dilithium", status);
+            }
         }
 
         // Proprietary

--- a/src/script/dilithium_leaf.cpp
+++ b/src/script/dilithium_leaf.cpp
@@ -1,0 +1,179 @@
+// Copyright (c) 2026 The BTQ Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <script/dilithium_leaf.h>
+
+#include <script/script.h>
+#include <script/solver.h>
+#include <span.h>
+
+#include <algorithm>
+
+CScript GetScriptForDilithiumThreshold(int m, const std::vector<CDilithiumPubKey>& pubkeys)
+{
+    CScript script;
+    script << OP_0; // accumulator, parked on the alt stack between checks
+    for (const CDilithiumPubKey& pubkey : pubkeys) {
+        script << OP_TOALTSTACK;
+        script << ToByteVector(pubkey);
+        script << OP_CHECKSIGDILITHIUM;
+        script << OP_FROMALTSTACK << OP_ADD;
+    }
+    script << m << OP_GREATERTHANOREQUAL;
+    return script;
+}
+
+namespace {
+//! Decode a script number pushed by any valid encoding, minimal or not.
+std::optional<int> DecodePushedNumber(opcodetype opcode, const std::vector<unsigned char>& data)
+{
+    if (opcode == OP_0) return 0;
+    if (opcode >= OP_1 && opcode <= OP_16) return CScript::DecodeOP_N(opcode);
+    if (data.empty() || data.size() > 4) return std::nullopt;
+    try {
+        return static_cast<int>(CScriptNum(data, /*fRequireMinimal=*/false, 4).getint());
+    } catch (const scriptnum_error&) {
+        return std::nullopt;
+    }
+}
+
+bool ParseThresholdAccumulator(const CScript& script, P2MRDilithiumLeafPolicy& out)
+{
+    CScript::const_iterator it = script.begin();
+    opcodetype opcode;
+    std::vector<unsigned char> data;
+
+    if (!script.GetOp(it, opcode, data) || opcode != OP_0) return false;
+
+    std::vector<CDilithiumPubKey> pubkeys;
+    while (true) {
+        if (!script.GetOp(it, opcode, data)) return false;
+        // Anything other than another OP_TOALTSTACK ends the key loop; this
+        // opcode is then the threshold push.
+        if (opcode != OP_TOALTSTACK) break;
+
+        if (!script.GetOp(it, opcode, data) || data.size() != CDilithiumPubKey::SIZE) return false;
+        const CDilithiumPubKey pubkey{Span<const unsigned char>{data}};
+        if (!pubkey.IsFullyValid()) return false;
+        pubkeys.push_back(pubkey);
+        if (pubkeys.size() > MAX_PUBKEYS_PER_MULTISIG) return false;
+
+        if (!script.GetOp(it, opcode, data) || opcode != OP_CHECKSIGDILITHIUM) return false;
+        if (!script.GetOp(it, opcode, data) || opcode != OP_FROMALTSTACK) return false;
+        if (!script.GetOp(it, opcode, data) || opcode != OP_ADD) return false;
+    }
+
+    const std::optional<int> m = DecodePushedNumber(opcode, data);
+    if (!m) return false;
+    if (!script.GetOp(it, opcode, data) || opcode != OP_GREATERTHANOREQUAL) return false;
+    if (it != script.end()) return false;
+    if (pubkeys.empty() || *m < 1 || *m > static_cast<int>(pubkeys.size())) return false;
+
+    out.type = P2MRLeafTemplate::THRESHOLD_ACCUMULATOR;
+    out.m = *m;
+    out.pubkeys = std::move(pubkeys);
+    return true;
+}
+} // namespace
+
+P2MRDilithiumLeafPolicy ParseP2MRDilithiumLeaf(const CScript& script)
+{
+    P2MRDilithiumLeafPolicy policy;
+
+    std::vector<std::vector<unsigned char>> solutions;
+    switch (Solver(script, solutions)) {
+    case TxoutType::DILITHIUM_PUBKEY: {
+        const CDilithiumPubKey pubkey{Span<const unsigned char>{solutions[0]}};
+        if (!pubkey.IsFullyValid()) return policy;
+        policy.type = P2MRLeafTemplate::SINGLE_CHECKSIGDILITHIUM;
+        policy.m = 1;
+        policy.pubkeys = {pubkey};
+        return policy;
+    }
+    case TxoutType::DILITHIUM_MULTISIG: {
+        const int m = solutions.front()[0];
+        const int n = solutions.back()[0];
+        if (n < 1 || m < 1 || m > n || solutions.size() != static_cast<size_t>(n) + 2) return policy;
+        std::vector<CDilithiumPubKey> pubkeys;
+        for (int i = 1; i <= n; ++i) {
+            const CDilithiumPubKey pubkey{Span<const unsigned char>{solutions[i]}};
+            if (!pubkey.IsFullyValid()) return policy;
+            pubkeys.push_back(pubkey);
+        }
+        policy.type = P2MRLeafTemplate::CHECKMULTISIGDILITHIUM;
+        policy.m = m;
+        policy.pubkeys = std::move(pubkeys);
+        return policy;
+    }
+    default:
+        break;
+    }
+
+    ParseThresholdAccumulator(script, policy);
+    return policy;
+}
+
+std::string P2MRLeafTemplateName(P2MRLeafTemplate type)
+{
+    switch (type) {
+    case P2MRLeafTemplate::SINGLE_CHECKSIGDILITHIUM: return "dilithium_single";
+    case P2MRLeafTemplate::CHECKMULTISIGDILITHIUM: return "dilithium_checkmultisig";
+    case P2MRLeafTemplate::THRESHOLD_ACCUMULATOR: return "dilithium_threshold";
+    case P2MRLeafTemplate::UNKNOWN: return "unknown";
+    } // no default case, so the compiler can warn about missing cases
+    return "unknown";
+}
+
+std::optional<size_t> FindPolicyKeyIndex(const P2MRDilithiumLeafPolicy& policy, const CDilithiumPubKey& pubkey)
+{
+    const auto it = std::find(policy.pubkeys.begin(), policy.pubkeys.end(), pubkey);
+    if (it == policy.pubkeys.end()) return std::nullopt;
+    return static_cast<size_t>(std::distance(policy.pubkeys.begin(), it));
+}
+
+bool BuildDilithiumLeafWitness(const P2MRDilithiumLeafPolicy& policy,
+                               const std::vector<std::vector<unsigned char>>& sigs_by_key_index,
+                               std::vector<std::vector<unsigned char>>& stack_out)
+{
+    stack_out.clear();
+    if (!policy.IsValid()) return false;
+    if (sigs_by_key_index.size() != policy.pubkeys.size()) return false;
+
+    switch (policy.type) {
+    case P2MRLeafTemplate::SINGLE_CHECKSIGDILITHIUM:
+        if (sigs_by_key_index[0].empty()) return false;
+        stack_out.push_back(sigs_by_key_index[0]);
+        return true;
+
+    case P2MRLeafTemplate::CHECKMULTISIGDILITHIUM:
+        // OP_CHECKMULTISIGDILITHIUM keeps the CHECKMULTISIG off-by-one dummy and
+        // consumes exactly m signatures, in pubkey order.
+        stack_out.emplace_back();
+        for (const auto& sig : sigs_by_key_index) {
+            if (static_cast<int>(stack_out.size()) == policy.m + 1) break;
+            if (!sig.empty()) stack_out.push_back(sig);
+        }
+        if (static_cast<int>(stack_out.size()) != policy.m + 1) {
+            stack_out.clear();
+            return false;
+        }
+        return true;
+
+    case P2MRLeafTemplate::THRESHOLD_ACCUMULATOR: {
+        const auto signed_count = std::count_if(sigs_by_key_index.begin(), sigs_by_key_index.end(),
+                                                [](const auto& sig) { return !sig.empty(); });
+        if (signed_count < policy.m) return false;
+        // The leaf checks key 0 first, so slot 0 has to be on top of the stack.
+        for (size_t k = sigs_by_key_index.size(); k-- > 0;) {
+            stack_out.push_back(sigs_by_key_index[k]);
+        }
+        return true;
+    }
+
+    case P2MRLeafTemplate::UNKNOWN:
+        return false;
+    } // no default case, so the compiler can warn about missing cases
+
+    return false;
+}

--- a/src/script/dilithium_leaf.h
+++ b/src/script/dilithium_leaf.h
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 The BTQ Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BTQ_SCRIPT_DILITHIUM_LEAF_H
+#define BTQ_SCRIPT_DILITHIUM_LEAF_H
+
+#include <crypto/dilithium_key.h>
+#include <script/script.h>
+
+#include <cstddef>
+#include <optional>
+#include <string>
+#include <vector>
+
+/**
+ * Recognised shapes of a Dilithium tapscript leaf inside a P2MR tree.
+ *
+ * Dilithium opcodes are consensus-valid only under SigVersion::P2MR_TAPSCRIPT,
+ * so these templates describe leaves of a BIP360 P2MR Merkle tree, never a
+ * bare scriptPubKey.
+ */
+enum class P2MRLeafTemplate {
+    //! <pubkey> OP_CHECKSIGDILITHIUM
+    SINGLE_CHECKSIGDILITHIUM,
+    //! <m> <pubkey>... <n> OP_CHECKMULTISIGDILITHIUM
+    CHECKMULTISIGDILITHIUM,
+    //! Accumulator m-of-n, see GetScriptForDilithiumThreshold
+    THRESHOLD_ACCUMULATOR,
+    UNKNOWN,
+};
+
+/** Spending policy expressed by a Dilithium P2MR leaf. */
+struct P2MRDilithiumLeafPolicy {
+    P2MRLeafTemplate type{P2MRLeafTemplate::UNKNOWN};
+    //! Signatures required. 1 for a single-key leaf.
+    int m{0};
+    //! Public keys in script order; index 0 is evaluated first.
+    std::vector<CDilithiumPubKey> pubkeys;
+
+    int n() const { return static_cast<int>(pubkeys.size()); }
+    bool IsValid() const { return type != P2MRLeafTemplate::UNKNOWN; }
+};
+
+/**
+ * Build an m-of-n Dilithium threshold leaf.
+ *
+ * Unlike OP_CHECKMULTISIGDILITHIUM, this accumulator form lets a key that did
+ * not sign contribute an empty signature slot, so any m-sized subset of the n
+ * signers produces a valid witness. This is the form btq-multisig uses and the
+ * only one that supports partial signing across independent wallets.
+ *
+ *   OP_0
+ *   (OP_TOALTSTACK <pubkey> OP_CHECKSIGDILITHIUM OP_FROMALTSTACK OP_ADD) x n
+ *   <m> OP_GREATERTHANOREQUAL
+ */
+CScript GetScriptForDilithiumThreshold(int m, const std::vector<CDilithiumPubKey>& pubkeys);
+
+/** Classify a leaf script. Returns type UNKNOWN when nothing matches. */
+P2MRDilithiumLeafPolicy ParseP2MRDilithiumLeaf(const CScript& script);
+
+/** Stable RPC-facing name for a leaf template. */
+std::string P2MRLeafTemplateName(P2MRLeafTemplate type);
+
+/** Position of `pubkey` in the policy's script order, if it participates. */
+std::optional<size_t> FindPolicyKeyIndex(const P2MRDilithiumLeafPolicy& policy, const CDilithiumPubKey& pubkey);
+
+/**
+ * Assemble the signature portion of the witness stack for a leaf.
+ *
+ * `sigs_by_key_index` is parallel to policy.pubkeys; an empty entry means that
+ * key did not sign. On success `stack_out` holds the elements that go below the
+ * leaf script and control block, in push order (stack bottom first).
+ *
+ * Returns false when the available signatures cannot satisfy the policy.
+ */
+bool BuildDilithiumLeafWitness(const P2MRDilithiumLeafPolicy& policy,
+                               const std::vector<std::vector<unsigned char>>& sigs_by_key_index,
+                               std::vector<std::vector<unsigned char>>& stack_out);
+
+#endif // BTQ_SCRIPT_DILITHIUM_LEAF_H

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -2142,6 +2142,21 @@ uint256 ComputeTaprootMerkleRoot(Span<const unsigned char> control, const uint25
     return k;
 }
 
+uint256 ComputeP2MRMerkleRoot(Span<const unsigned char> control, const uint256& tapleaf_hash)
+{
+    assert(control.size() >= P2MR_CONTROL_BASE_SIZE);
+    assert(control.size() <= P2MR_CONTROL_MAX_SIZE);
+    assert((control.size() - P2MR_CONTROL_BASE_SIZE) % P2MR_CONTROL_NODE_SIZE == 0);
+
+    const int path_len = (control.size() - P2MR_CONTROL_BASE_SIZE) / P2MR_CONTROL_NODE_SIZE;
+    uint256 k = tapleaf_hash;
+    for (int i = 0; i < path_len; ++i) {
+        Span node{Span{control}.subspan(P2MR_CONTROL_BASE_SIZE + P2MR_CONTROL_NODE_SIZE * i, P2MR_CONTROL_NODE_SIZE)};
+        k = ComputeTapbranchHash(k, node);
+    }
+    return k;
+}
+
 static bool VerifyTaprootCommitment(const std::vector<unsigned char>& control, const std::vector<unsigned char>& program, const uint256& tapleaf_hash)
 {
     assert(control.size() >= TAPROOT_CONTROL_BASE_SIZE);
@@ -2163,13 +2178,7 @@ static bool VerifyP2MRCommitment(const std::vector<unsigned char>& control, cons
     assert(control.size() >= P2MR_CONTROL_BASE_SIZE);
     assert(program.size() >= uint256::size());
 
-    const int path_len = (control.size() - P2MR_CONTROL_BASE_SIZE) / P2MR_CONTROL_NODE_SIZE;
-    uint256 k = tapleaf_hash;
-    for (int i = 0; i < path_len; ++i) {
-        Span node{Span{control}.subspan(P2MR_CONTROL_BASE_SIZE + P2MR_CONTROL_NODE_SIZE * i, P2MR_CONTROL_NODE_SIZE)};
-        k = ComputeTapbranchHash(k, node);
-    }
-    return k == uint256(Span{program});
+    return ComputeP2MRMerkleRoot(control, tapleaf_hash) == uint256(Span{program});
 }
 
 static bool VerifyWitnessProgram(const CScriptWitness& witness, int witversion, const std::vector<unsigned char>& program, unsigned int flags, const BaseSignatureChecker& checker, ScriptError* serror, bool is_p2sh)

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -409,6 +409,10 @@ uint256 ComputeTapbranchHash(Span<const unsigned char> a, Span<const unsigned ch
 /** Compute the BIP341 taproot script tree Merkle root from control block and leaf hash.
  *  Requires control block to have valid length (33 + k*32, with k in {0,1,..,128}). */
 uint256 ComputeTaprootMerkleRoot(Span<const unsigned char> control, const uint256& tapleaf_hash);
+/** Compute the BIP360 P2MR script tree Merkle root from control block and leaf hash.
+ *  Unlike Taproot there is no internal key, so the root is the witness program itself.
+ *  Requires control block to have valid length (1 + k*32, with k in {0,1,..,128}). */
+uint256 ComputeP2MRMerkleRoot(Span<const unsigned char> control, const uint256& tapleaf_hash);
 
 bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& script, unsigned int flags, const BaseSignatureChecker& checker, SigVersion sigversion, ScriptExecutionData& execdata, ScriptError* error = nullptr);
 bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& script, unsigned int flags, const BaseSignatureChecker& checker, SigVersion sigversion, ScriptError* error = nullptr);

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -9,6 +9,7 @@
 #include <key.h>
 #include <policy/policy.h>
 #include <primitives/transaction.h>
+#include <script/dilithium_leaf.h>
 #include <script/keyorigin.h>
 #include <script/miniscript.h>
 #include <script/script.h>
@@ -403,6 +404,27 @@ struct TapSatisfier: Satisfier<XOnlyPubKey> {
 static bool SignStep(const SigningProvider& provider, const BaseSignatureCreator& creator, const CScript& scriptPubKey,
                      std::vector<valtype>& ret, TxoutType& whichTypeRet, SigVersion sigversion, SignatureData& sigdata, const uint256* leaf_hash = nullptr);
 
+/**
+ * Sign a threshold accumulator leaf, one empty-able slot per key.
+ *
+ * Every key is always attempted so that a signer contributes everything it can
+ * in one pass: signatures land in sigdata even when the threshold is not met
+ * yet, which is what lets a later signer finish the input.
+ */
+static bool SignDilithiumAccumulatorLeaf(const SigningProvider& provider, const BaseSignatureCreator& creator, SignatureData& sigdata,
+                                         const P2MRDilithiumLeafPolicy& policy, const CScript& script, const uint256& leaf_hash,
+                                         std::vector<valtype>& result)
+{
+    std::vector<std::vector<unsigned char>> sigs_by_key_index(policy.pubkeys.size());
+    for (size_t i = 0; i < policy.pubkeys.size(); ++i) {
+        std::vector<unsigned char> sig;
+        if (CreateDilithiumSig(creator, sigdata, provider, sig, policy.pubkeys[i], script, SigVersion::P2MR_TAPSCRIPT, &leaf_hash)) {
+            sigs_by_key_index[i] = std::move(sig);
+        }
+    }
+    return BuildDilithiumLeafWitness(policy, sigs_by_key_index, result);
+}
+
 static bool SignTaprootScript(const SigningProvider& provider, const BaseSignatureCreator& creator, SignatureData& sigdata, int leaf_version, Span<const unsigned char> script_bytes, SigVersion sigversion, std::vector<valtype>& result)
 {
     // Only BIP342 tapscript signing is supported for now.
@@ -419,6 +441,12 @@ static bool SignTaprootScript(const SigningProvider& provider, const BaseSignatu
     // permits those opcodes, so let the ordinary solver sign directly
     // recognized Dilithium leaf scripts such as <pubkey> OP_CHECKSIGDILITHIUM.
     if (sigversion == SigVersion::P2MR_TAPSCRIPT && result.empty()) {
+        // The threshold accumulator leaf is not a Solver-recognized template,
+        // because its per-key checks are spelled out opcode by opcode.
+        const P2MRDilithiumLeafPolicy policy = ParseP2MRDilithiumLeaf(script);
+        if (policy.type == P2MRLeafTemplate::THRESHOLD_ACCUMULATOR) {
+            return SignDilithiumAccumulatorLeaf(provider, creator, sigdata, policy, script, leaf_hash, result);
+        }
         TxoutType which_type;
         return SignStep(provider, creator, script, result, which_type, sigversion, sigdata, &leaf_hash);
     }

--- a/src/test/psbt_dilithium_tests.cpp
+++ b/src/test/psbt_dilithium_tests.cpp
@@ -1,0 +1,353 @@
+// Copyright (c) 2026 The BTQ Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <addresstype.h>
+#include <core_io.h>
+#include <crypto/dilithium_key.h>
+#include <key_io.h>
+#include <policy/policy.h>
+#include <primitives/transaction.h>
+#include <psbt.h>
+#include <psbt_dilithium.h>
+#include <script/dilithium_leaf.h>
+#include <script/interpreter.h>
+#include <script/script.h>
+#include <script/sign.h>
+#include <script/signingprovider.h>
+#include <test/util/setup_common.h>
+#include <util/strencodings.h>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(psbt_dilithium_tests, BasicTestingSetup)
+
+namespace {
+
+struct Signer {
+    CDilithiumKey key;
+    CDilithiumPubKey pubkey;
+};
+
+Signer MakeSigner()
+{
+    Signer s;
+    s.key.MakeNewKey();
+    s.pubkey = s.key.GetPubKey();
+    return s;
+}
+
+/** A funded 1-in 1-out spend of a single-leaf P2MR output, as a PSBT. */
+struct Fixture {
+    std::vector<Signer> signers;
+    CScript leaf_script;
+    P2MRBuilder builder;
+    WitnessV2P2MR output;
+    CTxOut prevout;
+    PartiallySignedTransaction psbt;
+    FlatSigningProvider full_provider; //!< holds every private key
+
+    FlatSigningProvider ProviderFor(const std::vector<size_t>& key_indexes) const
+    {
+        FlatSigningProvider provider;
+        provider.p2mr_trees = full_provider.p2mr_trees;
+        for (size_t i : key_indexes) {
+            const DilithiumPKHash id(signers[i].pubkey);
+            provider.dilithium_pubkeys.emplace(id, signers[i].pubkey);
+            provider.dilithium_keys.emplace(id, signers[i].key);
+        }
+        return provider;
+    }
+};
+
+Fixture MakeFixture(const CScript& leaf_script, std::vector<Signer> signers)
+{
+    Fixture f;
+    f.signers = std::move(signers);
+    f.leaf_script = leaf_script;
+
+    f.builder.Add(0, leaf_script, TAPROOT_LEAF_TAPSCRIPT);
+    f.builder.Finalize();
+    BOOST_REQUIRE(f.builder.IsComplete());
+    f.output = f.builder.GetOutput();
+
+    f.prevout.nValue = 100000;
+    f.prevout.scriptPubKey = GetScriptForDestination(f.output);
+
+    CMutableTransaction tx;
+    tx.nVersion = 2;
+    tx.vin.emplace_back(COutPoint{uint256{1}, 0});
+    tx.vout.emplace_back(90000, CScript() << OP_TRUE);
+
+    f.psbt = PartiallySignedTransaction{tx};
+    f.psbt.inputs[0].witness_utxo = f.prevout;
+
+    f.full_provider.p2mr_trees[f.output] = f.builder;
+    for (const Signer& s : f.signers) {
+        const DilithiumPKHash id(s.pubkey);
+        f.full_provider.dilithium_pubkeys.emplace(id, s.pubkey);
+        f.full_provider.dilithium_keys.emplace(id, s.key);
+    }
+    return f;
+}
+
+std::string Roundtrip(PartiallySignedTransaction& psbt)
+{
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << psbt;
+    const std::string encoded = EncodeBase64(MakeUCharSpan(ss));
+    PartiallySignedTransaction decoded;
+    std::string error;
+    BOOST_REQUIRE_MESSAGE(DecodeBase64PSBT(decoded, encoded, error), error);
+    psbt = decoded;
+    return encoded;
+}
+
+bool WitnessVerifies(const Fixture& f, const PartiallySignedTransaction& psbt)
+{
+    PartiallySignedTransaction copy = psbt;
+    CMutableTransaction result;
+    if (!FinalizeAndExtractPSBT(copy, result)) return false;
+
+    PrecomputedTransactionData txdata;
+    txdata.Init(result, {f.prevout}, /*force=*/true);
+    const CTransaction tx{result};
+    TransactionSignatureChecker checker(&tx, 0, f.prevout.nValue, txdata, MissingDataBehavior::FAIL);
+    return VerifyScript(result.vin[0].scriptSig, f.prevout.scriptPubKey, &result.vin[0].scriptWitness,
+                        STANDARD_SCRIPT_VERIFY_FLAGS | SCRIPT_VERIFY_DILITHIUM, checker);
+}
+
+} // namespace
+
+BOOST_AUTO_TEST_CASE(threshold_leaf_roundtrips_through_the_parser)
+{
+    std::vector<CDilithiumPubKey> pubkeys;
+    for (int i = 0; i < 3; ++i) pubkeys.push_back(MakeSigner().pubkey);
+
+    const CScript script = GetScriptForDilithiumThreshold(2, pubkeys);
+    const P2MRDilithiumLeafPolicy policy = ParseP2MRDilithiumLeaf(script);
+
+    BOOST_CHECK(policy.type == P2MRLeafTemplate::THRESHOLD_ACCUMULATOR);
+    BOOST_CHECK_EQUAL(policy.m, 2);
+    BOOST_CHECK_EQUAL(policy.n(), 3);
+    BOOST_CHECK(policy.pubkeys == pubkeys);
+    for (size_t i = 0; i < pubkeys.size(); ++i) {
+        BOOST_CHECK_EQUAL(FindPolicyKeyIndex(policy, pubkeys[i]).value(), i);
+    }
+    BOOST_CHECK(!FindPolicyKeyIndex(policy, MakeSigner().pubkey).has_value());
+}
+
+BOOST_AUTO_TEST_CASE(single_key_leaf_is_recognised)
+{
+    const CDilithiumPubKey pubkey = MakeSigner().pubkey;
+    CScript script;
+    script << ToByteVector(pubkey) << OP_CHECKSIGDILITHIUM;
+
+    const P2MRDilithiumLeafPolicy policy = ParseP2MRDilithiumLeaf(script);
+    BOOST_CHECK(policy.type == P2MRLeafTemplate::SINGLE_CHECKSIGDILITHIUM);
+    BOOST_CHECK_EQUAL(policy.m, 1);
+    BOOST_CHECK_EQUAL(policy.n(), 1);
+}
+
+BOOST_AUTO_TEST_CASE(unknown_leaves_are_not_misparsed)
+{
+    BOOST_CHECK(!ParseP2MRDilithiumLeaf(CScript() << OP_TRUE).IsValid());
+    // A truncated accumulator (missing the final threshold comparison).
+    const CDilithiumPubKey pubkey = MakeSigner().pubkey;
+    CScript truncated;
+    truncated << OP_0 << OP_TOALTSTACK << ToByteVector(pubkey) << OP_CHECKSIGDILITHIUM << OP_FROMALTSTACK << OP_ADD;
+    BOOST_CHECK(!ParseP2MRDilithiumLeaf(truncated).IsValid());
+}
+
+BOOST_AUTO_TEST_CASE(threshold_witness_puts_the_first_key_on_top)
+{
+    std::vector<CDilithiumPubKey> pubkeys;
+    for (int i = 0; i < 3; ++i) pubkeys.push_back(MakeSigner().pubkey);
+    const P2MRDilithiumLeafPolicy policy = ParseP2MRDilithiumLeaf(GetScriptForDilithiumThreshold(2, pubkeys));
+
+    // Keys 0 and 2 signed; key 1 did not.
+    const std::vector<std::vector<unsigned char>> sigs{{0xaa}, {}, {0xcc}};
+    std::vector<std::vector<unsigned char>> stack;
+    BOOST_REQUIRE(BuildDilithiumLeafWitness(policy, sigs, stack));
+
+    // The leaf checks key 0 first and OP_CHECKSIGDILITHIUM consumes from the
+    // top, so the stack is pushed in reverse key order.
+    BOOST_REQUIRE_EQUAL(stack.size(), 3U);
+    BOOST_CHECK(stack[0] == std::vector<unsigned char>{0xcc});
+    BOOST_CHECK(stack[1].empty());
+    BOOST_CHECK(stack[2] == std::vector<unsigned char>{0xaa});
+
+    // One signature is not enough for a 2-of-3.
+    std::vector<std::vector<unsigned char>> too_few_stack;
+    BOOST_CHECK(!BuildDilithiumLeafWitness(policy, {{0xaa}, {}, {}}, too_few_stack));
+    BOOST_CHECK(too_few_stack.empty());
+}
+
+BOOST_AUTO_TEST_CASE(single_key_psbt_survives_serialization)
+{
+    const Signer signer = MakeSigner();
+    CScript leaf;
+    leaf << ToByteVector(signer.pubkey) << OP_CHECKSIGDILITHIUM;
+    Fixture f = MakeFixture(leaf, {signer});
+
+    // Sign without finalizing, so the PSBT has to carry the Dilithium material.
+    const PrecomputedTransactionData txdata = PrecomputePSBTData(f.psbt);
+    BOOST_CHECK(!SignPSBTInput(f.ProviderFor({}), f.psbt, 0, &txdata, SIGHASH_ALL, nullptr, /*finalize=*/false));
+    BOOST_CHECK(SignPSBTInput(f.full_provider, f.psbt, 0, &txdata, SIGHASH_ALL, nullptr, /*finalize=*/false));
+
+    BOOST_CHECK_EQUAL(f.psbt.inputs[0].m_p2mr_scripts.size(), 1U);
+    BOOST_CHECK_EQUAL(f.psbt.inputs[0].m_p2mr_dilithium_script_sigs.size(), 1U);
+    BOOST_CHECK(f.psbt.inputs[0].m_p2mr_merkle_root == f.builder.GetSpendData().merkle_root);
+
+    PartiallySignedTransaction before = f.psbt;
+    Roundtrip(f.psbt);
+    BOOST_CHECK(f.psbt.inputs[0].m_p2mr_scripts == before.inputs[0].m_p2mr_scripts);
+    BOOST_CHECK(f.psbt.inputs[0].m_p2mr_dilithium_script_sigs == before.inputs[0].m_p2mr_dilithium_script_sigs);
+    BOOST_CHECK(f.psbt.inputs[0].m_p2mr_merkle_root == before.inputs[0].m_p2mr_merkle_root);
+
+    // A wallet with no keys at all can finalize what the PSBT already carries.
+    BOOST_CHECK(WitnessVerifies(f, f.psbt));
+}
+
+BOOST_AUTO_TEST_CASE(threshold_psbt_accumulates_signatures_across_providers)
+{
+    std::vector<Signer> signers{MakeSigner(), MakeSigner(), MakeSigner()};
+    std::vector<CDilithiumPubKey> pubkeys;
+    for (const Signer& s : signers) pubkeys.push_back(s.pubkey);
+    Fixture f = MakeFixture(GetScriptForDilithiumThreshold(2, pubkeys), signers);
+
+    const PrecomputedTransactionData txdata = PrecomputePSBTData(f.psbt);
+
+    // Signer 0 alone cannot satisfy a 2-of-3, but must still leave its
+    // signature behind for the next signer.
+    PartiallySignedTransaction first = f.psbt;
+    BOOST_CHECK(!SignPSBTInput(f.ProviderFor({0}), first, 0, &txdata, SIGHASH_ALL, nullptr, /*finalize=*/false));
+    BOOST_CHECK_EQUAL(first.inputs[0].m_p2mr_dilithium_script_sigs.size(), 1U);
+    BOOST_CHECK_EQUAL(InspectP2MRInput(first, 0).sigs_present, 1);
+    BOOST_CHECK(InspectP2MRInput(first, 0).status == P2MRInputStatus::PARTIALLY_SIGNED);
+    Roundtrip(first);
+
+    // Signer 2 works from the serialized PSBT and never sees signer 0's key.
+    PartiallySignedTransaction second = f.psbt;
+    BOOST_CHECK(!SignPSBTInput(f.ProviderFor({2}), second, 0, &txdata, SIGHASH_ALL, nullptr, /*finalize=*/false));
+    Roundtrip(second);
+
+    PartiallySignedTransaction combined = first;
+    BOOST_REQUIRE(combined.Merge(second));
+    BOOST_CHECK_EQUAL(combined.inputs[0].m_p2mr_dilithium_script_sigs.size(), 2U);
+
+    const P2MRInputInfo info = InspectP2MRInput(combined, 0);
+    BOOST_CHECK(info.status == P2MRInputStatus::FINALIZABLE);
+    BOOST_CHECK_EQUAL(info.sigs_present, 2);
+    BOOST_CHECK_EQUAL(info.sigs_required, 2);
+
+    BOOST_CHECK(WitnessVerifies(f, combined));
+}
+
+BOOST_AUTO_TEST_CASE(finalized_input_drops_the_bulky_signing_material)
+{
+    const Signer signer = MakeSigner();
+    CScript leaf;
+    leaf << ToByteVector(signer.pubkey) << OP_CHECKSIGDILITHIUM;
+    Fixture f = MakeFixture(leaf, {signer});
+
+    const PrecomputedTransactionData txdata = PrecomputePSBTData(f.psbt);
+    BOOST_REQUIRE(SignPSBTInput(f.full_provider, f.psbt, 0, &txdata, SIGHASH_ALL, nullptr, /*finalize=*/true));
+
+    BOOST_CHECK(!f.psbt.inputs[0].final_script_witness.IsNull());
+    BOOST_CHECK(f.psbt.inputs[0].m_p2mr_scripts.empty());
+    BOOST_CHECK(f.psbt.inputs[0].m_p2mr_dilithium_script_sigs.empty());
+    BOOST_CHECK(f.psbt.inputs[0].m_p2mr_merkle_root.IsNull());
+    BOOST_CHECK(InspectP2MRInput(f.psbt, 0).status == P2MRInputStatus::FINALIZED);
+}
+
+BOOST_AUTO_TEST_CASE(a_forged_signature_is_rejected_on_decode)
+{
+    const Signer signer = MakeSigner();
+    CScript leaf;
+    leaf << ToByteVector(signer.pubkey) << OP_CHECKSIGDILITHIUM;
+    Fixture f = MakeFixture(leaf, {signer});
+
+    const PrecomputedTransactionData txdata = PrecomputePSBTData(f.psbt);
+    BOOST_REQUIRE(SignPSBTInput(f.full_provider, f.psbt, 0, &txdata, SIGHASH_ALL, nullptr, /*finalize=*/false));
+
+    auto& entry = *f.psbt.inputs[0].m_p2mr_dilithium_script_sigs.begin();
+    std::vector<unsigned char> sig = entry.second.second;
+    sig[100] ^= 0xff;
+    f.psbt.inputs[0].m_p2mr_dilithium_script_sigs[entry.first].second = sig;
+
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << f.psbt;
+    PartiallySignedTransaction decoded;
+    std::string error;
+    BOOST_CHECK(!DecodeRawPSBT(decoded, MakeByteSpan(ss), error));
+    BOOST_CHECK_MESSAGE(error.find("signature") != std::string::npos, error);
+}
+
+BOOST_AUTO_TEST_CASE(a_leaf_not_committed_to_by_the_output_is_rejected)
+{
+    const Signer signer = MakeSigner();
+    CScript leaf;
+    leaf << ToByteVector(signer.pubkey) << OP_CHECKSIGDILITHIUM;
+    Fixture f = MakeFixture(leaf, {signer});
+
+    // Advertise a leaf that is not in the tree the output commits to.
+    CScript foreign_leaf;
+    foreign_leaf << ToByteVector(MakeSigner().pubkey) << OP_CHECKSIGDILITHIUM;
+    const auto spenddata = f.builder.GetSpendData();
+    const auto& control_blocks = spenddata.scripts.begin()->second;
+    f.psbt.inputs[0].m_p2mr_scripts[{std::vector<unsigned char>(foreign_leaf.begin(), foreign_leaf.end()), TAPROOT_LEAF_TAPSCRIPT}] = control_blocks;
+
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << f.psbt;
+    PartiallySignedTransaction decoded;
+    std::string error;
+    BOOST_CHECK(!DecodeRawPSBT(decoded, MakeByteSpan(ss), error));
+    BOOST_CHECK_MESSAGE(error.find("commit") != std::string::npos, error);
+}
+
+BOOST_AUTO_TEST_CASE(a_merkle_root_disagreeing_with_the_output_is_rejected)
+{
+    const Signer signer = MakeSigner();
+    CScript leaf;
+    leaf << ToByteVector(signer.pubkey) << OP_CHECKSIGDILITHIUM;
+    Fixture f = MakeFixture(leaf, {signer});
+
+    f.psbt.inputs[0].m_p2mr_merkle_root = uint256{42};
+
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << f.psbt;
+    PartiallySignedTransaction decoded;
+    std::string error;
+    BOOST_CHECK(!DecodeRawPSBT(decoded, MakeByteSpan(ss), error));
+    BOOST_CHECK_MESSAGE(error.find("merkle root") != std::string::npos, error);
+}
+
+BOOST_AUTO_TEST_CASE(duplicate_wire_keys_are_rejected)
+{
+    const Signer signer = MakeSigner();
+    CScript leaf;
+    leaf << ToByteVector(signer.pubkey) << OP_CHECKSIGDILITHIUM;
+    Fixture f = MakeFixture(leaf, {signer});
+
+    const PrecomputedTransactionData txdata = PrecomputePSBTData(f.psbt);
+    BOOST_REQUIRE(SignPSBTInput(f.full_provider, f.psbt, 0, &txdata, SIGHASH_ALL, nullptr, /*finalize=*/false));
+
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << f.psbt;
+    std::vector<unsigned char> bytes{MakeUCharSpan(ss).begin(), MakeUCharSpan(ss).end()};
+
+    // Locate the merkle root record (0x01 0x1a, then a 32-byte value) and
+    // duplicate it in place.
+    const std::vector<unsigned char> record{0x01, PSBT_IN_P2MR_MERKLE_ROOT, 0x20};
+    const auto it = std::search(bytes.begin(), bytes.end(), record.begin(), record.end());
+    BOOST_REQUIRE(it != bytes.end());
+    bytes.insert(it + record.size() + 32, it, it + record.size() + 32);
+
+    PartiallySignedTransaction decoded;
+    std::string error;
+    BOOST_CHECK(!DecodeRawPSBT(decoded, MakeByteSpan(bytes), error));
+    BOOST_CHECK_MESSAGE(error.find("Duplicate Key") != std::string::npos, error);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/psbt_dilithium_tests.cpp
+++ b/src/test/psbt_dilithium_tests.cpp
@@ -350,4 +350,50 @@ BOOST_AUTO_TEST_CASE(duplicate_wire_keys_are_rejected)
     BOOST_CHECK_MESSAGE(error.find("Duplicate Key") != std::string::npos, error);
 }
 
+// The PSBT parse cap on control blocks must be the consensus cap, not an
+// independent value. Anything smaller would leave outputs that are spendable
+// on-chain but unspendable through a PSBT.
+BOOST_AUTO_TEST_CASE(control_blocks_up_to_the_consensus_limit_round_trip)
+{
+    for (const int depth : {1, 16, 17, 32, (int)P2MR_CONTROL_MAX_NODE_COUNT}) {
+        // A degenerate tree, so the first leaf sits at `depth` and therefore
+        // carries a merkle path of `depth` nodes.
+        P2MRBuilder builder;
+        builder.Add(depth, CScript() << OP_1, TAPROOT_LEAF_TAPSCRIPT);
+        builder.Add(depth, CScript() << OP_2, TAPROOT_LEAF_TAPSCRIPT);
+        for (int d = depth - 1; d >= 1; --d) {
+            builder.Add(d, CScript() << OP_1 << d << OP_EQUAL, TAPROOT_LEAF_TAPSCRIPT);
+        }
+        builder.Finalize();
+        BOOST_REQUIRE_MESSAGE(builder.IsComplete(), "tree incomplete at depth " << depth);
+
+        const P2MRSpendData spenddata = builder.GetSpendData();
+        size_t widest = 0;
+        for (const auto& [leaf, controls] : spenddata.scripts) {
+            for (const auto& control : controls) widest = std::max(widest, control.size());
+        }
+        BOOST_CHECK_EQUAL(widest, P2MR_CONTROL_BASE_SIZE + P2MR_CONTROL_NODE_SIZE * depth);
+
+        CMutableTransaction tx;
+        tx.nVersion = 2;
+        tx.vin.emplace_back(COutPoint{uint256{1}, 0});
+        tx.vout.emplace_back(90000, CScript() << OP_TRUE);
+
+        PartiallySignedTransaction psbt{tx};
+        CTxOut prevout;
+        prevout.nValue = 100000;
+        prevout.scriptPubKey = GetScriptForDestination(builder.GetOutput());
+        psbt.inputs[0].witness_utxo = prevout;
+        psbt.inputs[0].m_p2mr_merkle_root = spenddata.merkle_root;
+        for (const auto& [leaf, controls] : spenddata.scripts) {
+            psbt.inputs[0].m_p2mr_scripts[leaf] = controls;
+        }
+
+        const PartiallySignedTransaction before = psbt;
+        Roundtrip(psbt);
+        BOOST_CHECK_MESSAGE(psbt.inputs[0].m_p2mr_scripts == before.inputs[0].m_p2mr_scripts,
+                            "control blocks lost at depth " << depth);
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/p2mr.cpp
+++ b/src/wallet/p2mr.cpp
@@ -13,6 +13,7 @@
 #include <rpc/protocol.h>
 #include <rpc/request.h>
 #include <rpc/util.h>
+#include <script/dilithium_leaf.h>
 #include <script/interpreter.h>
 #include <script/script.h>
 #include <script/sign.h>
@@ -32,6 +33,19 @@
 #include <set>
 
 namespace wallet {
+
+bool WalletHaveDilithiumKey(const CWallet& wallet, const CKeyID& keyid)
+{
+    for (ScriptPubKeyMan* spk_man : wallet.GetAllScriptPubKeyMans()) {
+        if (auto desc_spk_man = dynamic_cast<DescriptorScriptPubKeyMan*>(spk_man)) {
+            LOCK(desc_spk_man->cs_desc_man);
+            if (desc_spk_man->HaveDilithiumKey(keyid)) return true;
+        } else if (auto legacy_spk_man = dynamic_cast<LegacyScriptPubKeyMan*>(spk_man)) {
+            if (legacy_spk_man->HaveDilithiumKey(keyid)) return true;
+        }
+    }
+    return false;
+}
 
 namespace {
 constexpr const char* P2MR_STATE_CREATED{"created"};
@@ -132,8 +146,16 @@ std::set<CKeyID> GetP2MRDilithiumKeyIDs(const std::vector<P2MRTreeLeaf>& leaves)
                 AddDilithiumKeyIDFromPubKey(pubkey, key_ids);
             }
             break;
-        default:
+        default: {
+            // Threshold accumulator leaves spell out their key checks opcode by
+            // opcode, so Solver does not recognize them as a template.
+            const P2MRDilithiumLeafPolicy policy = ParseP2MRDilithiumLeaf(script);
+            if (policy.type != P2MRLeafTemplate::THRESHOLD_ACCUMULATOR) break;
+            for (const CDilithiumPubKey& pubkey : policy.pubkeys) {
+                AddDilithiumKeyIDFromPubKey(pubkey, key_ids);
+            }
             break;
+        }
         }
     }
     return key_ids;
@@ -168,19 +190,6 @@ P2MRKeyRequirements GetP2MRKeyRequirements(const std::vector<P2MRTreeLeaf>& leav
         AddP2MRXOnlyKeys(CScript{leaf.script.begin(), leaf.script.end()}, out.xonly_pubkeys);
     }
     return out;
-}
-
-bool WalletHaveDilithiumKey(const CWallet& wallet, const CKeyID& keyid)
-{
-    for (ScriptPubKeyMan* spk_man : wallet.GetAllScriptPubKeyMans()) {
-        if (auto desc_spk_man = dynamic_cast<DescriptorScriptPubKeyMan*>(spk_man)) {
-            LOCK(desc_spk_man->cs_desc_man);
-            if (desc_spk_man->HaveDilithiumKey(keyid)) return true;
-        } else if (auto legacy_spk_man = dynamic_cast<LegacyScriptPubKeyMan*>(spk_man)) {
-            if (legacy_spk_man->HaveDilithiumKey(keyid)) return true;
-        }
-    }
-    return false;
 }
 
 bool WalletHaveXOnlyKey(const CWallet& wallet, const XOnlyPubKey& pubkey)

--- a/src/wallet/p2mr.h
+++ b/src/wallet/p2mr.h
@@ -133,6 +133,9 @@ std::optional<P2MREntry> GetP2MRByDestination(const CWallet& wallet, const CTxDe
  */
 std::optional<CKeyID> GetSingleDilithiumKeyIDForP2MR(const CWallet& wallet, const CTxDestination& dest);
 
+/** Whether any ScriptPubKeyMan in the wallet holds this Dilithium private key. */
+bool WalletHaveDilithiumKey(const CWallet& wallet, const CKeyID& keyid);
+
 /** Create and persist a new P2MR destination.
  *  Pass add_to_address_book=false for change destinations: an address book
  *  entry is what makes CWallet::IsChange treat an output as a receive. */

--- a/src/wallet/rpc/dilithium.cpp
+++ b/src/wallet/rpc/dilithium.cpp
@@ -12,6 +12,7 @@
 #include <wallet/walletdb.h>
 #include <crypto/dilithium_key.h>
 #include <key_io.h>
+#include <script/dilithium_leaf.h>
 #include <script/script.h>
 #include <script/solver.h>
 #include <script/sign.h>
@@ -380,6 +381,169 @@ RPCHelpMan verifymessagewithdilithium()
                                           /*strSignature=*/request.params[1].get_str(),
                                           /*strMessage=*/request.params[2].get_str(),
                                           "verifymessagewithdilithium \"address\" \"signature\" \"message\"");
+        },
+    };
+}
+
+RPCHelpMan getdilithiumpubkey()
+{
+    return RPCHelpMan{"getdilithiumpubkey",
+        "\nReturn the Dilithium public keys named by a wallet P2MR destination.\n"
+        "Share the pubkey of a single-key destination with your co-signers to build\n"
+        "a multisig with createdilithiummultisig.\n",
+        {
+            {"p2mr_id", RPCArg::Type::STR, RPCArg::Optional::NO, "P2MR metadata id, as returned by getnewdilithiumaddress"},
+        },
+        RPCResult{
+            RPCResult::Type::OBJ, "", "",
+            {
+                {RPCResult::Type::STR, "address", "The P2MR address"},
+                {RPCResult::Type::ARR, "pubkeys", "Dilithium public keys in leaf order",
+                {
+                    {RPCResult::Type::OBJ, "", "",
+                    {
+                        {RPCResult::Type::STR_HEX, "pubkey", "The Dilithium public key"},
+                        {RPCResult::Type::BOOL, "ismine", "Whether this wallet holds the private key"},
+                    }},
+                }},
+            }
+        },
+        RPCExamples{HelpExampleCli("getdilithiumpubkey", "\"abcd1234\"")},
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+        {
+            std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
+            if (!wallet) return UniValue::VNULL;
+
+            LOCK(wallet->cs_wallet);
+            auto entry = GetP2MR(*wallet, request.params[0].get_str());
+            if (!entry) throw JSONRPCError(RPC_INVALID_PARAMETER, "unknown p2mr_id");
+
+            UniValue pubkeys(UniValue::VARR);
+            for (const P2MRTreeLeaf& leaf : entry->tree) {
+                const CScript script{leaf.script.begin(), leaf.script.end()};
+                const P2MRDilithiumLeafPolicy policy = ParseP2MRDilithiumLeaf(script);
+                for (const CDilithiumPubKey& pubkey : policy.pubkeys) {
+                    CKeyID keyid;
+                    const uint160 id = pubkey.GetID();
+                    std::copy(id.begin(), id.end(), keyid.begin());
+                    UniValue obj(UniValue::VOBJ);
+                    obj.pushKV("pubkey", HexStr(pubkey));
+                    obj.pushKV("ismine", WalletHaveDilithiumKey(*wallet, keyid));
+                    pubkeys.push_back(std::move(obj));
+                }
+            }
+            if (pubkeys.empty()) {
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "destination names no Dilithium public keys");
+            }
+
+            UniValue result(UniValue::VOBJ);
+            result.pushKV("address", entry->address);
+            result.pushKV("pubkeys", std::move(pubkeys));
+            return result;
+        },
+    };
+}
+
+RPCHelpMan createdilithiummultisig()
+{
+    return RPCHelpMan{"createdilithiummultisig",
+        "\nRegister an m-of-n Dilithium multisig P2MR destination in this wallet.\n"
+        "\nEvery co-signer must call this with the same m and the same pubkey list in the\n"
+        "same order; they then all derive the same address. Funds sent to it are spent by\n"
+        "passing a PSBT between the co-signers with walletprocesspsbt until m signatures\n"
+        "have accumulated.\n",
+        {
+            {"nrequired", RPCArg::Type::NUM, RPCArg::Optional::NO, "Number of signatures required"},
+            {"pubkeys", RPCArg::Type::ARR, RPCArg::Optional::NO, "Dilithium public keys, hex encoded",
+                {
+                    {"pubkey", RPCArg::Type::STR_HEX, RPCArg::Optional::OMITTED, "A Dilithium public key"},
+                },
+            },
+            {"label", RPCArg::Type::STR, RPCArg::Default{""}, "Optional label"},
+        },
+        RPCResult{
+            RPCResult::Type::OBJ, "", "",
+            {
+                {RPCResult::Type::STR, "address", "The multisig P2MR address"},
+                {RPCResult::Type::STR, "p2mr_id", "Wallet-local P2MR metadata id"},
+                {RPCResult::Type::STR_HEX, "scriptPubKey", "P2MR scriptPubKey"},
+                {RPCResult::Type::STR_HEX, "merkle_root", "P2MR merkle root"},
+                {RPCResult::Type::STR_HEX, "leaf_script", "The Dilithium threshold leaf script"},
+                {RPCResult::Type::NUM, "signers_available", "How many of the n keys this wallet can sign with"},
+            }
+        },
+        RPCExamples{
+            HelpExampleCli("createdilithiummultisig", "2 '[\"pubkeyhex1\",\"pubkeyhex2\",\"pubkeyhex3\"]'")
+            + HelpExampleRpc("createdilithiummultisig", "2, [\"pubkeyhex1\",\"pubkeyhex2\",\"pubkeyhex3\"]")
+        },
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+        {
+            std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
+            if (!wallet) return UniValue::VNULL;
+
+            const int required = request.params[0].getInt<int>();
+            const UniValue& keys = request.params[1].get_array();
+            const std::string label = request.params[2].isNull() ? "" : LabelFromValue(request.params[2]);
+
+            if (keys.empty()) {
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "pubkeys must not be empty");
+            }
+            if (keys.size() > MAX_PUBKEYS_PER_MULTISIG) {
+                throw JSONRPCError(RPC_INVALID_PARAMETER,
+                    strprintf("Number of keys involved in the multisignature address creation > %d", MAX_PUBKEYS_PER_MULTISIG));
+            }
+            if (required < 1 || required > (int)keys.size()) {
+                throw JSONRPCError(RPC_INVALID_PARAMETER,
+                    strprintf("wrong number of keys, nrequired must be between 1 and %d", (int)keys.size()));
+            }
+
+            std::vector<CDilithiumPubKey> pubkeys;
+            for (size_t i = 0; i < keys.size(); ++i) {
+                const auto bytes = TryParseHex<unsigned char>(keys[i].get_str());
+                if (!bytes || bytes->size() != CDilithiumPubKey::SIZE) {
+                    throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY,
+                        strprintf("pubkey %d is not a %d-byte hex Dilithium public key", (int)i, (int)CDilithiumPubKey::SIZE));
+                }
+                const CDilithiumPubKey pubkey{*bytes};
+                if (!pubkey.IsFullyValid()) {
+                    throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, strprintf("pubkey %d is not a valid Dilithium public key", (int)i));
+                }
+                // Duplicates would silently lower the effective threshold, since
+                // one private key could then fill several accumulator slots.
+                if (std::find(pubkeys.begin(), pubkeys.end(), pubkey) != pubkeys.end()) {
+                    throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("pubkey %d is a duplicate", (int)i));
+                }
+                pubkeys.push_back(pubkey);
+            }
+
+            const CScript leaf_script = GetScriptForDilithiumThreshold(required, pubkeys);
+            P2MRTreeLeaf leaf;
+            leaf.depth = 0;
+            leaf.leaf_version = TAPROOT_LEAF_TAPSCRIPT;
+            leaf.script.assign(leaf_script.begin(), leaf_script.end());
+
+            LOCK(wallet->cs_wallet);
+            auto created = CreateP2MR(*wallet, {leaf}, label);
+            if (!created) {
+                throw JSONRPCError(RPC_WALLET_ERROR, util::ErrorString(created).original);
+            }
+
+            int available = 0;
+            for (const CDilithiumPubKey& pubkey : pubkeys) {
+                CKeyID keyid;
+                const uint160 id = pubkey.GetID();
+                std::copy(id.begin(), id.end(), keyid.begin());
+                if (WalletHaveDilithiumKey(*wallet, keyid)) ++available;
+            }
+
+            UniValue result(UniValue::VOBJ);
+            result.pushKV("address", created->address);
+            result.pushKV("p2mr_id", created->id);
+            result.pushKV("scriptPubKey", HexStr(created->script_pub_key));
+            result.pushKV("merkle_root", HexStr(created->merkle_root));
+            result.pushKV("leaf_script", HexStr(leaf_script));
+            result.pushKV("signers_available", available);
+            return result;
         },
     };
 }

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -877,6 +877,8 @@ RPCHelpMan verifymessagewithdilithium();
 // dilithium
 RPCHelpMan getnewdilithiumaddress();
 RPCHelpMan importdilithiumkey();
+RPCHelpMan getdilithiumpubkey();
+RPCHelpMan createdilithiummultisig();
 RPCHelpMan signtransactionwithdilithium();
 
 // p2mr
@@ -962,6 +964,8 @@ Span<const CRPCCommand> GetWalletRPCCommands()
         {"wallet", &verifymessagewithdilithium},
         {"wallet", &getnewdilithiumaddress},
         {"wallet", &importdilithiumkey},
+        {"wallet", &getdilithiumpubkey},
+        {"wallet", &createdilithiummultisig},
         {"wallet", &signtransactionwithdilithium},
         {"wallet", &getnewp2mraddress},
         {"wallet", &sendtop2mr},

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -133,6 +133,7 @@ BASE_SCRIPTS = [
     'wallet_dilithium_change.py --descriptors',
     'wallet_dilithium_signmessage.py --descriptors',
     'wallet_dilithium_psbt.py --descriptors',
+    'wallet_dilithium_psbt_multisig.py --descriptors',
     'wallet_bumpfee.py --legacy-wallet',
     'wallet_bumpfee.py --descriptors',
     'wallet_import_rescan.py --legacy-wallet',

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -134,6 +134,7 @@ BASE_SCRIPTS = [
     'wallet_dilithium_signmessage.py --descriptors',
     'wallet_dilithium_psbt.py --descriptors',
     'wallet_dilithium_psbt_multisig.py --descriptors',
+    'tool_dilithium_psbt.py --descriptors',
     'wallet_bumpfee.py --legacy-wallet',
     'wallet_bumpfee.py --descriptors',
     'wallet_import_rescan.py --legacy-wallet',

--- a/test/functional/tool_dilithium_psbt.py
+++ b/test/functional/tool_dilithium_psbt.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The BTQ Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Drive a 2-of-3 Dilithium P2MR spend through contrib/btq/dilithium-psbt.sh.
+
+The Python functional tests already cover the RPCs. This file exists so the
+documented CLI wrapper cannot drift from those RPCs unnoticed: it creates
+three wallets, registers the same 2-of-3, and spends via the script's
+create / sign / combine / finalize commands, never calling those RPCs itself.
+"""
+
+import json
+import os
+import subprocess
+
+from decimal import Decimal
+
+from test_framework.test_framework import BTQTestFramework
+from test_framework.util import assert_equal
+
+
+class ToolDilithiumPSBTTest(BTQTestFramework):
+    def add_options(self, parser):
+        self.add_wallet_options(parser, descriptors=True, legacy=False)
+
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_cli()
+        self.skip_if_no_wallet()
+
+    def script_cmd(self, *args, stdin=None):
+        script = os.path.join(self.config["environment"]["SRCDIR"], "contrib", "btq", "dilithium-psbt.sh")
+        cli = f"{self.nodes[0].cli.binary} -datadir={self.nodes[0].cli.datadir}"
+        cmd = [script, f"--cli={cli}", *args]
+        self.log.debug(" ".join(cmd))
+        return subprocess.run(
+            cmd,
+            check=True,
+            capture_output=True,
+            text=True,
+            input=stdin,
+        )
+
+    def run_test(self):
+        node = self.nodes[0]
+        node.createwallet(wallet_name="funding", descriptors=True)
+        funding = node.get_wallet_rpc("funding")
+        self.generatetoaddress(node, 110, funding.getnewaddress())
+
+        for name in ("alice", "bob", "carol"):
+            node.createwallet(wallet_name=name, descriptors=True)
+
+        self.log.info("pubkey publishes one Dilithium key per wallet")
+        keys = []
+        for name in ("alice", "bob", "carol"):
+            out = json.loads(self.script_cmd("pubkey", name).stdout)
+            assert_equal(out["wallet"], name)
+            assert_equal(out["ismine"], True)
+            assert_equal(len(out["pubkey"]), 2624)  # 1312-byte key, hex
+            keys.append(out["pubkey"])
+
+        self.log.info("every co-signer registers the same 2-of-3")
+        addresses = []
+        for name in ("alice", "bob", "carol"):
+            out = json.loads(self.script_cmd("register", name, "2", *keys).stdout)
+            assert_equal(out["signers_available"], 1)
+            addresses.append(out["address"])
+        assert_equal(len(set(addresses)), 1)
+        address = addresses[0]
+
+        self.log.info("fund the multisig and build an unsigned PSBT")
+        funding.sendtoaddress(address, Decimal("10"))
+        self.generate(node, 1)
+        utxo = next(u for u in node.get_wallet_rpc("alice").listunspent() if u["address"] == address)
+        dest = funding.getnewaddress()
+        unsigned = self.script_cmd(
+            "create", "alice", f"{utxo['txid']}:{utxo['vout']}", dest, "4",
+        ).stdout.strip()
+        status = json.loads(self.script_cmd("status", unsigned).stdout)
+        assert_equal(status["status"], "unsigned")
+        assert_equal(status["signatures"], 0)
+        assert_equal(status["required"], 2)
+
+        self.log.info("alice and carol sign independently, then combine")
+        alice_psbt = self.script_cmd("sign", "alice", unsigned).stdout.strip()
+        carol_psbt = self.script_cmd("sign", "carol", unsigned).stdout.strip()
+        assert_equal(json.loads(self.script_cmd("status", alice_psbt).stdout)["signatures"], 1)
+        combined = self.script_cmd("combine", alice_psbt, carol_psbt).stdout.strip()
+        combined_status = json.loads(self.script_cmd("status", combined).stdout)
+        assert_equal(combined_status["status"], "finalizable")
+        assert_equal(combined_status["signatures"], 2)
+
+        self.log.info("finalize, broadcast, confirm")
+        raw = self.script_cmd("finalize", combined).stdout.strip()
+        txid = self.script_cmd("broadcast", raw).stdout.strip()
+        self.generate(node, 1)
+        assert_equal(node.get_wallet_rpc("alice").gettransaction(txid)["confirmations"], 1)
+
+        self.log.info("one signature is not enough to finalize")
+        funding.sendtoaddress(address, Decimal("6"))
+        self.generate(node, 1)
+        utxo2 = next(
+            u for u in node.get_wallet_rpc("alice").listunspent()
+            if u["address"] == address and u["amount"] == Decimal("6")
+        )
+        unsigned2 = self.script_cmd(
+            "create", "alice", f"{utxo2['txid']}:{utxo2['vout']}", dest, "2",
+        ).stdout.strip()
+        once = self.script_cmd("sign", "alice", unsigned2).stdout.strip()
+        proc = subprocess.run(
+            [
+                os.path.join(self.config["environment"]["SRCDIR"], "contrib", "btq", "dilithium-psbt.sh"),
+                f"--cli={self.nodes[0].cli.binary} -datadir={self.nodes[0].cli.datadir}",
+                "finalize",
+                once,
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert_equal(proc.returncode, 2)
+        assert "not complete" in proc.stderr
+
+
+if __name__ == "__main__":
+    ToolDilithiumPSBTTest().main()

--- a/test/functional/wallet_dilithium_psbt_multisig.py
+++ b/test/functional/wallet_dilithium_psbt_multisig.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The BTQ Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""End-to-end test of the BTQ-PSBT Dilithium extension.
+
+Before this extension a PSBT could not carry Dilithium material at all: the P2MR
+leaf script, its control block and any Dilithium signature were dropped on
+serialization, so a partially signed transaction could not be handed to another
+wallet. The single-wallet cases in wallet_dilithium_psbt.py passed only because
+signing and finalizing happened inside one process.
+
+Here each co-signer is a separate wallet that only ever sees base64 PSBTs.
+"""
+
+import base64
+from decimal import Decimal
+
+from test_framework.test_framework import BTQTestFramework
+from test_framework.util import assert_equal, assert_greater_than, assert_raises_rpc_error
+
+
+class WalletDilithiumPSBTMultisigTest(BTQTestFramework):
+    def add_options(self, parser):
+        self.add_wallet_options(parser, descriptors=True, legacy=False)
+
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def make_signer(self, name):
+        """A wallet holding exactly one Dilithium key, plus that key's pubkey."""
+        self.nodes[0].createwallet(wallet_name=name, descriptors=True)
+        wallet = self.nodes[0].get_wallet_rpc(name)
+        created = wallet.getnewdilithiumaddress()
+        keys = wallet.getdilithiumpubkey(created["p2mr_id"])["pubkeys"]
+        assert_equal(len(keys), 1)
+        assert_equal(keys[0]["ismine"], True)
+        return wallet, keys[0]["pubkey"]
+
+    def input_status(self, wallet, psbt):
+        decoded = wallet.decodepsbt(psbt)
+        return decoded["inputs"][0]["p2mr_dilithium"]
+
+    def run_test(self):
+        node = self.nodes[0]
+
+        node.createwallet(wallet_name="funding", descriptors=True)
+        funding = node.get_wallet_rpc("funding")
+        self.generatetoaddress(node, 110, funding.getnewaddress())
+
+        alice, alice_pk = self.make_signer("alice")
+        bob, bob_pk = self.make_signer("bob")
+        carol, carol_pk = self.make_signer("carol")
+        pubkeys = [alice_pk, bob_pk, carol_pk]
+
+        self.log.info("all three co-signers derive the same 2-of-3 address")
+        registered = [w.createdilithiummultisig(2, pubkeys, "shared") for w in (alice, bob, carol)]
+        address = registered[0]["address"]
+        for reg in registered:
+            assert_equal(reg["address"], address)
+            assert_equal(reg["scriptPubKey"], registered[0]["scriptPubKey"])
+            assert_equal(reg["leaf_script"], registered[0]["leaf_script"])
+            # Each co-signer holds exactly one of the three keys.
+            assert_equal(reg["signers_available"], 1)
+        assert registered[0]["scriptPubKey"].startswith("5220"), registered[0]["scriptPubKey"]
+
+        self.log.info("fund the multisig")
+        funding.sendtoaddress(address, Decimal("10"))
+        self.generate(node, 1)
+        utxo = next(u for u in alice.listunspent() if u["address"] == address)
+
+        destination = funding.getnewaddress()
+        psbt = alice.walletcreatefundedpsbt(
+            [{"txid": utxo["txid"], "vout": utxo["vout"]}],
+            [{destination: Decimal("4")}],
+        )["psbt"]
+
+        self.log.info("an unsigned PSBT already advertises the leaf and its policy")
+        decoded = alice.decodepsbt(psbt)
+        leaf = decoded["inputs"][0]["p2mr_scripts"][0]
+        assert_equal(leaf["script"], registered[0]["leaf_script"])
+        assert_equal(leaf["leaf_ver"], 192)
+        assert_equal(leaf["dilithium_policy"], "dilithium_threshold")
+        assert_equal(leaf["dilithium_required"], 2)
+        assert_equal(leaf["dilithium_total"], 3)
+        assert_equal(decoded["inputs"][0]["p2mr_merkle_root"], registered[0]["merkle_root"])
+        assert_equal(self.input_status(alice, psbt)["status"], "unsigned")
+
+        self.log.info("alice signs; the PSBT survives serialization with one signature")
+        half = alice.walletprocesspsbt(psbt)
+        assert_equal(half["complete"], False)
+        status = self.input_status(bob, half["psbt"])
+        assert_equal(status["status"], "partially_signed")
+        assert_equal(status["signatures"], 1)
+        assert_equal(status["required"], 2)
+        sigs = bob.decodepsbt(half["psbt"])["inputs"][0]["p2mr_dilithium_script_path_sigs"]
+        assert_equal([s["pubkey"] for s in sigs], [alice_pk])
+        # 2420-byte Dilithium signature plus the sighash byte.
+        assert_equal(len(sigs[0]["sig"]), 2 * 2421)
+
+        self.log.info("carol signs the same PSBT independently of bob")
+        carol_half = carol.walletprocesspsbt(psbt)
+        assert_equal(carol_half["complete"], False)
+        assert_equal(self.input_status(carol, carol_half["psbt"])["signatures"], 1)
+
+        self.log.info("combinepsbt merges two independent partial signatures")
+        combined = node.combinepsbt([half["psbt"], carol_half["psbt"]])
+        status = self.input_status(alice, combined)
+        assert_equal(status["signatures"], 2)
+        assert_equal(status["status"], "finalizable")
+
+        self.log.info("finalizepsbt turns the collected signatures into a witness")
+        final = node.finalizepsbt(combined)
+        assert_equal(final["complete"], True)
+        assert_equal(node.testmempoolaccept([final["hex"]])[0]["allowed"], True)
+
+        txid = node.sendrawtransaction(final["hex"])
+        self.generate(node, 1)
+        assert_equal(alice.gettransaction(txid)["confirmations"], 1)
+
+        self.log.info("sequential signing (alice then bob) also completes")
+        funding.sendtoaddress(address, Decimal("6"))
+        self.generate(node, 1)
+        utxo2 = next(u for u in alice.listunspent() if u["address"] == address and u["amount"] == Decimal("6"))
+        psbt2 = alice.walletcreatefundedpsbt(
+            [{"txid": utxo2["txid"], "vout": utxo2["vout"]}],
+            [{destination: Decimal("2")}],
+        )["psbt"]
+        step1 = alice.walletprocesspsbt(psbt2)
+        assert_equal(step1["complete"], False)
+        step2 = bob.walletprocesspsbt(step1["psbt"])
+        assert_equal(step2["complete"], True)
+        assert_equal(self.input_status(bob, step2["psbt"])["status"], "finalized")
+        final2 = node.finalizepsbt(step2["psbt"])
+        txid2 = node.sendrawtransaction(final2["hex"])
+        self.generate(node, 1)
+        assert_equal(alice.gettransaction(txid2)["confirmations"], 1)
+
+        self.log.info("re-signing with a key that already signed does not add a signature")
+        funding.sendtoaddress(address, Decimal("3"))
+        self.generate(node, 1)
+        utxo3 = next(u for u in alice.listunspent() if u["address"] == address and u["amount"] == Decimal("3"))
+        psbt3 = alice.walletcreatefundedpsbt(
+            [{"txid": utxo3["txid"], "vout": utxo3["vout"]}],
+            [{destination: Decimal("1")}],
+        )["psbt"]
+        once = alice.walletprocesspsbt(psbt3)["psbt"]
+        twice = alice.walletprocesspsbt(once)["psbt"]
+        assert_equal(self.input_status(alice, twice)["signatures"], 1)
+        # One signature short of the threshold must not finalize.
+        under_threshold = node.finalizepsbt(twice, False)
+        assert_equal(under_threshold["complete"], False)
+        assert "hex" not in under_threshold
+
+        self.log.info("a forged signature is rejected when the PSBT is decoded")
+        # `once` still carries alice's signature; a completed PSBT would have
+        # replaced it with a final witness.
+        assert_greater_than(len(once), 0)
+        tampered = self.corrupt_first_signature(node, once)
+        assert_raises_rpc_error(-22, "signature", node.decodepsbt, tampered)
+        assert_raises_rpc_error(-22, "signature", node.finalizepsbt, tampered)
+
+    def corrupt_first_signature(self, node, psbt_b64):
+        """Flip a byte inside the first Dilithium signature value."""
+        raw = bytearray(base64.b64decode(psbt_b64))
+        sig = bytes.fromhex(node.decodepsbt(psbt_b64)["inputs"][0]["p2mr_dilithium_script_path_sigs"][0]["sig"])
+        offset = raw.find(sig)
+        assert offset != -1, "signature not found in PSBT bytes"
+        raw[offset + 100] ^= 0xFF
+        return base64.b64encode(bytes(raw)).decode()
+
+
+if __name__ == "__main__":
+    WalletDilithiumPSBTMultisigTest().main()


### PR DESCRIPTION
## Summary
- A PSBT can now carry the P2MR leaf, control block and Dilithium partial signatures between wallets, so a 2-of-3 no longer needs the `.btqms` workaround. Fail-closed parse: a forged signature is rejected when the PSBT is read, not when it is broadcast.
- `createdilithiummultisig` / `getdilithiumpubkey` plus the existing `walletcreatefundedpsbt` → `walletprocesspsbt` → `combinepsbt` → `finalizepsbt` flow are the RPCs. `doc/psbt.md` has the copy-paste `btq-cli` recipe; `contrib/btq/dilithium-psbt.sh` wraps it so the ~16 KB payload stays in a file.
- Parse cap on control blocks is the consensus limit (`P2MR_CONTROL_MAX_SIZE`), not 513 bytes, so a deep leaf that is spendable on-chain is also spendable through a PSBT.

Fixes #85.

## Test plan
- [ ] `src/test/test_btq --run_test=psbt_dilithium_tests`
- [ ] `test/functional/wallet_dilithium_psbt.py`
- [ ] `test/functional/wallet_dilithium_psbt_multisig.py`
- [ ] `test/functional/tool_dilithium_psbt.py`
- [ ] Follow `doc/psbt.md` “Dilithium P2MR” against a regtest node using only `btq-cli`
- [ ] `decodepsbt` on a 1-of-2 signed PSBT shows `status: partially_signed` and `signatures: 1`; a flipped byte in the signature is rejected at decode