### PR TITLE
test: run script_assets_test on a pinned corpus

### DIFF
--- a/.github/workflows/build-and-address-tests.yml
+++ b/.github/workflows/build-and-address-tests.yml
@@ -69,6 +69,21 @@ jobs:
       - name: Unit tests (make check)
         run: make check
 
+      # Bitcoin Core's script oracle, pinned. Do not use /main — it moves.
+      # Last commit that touched this JSON: 2025-07-23.
+      # Intended long-term home: btq-ag/qa-assets (TBD).
+      - name: script_assets_test (pinned bitcoin-core/qa-assets)
+        env:
+          SCRIPT_ASSETS_COMMIT: b33d85102d169b54d966ea315ad81a636680aefa
+        run: |
+          set -euo pipefail
+          ASSETS_DIR="$RUNNER_TEMP/qa-assets-unit"
+          mkdir -p "$ASSETS_DIR"
+          curl --location --fail \
+            "https://raw.githubusercontent.com/bitcoin-core/qa-assets/${SCRIPT_ASSETS_COMMIT}/unit_test_data/script_assets_test.json" \
+            -o "$ASSETS_DIR/script_assets_test.json"
+          DIR_UNIT_TEST_DATA="$ASSETS_DIR" src/test/test_btq --run_test=script_tests/script_assets_test
+
       - name: Smoke test - wallet + address generation (regtest)
         # Self-contained smoke test, on purpose NOT using the upstream
         # functional-test framework:

--- a/ci/test/06_script_b.sh
+++ b/ci/test/06_script_b.sh
@@ -56,7 +56,8 @@ index 65e31724bc..f61b471953 100644
 if [ "$RUN_FUZZ_TESTS" = "true" ]; then
   export DIR_FUZZ_IN=${DIR_QA_ASSETS}/fuzz_seed_corpus/
   if [ ! -d "$DIR_FUZZ_IN" ]; then
