### PR TITLE
test: cover LWMA vs the 144-block anti-DoS floor

### DIFF
--- a/contrib/btq/lwma-antidos-note.md
+++ b/contrib/btq/lwma-antidos-note.md
@@ -1,0 +1,74 @@
+# LWMA and the 144-block anti-DoS work threshold
+
+Characterization note for [GitHub issue #168](https://github.com/btq-ag/btq-core/issues/168).
+No consensus or net_processing change is proposed here.
+
+## What `GetAntiDoSWorkThreshold` does
+
+`PeerManagerImpl::GetAntiDoSWorkThreshold` in `src/net_processing.cpp`
+computes:
+
+```
+near = tip.nChainWork - min(144 * GetBlockProof(tip), tip.nChainWork)
+threshold = max(near, MinimumChainWork())
+```
+
+Incoming headers (and compact-block / block paths that consult the same
+helper) with total chain work below that threshold are treated as a
+low-work DoS candidate (`TryLowWorkHeadersSync` and the compact-block
+guard). The 144-block buffer is so near-tip forks are still accepted.
+
+## Why Bitcoin is fine
+
+Bitcoin retargets every 2016 blocks. Across a 144-block window difficulty
+barely moves, so two honest forks of similar length stay near equal
+per-block work (`r ≈ 1`). For any fork length `H > 144`,
+`1 > (H - 144) / H`, so same-length peers stay above the threshold.
+
+## Why BTQ is not
+
+BTQ uses per-block LWMA with `nPowTargetSpacing = 60s`. Two branches can
+diverge by orders of magnitude. A public-testnet observation was roughly
+difficulty ~40 vs ~7800 (`r ≈ 0.005`). Activation heights
+(`nLWMAHeight` in `src/kernel/chainparams.cpp`): mainnet = 1;
+testnet/regtest = 300000.
+
+## The ignore inequality
+
+A same-length fork is ignored when
+
+```
+D2 / D1 < (H1 - 144) / H2
+```
+
+Worked numbers for `H1 = H2 = 450`:
+
+- crossover: `r < 306 / 450 ≈ 0.68`
+- observed testnet shape: `r ≈ 40 / 7800 ≈ 0.005` (far below)
+
+Each side's tip-relative threshold can then treat the other as low-work.
+Unit coverage of this arithmetic lives in
+`src/test/pow_lwma_tests.cpp` (`antidos_work_threshold_lwma_divergence`).
+
+## Mainnet genesis implications
+
+Mainnet launches with `nLWMAHeight = 1` (LWMA from the first block) and
+`powLimit` `00000377ae…`. `nMinimumChainWork` is nonzero
+(`0x49d414` = `GetBlockProof(genesis)` at `nBits 0x1e0377ae`). On
+testnet/regtest `nMinimumChainWork` is zero, so `max()` does not provide
+a floor and the 144-block tip-relative term dominates once the chain is
+taller than 144 blocks. Early on mainnet (`height < 144`)
+`near_chaintip_work` is 0 and the floor is one genesis-block of work —
+still not a defense against a long low-diff fork after height 144.
+
+## Regtest limitation
+
+`CRegTestParams` sets `fPowNoRetargeting = true` and
+`nLWMAHeight = 300000`. Regtest cannot reproduce live LWMA difficulty
+swings. Characterization is the formula unit test above, not a P2P
+functional test.
+
+## Next step
+
+Measure before changing the 144-block buffer. This note does not
+recommend a specific new constant or any consensus change.

--- a/src/test/pow_lwma_tests.cpp
+++ b/src/test/pow_lwma_tests.cpp
@@ -642,4 +642,135 @@ BOOST_AUTO_TEST_CASE(lwma_window_departure_cost_to_honest_miners)
     }
 }
 
