### PR TITLE
doc: point leftover hosts at owned domains

### DIFF
--- a/contrib/guix/README.md
+++ b/contrib/guix/README.md
@@ -106,11 +106,11 @@ worktree to save disk space:
 ## Attesting to build outputs
 
 Much like how Gitian build outputs are attested to in a `gitian.sigs`
-repository, Guix build outputs are attested to in the [`guix.sigs`
-repository](https://github.com/btq-core/guix.sigs).
+repository, Guix build outputs are attested to in a `guix.sigs` repository.
+The intended home is `btq-ag/guix.sigs` (**TBD** — not published yet).
 
-After you've cloned the `guix.sigs` repository, to attest to the current
-worktree's commit/tag:
+Once that repository exists, clone it and attest to the current worktree's
+commit/tag:
 
 ```
 env GUIX_SIGS_REPO=<path/to/guix.sigs> SIGNER=<gpg-key-name> ./contrib/guix/guix-attest
@@ -121,8 +121,8 @@ See `./contrib/guix/guix-attest --help` for more information on the various ways
 
 ## Verifying build output attestations
 
-After at least one other signer has uploaded their signatures to the `guix.sigs`
-repository:
+Once `btq-ag/guix.sigs` exists and at least one other signer has uploaded
+their signatures:
 
 ```
 git -C <path/to/guix.sigs> pull

--- a/doc-btq/SECURITY.md
+++ b/doc-btq/SECURITY.md
@@ -2,13 +2,14 @@
 
 ## Supported Versions
 
-We provide security updates for the following BTQ versions:
+BTQ Core has not launched mainnet. Releases are tagged `vX.Y.Z-testnet`.
+Only the most recent release line receives security fixes.
 
-| Version | Supported          | End of Life |
-| ------- | ------------------ | ----------- |
-| 1.1.x   | ✅ Current         | TBD         |
-| 1.0.x   | ✅ Maintenance     | 2025-12-31  |
-| 0.1.x   | ⚠️ Critical only   | 2024-12-31  |
+| Version | Supported |
+| ------- | --------- |
+| `v0.4.4-testnet` | Current |
+| `v0.4.3-testnet` | Tag only; binaries were not published |
+| earlier `-testnet` | No |
 
 ## Reporting a Vulnerability
 

--- a/doc-btq/SECURITY.md
+++ b/doc-btq/SECURITY.md
@@ -7,7 +7,7 @@ Only the most recent release line receives security fixes.
 
 | Version | Supported |
 | ------- | --------- |
-| `v0.4.4-testnet` | Current |
+| `v0.5.0-testnet` | Current |
 | `v0.4.3-testnet` | Tag only; binaries were not published |
 | earlier `-testnet` | No |
 

--- a/doc/man/btq-cli.1
+++ b/doc/man/btq-cli.1
@@ -173,7 +173,7 @@ Use the test chain. Equivalent to \fB\-chain\fR=\fI\,test\/\fR.
 Copyright (C) 2009-2023 The BTQ Core developers
 
 Please contribute if you find BTQ Core useful. Visit
-<https://btqcore.org/> for further information about the software.
+<https://bitcoinquantum.com/> for further information about the software.
 The source code is available from <https://github.com/btq/btq>.
 
 This is experimental software.

--- a/doc/man/btq-qt.1
+++ b/doc/man/btq-qt.1
@@ -814,7 +814,7 @@ Show splash screen on startup (default: 1)
 Copyright (C) 2009-2023 The BTQ Core developers
 
 Please contribute if you find BTQ Core useful. Visit
-<https://btqcore.org/> for further information about the software.
+<https://bitcoinquantum.com/> for further information about the software.
 The source code is available from <https://github.com/btq/btq>.
 
 This is experimental software.

--- a/doc/man/btq-tx.1
+++ b/doc/man/btq-tx.1
@@ -137,7 +137,7 @@ Set register NAME to given JSON\-STRING
 Copyright (C) 2009-2023 The BTQ Core developers
 
 Please contribute if you find BTQ Core useful. Visit
-<https://btqcore.org/> for further information about the software.
+<https://bitcoinquantum.com/> for further information about the software.
 The source code is available from <https://github.com/btq/btq>.
 
 This is experimental software.

--- a/doc/man/btq-util.1
+++ b/doc/man/btq-util.1
@@ -57,7 +57,7 @@ Perform proof of work on hex header string
 Copyright (C) 2009-2023 The BTQ Core developers
 
 Please contribute if you find BTQ Core useful. Visit
-<https://btqcore.org/> for further information about the software.
+<https://bitcoinquantum.com/> for further information about the software.
 The source code is available from <https://github.com/btq/btq>.
 
 This is experimental software.

--- a/doc/man/btq-wallet.1
+++ b/doc/man/btq-wallet.1
@@ -113,7 +113,7 @@ Attempt to recover private keys from a corrupt wallet. Warning:
 Copyright (C) 2009-2023 The BTQ Core developers
 
 Please contribute if you find BTQ Core useful. Visit
-<https://btqcore.org/> for further information about the software.
+<https://bitcoinquantum.com/> for further information about the software.
 The source code is available from <https://github.com/btq/btq>.
 
 This is experimental software.

--- a/doc/man/btqd.1
+++ b/doc/man/btqd.1
@@ -792,7 +792,7 @@ Accept command line and JSON\-RPC commands
 Copyright (C) 2009-2023 The BTQ Core developers
 
 Please contribute if you find BTQ Core useful. Visit
-<https://btqcore.org/> for further information about the software.
+<https://bitcoinquantum.com/> for further information about the software.
 The source code is available from <https://github.com/btq/btq>.
 
 This is experimental software.


### PR DESCRIPTION
## What

Point leftover inherited download/attest hosts at properties BTQ owns, and replace the fictional support table.

## Why

#158 deleted `verify-binaries` after it fetched sums from domains we do not own. Two leftovers remain:

- Man pages still send people to `btqcore.org`.
- `contrib/guix/README.md` linked `github.com/btq-core/guix.sigs`, which 404s.

`doc-btq/SECURITY.md` still listed 1.1.x / 1.0.x / 0.1.x as supported. Those lines do not exist; tags are `vX.Y.Z-testnet`. Root `SECURITY.md` already says only the latest testnet line is supported.

This is a slice of #145 (unowned hosts and a true support table). It does not add `SHA256SUMS` or stand up `guix.sigs`.

## Approach

- Man pages: `btqcore.org` → `bitcoinquantum.com`.
- Guix README: name `btq-ag/guix.sigs` as the intended attestation repo and mark it **TBD** until it exists. No link to a 404.
- `doc-btq/SECURITY.md`: table of actual tags (`v0.4.4-testnet` current; `v0.4.3-testnet` tag only; earlier unsupported).

Refs #145

## Testing

Docs only. No unit or functional tests.

## Risks

Low. No consensus, wallet, or release-artifact change.