-    ${CI_RETRY_EXE} git clone --depth=1 https://github.com/btq-core/qa-assets "${DIR_QA_ASSETS}"
+    ${CI_RETRY_EXE} git clone https://github.com/bitcoin-core/qa-assets "${DIR_QA_ASSETS}"
+    git -C "${DIR_QA_ASSETS}" checkout --detach "${SCRIPT_ASSETS_COMMIT:-b33d85102d169b54d966ea315ad81a636680aefa}"
   fi
   (
     cd "${DIR_QA_ASSETS}"
@@ -67,7 +68,9 @@ elif [ "$RUN_UNIT_TESTS" = "true" ] || [ "$RUN_UNIT_TESTS_SEQUENTIAL" = "true" ]
   export DIR_UNIT_TEST_DATA=${DIR_QA_ASSETS}/unit_test_data/
   if [ ! -d "$DIR_UNIT_TEST_DATA" ]; then
     mkdir -p "$DIR_UNIT_TEST_DATA"
-    ${CI_RETRY_EXE} curl --location --fail https://github.com/btq-core/qa-assets/raw/main/unit_test_data/script_assets_test.json -o "${DIR_UNIT_TEST_DATA}/script_assets_test.json"
+    ${CI_RETRY_EXE} curl --location --fail \
+      "https://raw.githubusercontent.com/bitcoin-core/qa-assets/${SCRIPT_ASSETS_COMMIT:-b33d85102d169b54d966ea315ad81a636680aefa}/unit_test_data/script_assets_test.json" \
+      -o "${DIR_UNIT_TEST_DATA}/script_assets_test.json"
   fi
 fi
 

--- a/doc/audit-briefing.md
+++ b/doc/audit-briefing.md
@@ -79,6 +79,8 @@ from a constant that moved sitting next to one that did not.
 | `MAX_OPS_PER_SCRIPT` | 201 | 201 (unchanged) | `script/script.h` |
 | `MAX_STACK_SIZE` | 1,000 | 1,000 (unchanged) | `script/script.h` |
 
+Dilithium reclaims BIP342 OP_SUCCESS bytes `0xbb`–`0xbf` (`IsOpSuccess` in `src/script/script.cpp`). Upstream `script_assets_test` cases are skipped when a GetOp walk of the success or failure executed scripts finds those opcodes, or when the comment starts with `tapscript/inputmaxlimit` / `tapscript/pushmaxlimit` (Bitcoin’s 520-byte element limit; BTQ allows 15000). This is intentional and there are no unexplained corpus divergences. The JSON is fetched from `bitcoin-core/qa-assets` at pin `b33d85102d169b54d966ea315ad81a636680aefa`, not `main`. `btq-ag/qa-assets` is TBD.
+
 ### Mempool policy
 
 | Constant | Bitcoin | BTQ | Defined in |

--- a/doc/fuzzing.md
+++ b/doc/fuzzing.md
@@ -82,12 +82,14 @@ $ FUZZ=address_deserialize_v2 src/test/fuzz/fuzz -runs=1 fuzz_seed_corpus/addres
 
 ## Fuzzing corpora
 
-The project's collection of seed corpora is found in the [`btq-core/qa-assets`](https://github.com/btq-core/qa-assets) repo.
-
-To fuzz `process_message` using the [`btq-core/qa-assets`](https://github.com/btq-core/qa-assets) seed corpus:
+BTQ has no qa-assets fork yet (`btq-ag/qa-assets` is TBD). Until then, pin
+[`bitcoin-core/qa-assets`](https://github.com/bitcoin-core/qa-assets) at
+`b33d85102d169b54d966ea315ad81a636680aefa` (last change to
+`script_assets_test.json`). Do not track `main`.
 
 ```sh
-$ git clone https://github.com/btq-core/qa-assets
+$ git clone https://github.com/bitcoin-core/qa-assets
+$ git -C qa-assets checkout --detach b33d85102d169b54d966ea315ad81a636680aefa
 $ FUZZ=process_message src/test/fuzz/fuzz qa-assets/fuzz_seed_corpus/process_message/
 INFO: Seed: 1346407872
 INFO: Loaded 1 modules   (424174 inline 8-bit counters): 424174 [0x55d8a9004ab8, 0x55d8a906c3a6),
@@ -101,7 +103,7 @@ INFO: seed corpus: files: 991 min: 1b max: 1858b total: 288291b rss: 150Mb
 
 ## Run without sanitizers for increased throughput
 
-Fuzzing on a harness compiled with `--with-sanitizers=address,fuzzer,undefined` is good for finding bugs. However, the very slow execution even under libFuzzer will limit the ability to find new coverage. A good approach is to perform occasional long runs without the additional bug-detectors (configure `--with-sanitizers=fuzzer`) and then merge new inputs into a corpus as described in the qa-assets repo (https://github.com/btq-core/qa-assets/blob/main/.github/PULL_REQUEST_TEMPLATE.md).  Patience is useful; even with improved throughput, libFuzzer may need days and 10s of millions of executions to reach deep/hard targets.
+Fuzzing on a harness compiled with `--with-sanitizers=address,fuzzer,undefined` is good for finding bugs. However, the very slow execution even under libFuzzer will limit the ability to find new coverage. A good approach is to perform occasional long runs without the additional bug-detectors (configure `--with-sanitizers=fuzzer`) and then merge new inputs into a corpus as described in the qa-assets repo (https://github.com/bitcoin-core/qa-assets/blob/main/.github/PULL_REQUEST_TEMPLATE.md).  Patience is useful; even with improved throughput, libFuzzer may need days and 10s of millions of executions to reach deep/hard targets.
 
 ## Reproduce a fuzzer crash reported by the CI
 
@@ -117,9 +119,9 @@ Fuzzing on a harness compiled with `--with-sanitizers=address,fuzzer,undefined` 
 
 ## Submit improved coverage
 
-If you find coverage increasing inputs when fuzzing you are highly encouraged to submit them for inclusion in the [`btq-core/qa-assets`](https://github.com/btq-core/qa-assets) repo.
+If you find coverage increasing inputs when fuzzing you are highly encouraged to submit them for inclusion in the [`bitcoin-core/qa-assets`](https://github.com/bitcoin-core/qa-assets) repo.
 
-Every single pull request submitted against the BTQ Core repo is automatically tested against all inputs in the [`btq-core/qa-assets`](https://github.com/btq-core/qa-assets) repo. Contributing new coverage increasing inputs is an easy way to help make BTQ Core more robust.
+Every single pull request submitted against the BTQ Core repo is automatically tested against all inputs in the [`bitcoin-core/qa-assets`](https://github.com/bitcoin-core/qa-assets) repo. Contributing new coverage increasing inputs is an easy way to help make BTQ Core more robust.
 
 ## macOS hints for libFuzzer
 
@@ -324,7 +326,7 @@ be decoded in the same way.
 Fuzzing with Eclipser will likely be much more effective if using an existing corpus:
 
 ```sh
-$ git clone https://github.com/btq-core/qa-assets
+$ git clone https://github.com/bitcoin-core/qa-assets
 $ FUZZ=bech32 dotnet Eclipser/build/Eclipser.dll fuzz -p src/test/fuzz/fuzz -t 36000 -i qa-assets/fuzz_seed_corpus/bech32 outputs --src stdin
 ```
 

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -1710,6 +1710,96 @@ static std::vector<unsigned int> AllConsensusFlags()
 /** Precomputed list of all valid combinations of consensus-relevant script validation flags. */
 static const std::vector<unsigned int> ALL_CONSENSUS_FLAGS = AllConsensusFlags();
 
+// Dilithium reclaimed BIP342 OP_SUCCESS 0xbb–0xbf. Skip cases whose success or failure
+// executed scripts contain those opcodes (GetOp walk), plus known size-limit comment prefixes.
+static bool ScriptHasReclaimedDilithiumOpcode(const CScript& script)
+{
+    CScript::const_iterator pc = script.begin();
+    while (pc < script.end()) {
+        opcodetype opcode;
+        if (!script.GetOp(pc, opcode)) break;
+        if (opcode >= 0xbb && opcode <= 0xbf) return true;
+    }
+    return false;
+}
+
+static bool SideHasReclaimedDilithiumOpcode(const UniValue& test, const char* side)
+{
+    if (!test.exists(side)) return false;
+    const UniValue& obj = test[side];
+
+    const CScript scriptSig = ScriptFromHex(obj["scriptSig"].get_str());
+    if (ScriptHasReclaimedDilithiumOpcode(scriptSig)) return true;
+
+    const std::vector<CTxOut> prevouts = TxOutsFromJSON(test["prevouts"]);
+    const size_t idx = test["index"].getInt<int64_t>();
+    CScript scriptPubKey = prevouts[idx].scriptPubKey;
+    if (ScriptHasReclaimedDilithiumOpcode(scriptPubKey)) return true;
+
+    // Inner program for witness checks (redeem script when P2SH-wrapped).
+    CScript program = scriptPubKey;
+    if (scriptPubKey.IsPayToScriptHash()) {
+        CScript::const_iterator pc = scriptSig.begin();
+        std::vector<unsigned char> vData;
+        while (pc < scriptSig.end()) {
+            opcodetype opcode;
+            if (!scriptSig.GetOp(pc, opcode, vData)) break;
+        }
+        CScript redeem_script(vData.begin(), vData.end());
+        if (ScriptHasReclaimedDilithiumOpcode(redeem_script)) return true;
+        program = std::move(redeem_script);
+    }
+
+    std::vector<std::vector<unsigned char>> stack;
+    const UniValue& witness = obj["witness"];
+    if (witness.isArray()) {
+        for (size_t i = 0; i < witness.size(); ++i) {
+            stack.push_back(ParseHex(witness[i].get_str()));
+        }
+    }
+
+    int witversion;
+    std::vector<unsigned char> witprogram;
+    if (program.IsWitnessProgram(witversion, witprogram)) {
+        if (witversion == 1 && witprogram.size() == 32) {
+            // P2TR: strip annex when locating tapscript; key-path has no script to walk.
+            size_t n = stack.size();
+            if (n >= 2 && !stack.back().empty() && stack.back()[0] == ANNEX_TAG) {
+                --n;
+            }
+            if (n >= 2) {
+                const CScript tapscript(stack[n - 2].begin(), stack[n - 2].end());
+                if (ScriptHasReclaimedDilithiumOpcode(tapscript)) return true;
+            }
+        } else if (program.IsPayToWitnessScriptHash() || (witversion == 0 && witprogram.size() == 32)) {
+            // P2WSH: only the witness script (last stack item) is executed as a script.
+            if (!stack.empty()) {
+                const CScript witness_script(stack.back().begin(), stack.back().end());
+                if (ScriptHasReclaimedDilithiumOpcode(witness_script)) return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+static bool IsDilithiumReclaimedOpSuccessCase(const UniValue& test)
+{
+    if (SideHasReclaimedDilithiumOpcode(test, "success")) return true;
+    if (SideHasReclaimedDilithiumOpcode(test, "failure")) return true;
+    // Remainder of the known 11-case taproot set: GetOp does not see 0xbb–0xbf inside the
+    // 520/521-byte pushes. These cases assume Bitcoin's 520-byte element limit (failure is 521);
+    // BTQ allows 15000 so the failure path succeeds.
+    if (test.exists("comment")) {
+        const std::string& comment = test["comment"].get_str();
+        if (comment.rfind("tapscript/inputmaxlimit", 0) == 0 ||
+            comment.rfind("tapscript/pushmaxlimit", 0) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
 static void AssetTest(const UniValue& test)
 {
     BOOST_CHECK(test.isObject());
@@ -1813,6 +1903,14 @@ BOOST_AUTO_TEST_CASE(script_assets_test)
     BOOST_CHECK(tests.size() > 0);
 
     for (size_t i = 0; i < tests.size(); i++) {
+        if (IsDilithiumReclaimedOpSuccessCase(tests[i])) {
+            if (tests[i].exists("comment")) {
+                BOOST_TEST_MESSAGE("Skipping Dilithium-reclaimed OP_SUCCESS / size-limit case: " << tests[i]["comment"].get_str());
+            } else {
+                BOOST_TEST_MESSAGE("Skipping Dilithium-reclaimed OP_SUCCESS / size-limit case");
+            }
+            continue;
+        }
         AssetTest(tests[i]);
     }
     file.close();


### PR DESCRIPTION
## What

Make `script_tests/script_assets_test` actually run. Fetch Bitcoin Core's script-oracle JSON from a **pinned** `bitcoin-core/qa-assets` commit and skip the eleven cases that diverge on purpose.

## Why

The test is the ~2,244-case Taproot/legacy/script differential corpus. It has never run here: `DIR_UNIT_TEST_DATA` is unset locally (`BOOST_WARN` skip), and CI cloned `btq-core/qa-assets`, which 404s.

That file is still the right oracle for the ECDSA/Schnorr/Taproot machine BTQ still ships. It is not a Dilithium or P2MR test. On a live `test_btq` against this JSON: 262 raw failures, all in 11 named cases; after the skips, 0 unexplained failures.

## Approach

- Point lean CI and `ci/test/06_script_b.sh` at
  `bitcoin-core/qa-assets` commit `b33d85102d169b54d966ea315ad81a636680aefa`
  (last change to `script_assets_test.json`, 2025-07-23). Do not track `main`.
- Skip via a GetOp walk of executed scripts for opcodes `0xbb`–`0xbf` (Dilithium reclaimed BIP342 `OP_SUCCESS`), plus comment prefixes `tapscript/inputmaxlimit` / `tapscript/pushmaxlimit` (Bitcoin 520-byte element cap; BTQ allows 15,000).
- Leave the unset-env skip as `BOOST_WARN` so `make check` stays green without the JSON.
- `btq-ag/qa-assets` is TBD. This PR does not create that repo.

Refs #147

## Testing

```
DIR_UNIT_TEST_DATA=<dir-with-json> src/test/test_btq --run_test=script_tests/script_assets_test
```

Ran on Ubuntu 24.04: unpatched 262 failures; patched 11 skips, no errors.

## Risks

Low. No consensus change. CI now depends on a pinned third-party blob remaining at that SHA. If GitHub deletes the raw file, the new lean-CI step fails closed.