+namespace {
+
+// Must match PeerManagerImpl::GetAntiDoSWorkThreshold in net_processing.cpp.
+// Intentionally not tied to nLWMAWindow even though both happen to be 144.
+constexpr unsigned ANTIDOS_WORK_BUFFER_BLOCKS = 144;
+
+//! Local replica of PeerManagerImpl::GetAntiDoSWorkThreshold arithmetic
+//! (minus LOCK / ChainstateManager). Used to characterize issue #168 without
+//! friending PeerManagerImpl or driving P2P.
+arith_uint256 ReplicatedAntiDoSWorkThreshold(const CBlockIndex* tip,
+                                            const arith_uint256& minimum_chain_work)
+{
+    arith_uint256 near_chaintip_work = 0;
+    if (tip != nullptr) {
+        near_chaintip_work = tip->nChainWork
+            - std::min<arith_uint256>(ANTIDOS_WORK_BUFFER_BLOCKS * GetBlockProof(*tip), tip->nChainWork);
+    }
+    return std::max(near_chaintip_work, minimum_chain_work);
+}
+
+} // namespace
+
+//! Characterizes GetAntiDoSWorkThreshold under LWMA difficulty divergence
+//! (GitHub issue #168). A same-length fork is ignored as low-work when
+//!     D2/D1 < (H1 - 144) / H2
+//! For H1 = H2 = 450 that crossover is r < 306/450 ≈ 0.68. Upstream Bitcoin
+//! stays near r ≈ 1 across a 144-block window; BTQ per-block LWMA at 60s can
+//! produce r ≈ 0.005 (~40 vs ~7800 on testnet). Regtest cannot reproduce
+//! live swings (fPowNoRetargeting, nLWMAHeight = 300000); this test only
+//! exercises the tip-relative formula with synthetic arith_uint256 work.
+BOOST_AUTO_TEST_CASE(antidos_work_threshold_lwma_divergence)
+{
+    CBlockIndex local_stub;
+    local_stub.nBits = 0x1c00ffff; // mid-range compact; proof is large, ratio is stable
+    const arith_uint256 d_local = GetBlockProof(local_stub);
+
+    arith_uint256 local_target;
+    local_target.SetCompact(local_stub.nBits);
+    arith_uint256 peer_target = local_target * 200; // ~200x easier
+    const uint32_t peer_low_bits = peer_target.GetCompact();
+    CBlockIndex peer_stub;
+    peer_stub.nBits = peer_low_bits;
+    const arith_uint256 d_peer = GetBlockProof(peer_stub);
+
+    // Realized ratio r = d_peer / d_local ≈ 0.005 (integer bounds, no floats).
+    BOOST_CHECK(d_local / d_peer >= 150); // r <= 1/150 ≈ 0.0067
+    BOOST_CHECK(d_local / d_peer <= 250); // r >= 1/250 = 0.004
+
+    const arith_uint256 min_work_zero{0};
+
+    // 1. Fork length <= 144: the buffer absorbs a near-tip lower-diff fork.
+    // Shared prefix of 1000 blocks (not a tip-at-genesis construction, which
+    // would make near_chaintip_work = 0 and trivialize the assert).
+    {
+        const arith_uint256 local_work = d_local * 1144; // 1000 prefix + 144 local
+        const arith_uint256 peer_work = d_local * 1000 + d_peer * 144;
+
+        CBlockIndex tip;
+        tip.nBits = local_stub.nBits;
+        tip.nChainWork = local_work;
+        const arith_uint256 threshold = ReplicatedAntiDoSWorkThreshold(&tip, min_work_zero);
+
+        // threshold = 1144*d_local - 144*d_local = 1000*d_local
+        BOOST_CHECK(threshold == d_local * 1000);
+        BOOST_CHECK(peer_work >= threshold);
+        // Peer is strictly weaker per block; without the buffer, peer_work <
+        // local_work and would look like a low-work attack.
+        BOOST_CHECK(144 * d_peer < 144 * d_local);
+        BOOST_CHECK(peer_work < local_work);
+    }
+
+    // 2. Fork length 450, r ≈ 0.005 (issue #168 shape): peer below threshold.
+    // Crossover for H1=H2=450 is r < 306/450 ≈ 0.68; observed r ≈ 0.005 << 0.68.
+    {
+        const arith_uint256 local_work = d_local * 450;
+        const arith_uint256 peer_work = d_peer * 450;
+
+        CBlockIndex tip;
+        tip.nBits = local_stub.nBits;
+        tip.nChainWork = local_work;
+        const arith_uint256 threshold = ReplicatedAntiDoSWorkThreshold(&tip, min_work_zero);
+
+        // threshold = (450 - 144) * d_local = 306 * d_local
+        BOOST_CHECK(threshold == d_local * 306);
+        BOOST_CHECK(peer_work < threshold);
+    }
+
+    // 3. Fork length 450, r ≈ 1.0 (Bitcoin-like equal difficulty): peer above.
+    {
+        const arith_uint256 local_work = d_local * 450;
+        const arith_uint256 peer_work = d_local * 450;
+
+        CBlockIndex tip;
+        tip.nBits = local_stub.nBits;
+        tip.nChainWork = local_work;
+        const arith_uint256 threshold = ReplicatedAntiDoSWorkThreshold(&tip, min_work_zero);
+
+        BOOST_CHECK(threshold == d_local * 306);
+        BOOST_CHECK(peer_work >= threshold);
+    }
+
+    // 4. nMinimumChainWork = 0 (testnet/regtest): max() does not floor the
+    // tip-relative term. Reuse the #168 shape; also check chainparams floors.
+    {
+        const arith_uint256 local_work = d_local * 450;
+        const arith_uint256 peer_work = d_peer * 450;
+        const arith_uint256 near_chaintip_work = local_work - std::min<arith_uint256>(
+            ANTIDOS_WORK_BUFFER_BLOCKS * d_local, local_work);
+
+        CBlockIndex tip;
+        tip.nBits = local_stub.nBits;
+        tip.nChainWork = local_work;
+        const arith_uint256 threshold = ReplicatedAntiDoSWorkThreshold(&tip, min_work_zero);
+
+        BOOST_CHECK(threshold == near_chaintip_work); // max(near, 0) == near
+        BOOST_CHECK(peer_work < threshold);
+
+        // lwma_activation_height_configured already checks nLWMAHeight
+        // (mainnet=1, testnet=300000). Here only the MinimumChainWork floor.
+        const auto testnet = CreateChainParams(*m_node.args, ChainType::BTQTEST);
+        const auto regtest = CreateChainParams(*m_node.args, ChainType::BTQREGTEST);
+        const auto mainnet = CreateChainParams(*m_node.args, ChainType::BTQMAIN);
+        BOOST_CHECK(testnet->GetConsensus().nMinimumChainWork == uint256{});
+        BOOST_CHECK(regtest->GetConsensus().nMinimumChainWork == uint256{});
+        // 0x49d414 = GetBlockProof(genesis) at nBits 0x1e0377ae (chainparams.cpp).
+        BOOST_CHECK(mainnet->GetConsensus().nMinimumChainWork ==
+                    uint256S("000000000000000000000000000000000000000000000000000000000049d414"));
+        BOOST_CHECK(mainnet->GetConsensus().nMinimumChainWork != uint256{});
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## What

Add a unit test of `GetAntiDoSWorkThreshold`'s tip-relative formula and a short note. No consensus or `net_processing` change.

## Why

Issue #168 reports a public-testnet split: a shorter, heavier LWMA branch and the longer low-diff branch each treat the other as a low-work DoS. Bitcoin's 144-block buffer assumes competing tips have similar per-block work. BTQ's per-block LWMA at 60s spacing can make that false.

Regtest cannot reproduce live swings (`fPowNoRetargeting`, `nLWMAHeight = 300000`). This change only characterizes the arithmetic so the issue can be discussed with numbers.

## Approach

- Replicate the private helper's formula in `src/test/pow_lwma_tests.cpp` (do not friend `PeerManagerImpl`).
- Cases: near-tip fork absorbed by the 144-block buffer; H=450 and r≈0.005 (the observed shape) falls below the threshold; H=450 and r≈1 stays above; `nMinimumChainWork == 0` does not save testnet/regtest.
- Note at `contrib/btq/lwma-antidos-note.md`. Measure before changing 144.

Refs #168

## Testing

```
src/test/test_btq --run_test=pow_lwma_tests
```

Ran on Ubuntu 24.04 (Ryzen 9 5950X): 15 cases, no errors.

## Risks

Low. Test and note only. Does not change the 144-block constant or consensus.