### PR TITLE
ci: add weekly qa-assets pin bump

### DIFF
--- a/.github/workflows/build-and-address-tests.yml
+++ b/.github/workflows/build-and-address-tests.yml
@@ -69,14 +69,11 @@ jobs:
       - name: Unit tests (make check)
         run: make check
 
-      # Bitcoin Core's script oracle, pinned. Do not use /main — it moves.
-      # Last commit that touched this JSON: 2025-07-23.
-      # Intended long-term home: btq-ag/qa-assets (TBD).
+      # Bitcoin Core's script oracle. SHA lives in contrib/qa-assets.pin.
       - name: script_assets_test (pinned bitcoin-core/qa-assets)
-        env:
-          SCRIPT_ASSETS_COMMIT: b33d85102d169b54d966ea315ad81a636680aefa
         run: |
           set -euo pipefail
+          SCRIPT_ASSETS_COMMIT=$(grep -E '^[0-9a-f]{40}$' contrib/qa-assets.pin)
           ASSETS_DIR="$RUNNER_TEMP/qa-assets-unit"
           mkdir -p "$ASSETS_DIR"
           curl --location --fail \

--- a/.github/workflows/build-and-address-tests.yml
+++ b/.github/workflows/build-and-address-tests.yml
@@ -69,6 +69,21 @@ jobs:
       - name: Unit tests (make check)
         run: make check
 
+      # Bitcoin Core's script oracle, pinned. Do not use /main — it moves.
+      # Last commit that touched this JSON: 2025-07-23.
+      # Intended long-term home: btq-ag/qa-assets (TBD).
+      - name: script_assets_test (pinned bitcoin-core/qa-assets)
+        env:
+          SCRIPT_ASSETS_COMMIT: b33d85102d169b54d966ea315ad81a636680aefa
+        run: |
+          set -euo pipefail
+          ASSETS_DIR="$RUNNER_TEMP/qa-assets-unit"
+          mkdir -p "$ASSETS_DIR"
+          curl --location --fail \
+            "https://raw.githubusercontent.com/bitcoin-core/qa-assets/${SCRIPT_ASSETS_COMMIT}/unit_test_data/script_assets_test.json" \
+            -o "$ASSETS_DIR/script_assets_test.json"
+          DIR_UNIT_TEST_DATA="$ASSETS_DIR" src/test/test_btq --run_test=script_tests/script_assets_test
+
       - name: Smoke test - wallet + address generation (regtest)
         # Self-contained smoke test, on purpose NOT using the upstream
         # functional-test framework:

--- a/.github/workflows/qa-assets-bump.yml
+++ b/.github/workflows/qa-assets-bump.yml
@@ -1,0 +1,88 @@
+# Copyright (c) 2026 The BTQ Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+# Watch bitcoin-core/qa-assets for commits that touch script_assets_test.json.
+# If that path moved, open a pin PR. Do not follow repo main (fuzz corpora).
+#
+# GITHUB_TOKEN pushes do not start other workflows. The pin PR will not run
+# lean CI unless QA_ASSETS_BUMP_TOKEN (a PAT with workflow + contents) is set.
+
+name: qa-assets pin bump
+
+on:
+  schedule:
+    - cron: "27 7 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump:
+    if: github.repository == 'btq-ag/btq-core'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve latest JSON-touching commit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          NEW=$(gh api \
+            "repos/bitcoin-core/qa-assets/commits?path=unit_test_data/script_assets_test.json&per_page=1" \
+            --jq '.[0].sha')
+          CUR=$(grep -E '^[0-9a-f]{40}$' contrib/qa-assets.pin)
+          echo "new=$NEW" >> "$GITHUB_ENV"
+          echo "cur=$CUR" >> "$GITHUB_ENV"
+          echo "remote $NEW"
+          echo "pin    $CUR"
+
+      - name: Open pin PR
+        if: env.new != env.cur
+        env:
+          GH_TOKEN: ${{ secrets.QA_ASSETS_BUMP_TOKEN || secrets.GITHUB_TOKEN }}
+          NEW: ${{ env.new }}
+        run: |
+          set -euo pipefail
+          SHORT="${NEW:0:12}"
+          BRANCH="ci/qa-assets-pin-${SHORT}"
+          if gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number' | grep -q '[0-9]'; then
+            echo "PR already open for $BRANCH"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$BRANCH"
+          python3 -c "
+          from pathlib import Path
+          import os
+          Path('contrib/qa-assets.pin').write_text(
+              '# bitcoin-core/qa-assets commit that last touched\n'
+              '# unit_test_data/script_assets_test.json\n'
+              '# Bumped by .github/workflows/qa-assets-bump.yml — do not track main.\n'
+              '# Long-term home: btq-ag/qa-assets (TBD).\n'
+              + os.environ['NEW'] + '\n'
+          )
+          "
+          git add contrib/qa-assets.pin
+          git commit -m "ci: bump script_assets corpus pin
+
+          Update contrib/qa-assets.pin to ${NEW}.
+
+          Refs #147"
+          git push -u origin "$BRANCH"
+          gh pr create --base master --head "$BRANCH" \
+            --title "ci: bump script_assets corpus pin" \
+            --body "Weekly inherit of Bitcoin Core \`script_assets_test.json\`.
+
+          Pin moved from \`${{ env.cur }}\` to \`${NEW}\`.
+
+          This is only the last commit that touched that path, not qa-assets main.
+
+          Lean CI on this PR should run \`script_assets_test\`. If it is red, a new Bitcoin case disagrees with us — add a skip or fix the interpreter. Do not auto-merge.
+
+          Refs #147"

--- a/.github/workflows/qa-assets-bump.yml
+++ b/.github/workflows/qa-assets-bump.yml
@@ -50,8 +50,8 @@ jobs:
           set -euo pipefail
           SHORT="${NEW:0:12}"
           BRANCH="ci/qa-assets-pin-${SHORT}"
-          if gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number' | grep -q '[0-9]'; then
-            echo "PR already open for $BRANCH"
+          if git ls-remote --exit-code --heads origin "refs/heads/$BRANCH" >/dev/null 2>&1; then
+            echo "Branch already exists for $BRANCH"
             exit 0
           fi
           git config user.name "github-actions[bot]"

--- a/ci/test/06_script_b.sh
+++ b/ci/test/06_script_b.sh
@@ -56,7 +56,8 @@ index 65e31724bc..f61b471953 100644
 if [ "$RUN_FUZZ_TESTS" = "true" ]; then
   export DIR_FUZZ_IN=${DIR_QA_ASSETS}/fuzz_seed_corpus/
   if [ ! -d "$DIR_FUZZ_IN" ]; then
-    ${CI_RETRY_EXE} git clone --depth=1 https://github.com/btq-core/qa-assets "${DIR_QA_ASSETS}"
+    ${CI_RETRY_EXE} git clone https://github.com/bitcoin-core/qa-assets "${DIR_QA_ASSETS}"
+    git -C "${DIR_QA_ASSETS}" checkout --detach "${SCRIPT_ASSETS_COMMIT:-b33d85102d169b54d966ea315ad81a636680aefa}"
   fi
   (
     cd "${DIR_QA_ASSETS}"
@@ -67,7 +68,9 @@ elif [ "$RUN_UNIT_TESTS" = "true" ] || [ "$RUN_UNIT_TESTS_SEQUENTIAL" = "true" ]
   export DIR_UNIT_TEST_DATA=${DIR_QA_ASSETS}/unit_test_data/
   if [ ! -d "$DIR_UNIT_TEST_DATA" ]; then
     mkdir -p "$DIR_UNIT_TEST_DATA"
-    ${CI_RETRY_EXE} curl --location --fail https://github.com/btq-core/qa-assets/raw/main/unit_test_data/script_assets_test.json -o "${DIR_UNIT_TEST_DATA}/script_assets_test.json"
+    ${CI_RETRY_EXE} curl --location --fail \
+      "https://raw.githubusercontent.com/bitcoin-core/qa-assets/${SCRIPT_ASSETS_COMMIT:-b33d85102d169b54d966ea315ad81a636680aefa}/unit_test_data/script_assets_test.json" \
+      -o "${DIR_UNIT_TEST_DATA}/script_assets_test.json"
   fi
 fi
 

--- a/ci/test/06_script_b.sh
+++ b/ci/test/06_script_b.sh
@@ -56,8 +56,9 @@ index 65e31724bc..f61b471953 100644
 if [ "$RUN_FUZZ_TESTS" = "true" ]; then
   export DIR_FUZZ_IN=${DIR_QA_ASSETS}/fuzz_seed_corpus/
   if [ ! -d "$DIR_FUZZ_IN" ]; then
+    SCRIPT_ASSETS_COMMIT=$(grep -E '^[0-9a-f]{40}$' "${BASE_ROOT_DIR}/contrib/qa-assets.pin")
     ${CI_RETRY_EXE} git clone https://github.com/bitcoin-core/qa-assets "${DIR_QA_ASSETS}"
-    git -C "${DIR_QA_ASSETS}" checkout --detach "${SCRIPT_ASSETS_COMMIT:-b33d85102d169b54d966ea315ad81a636680aefa}"
+    git -C "${DIR_QA_ASSETS}" checkout --detach "${SCRIPT_ASSETS_COMMIT}"
   fi
   (
     cd "${DIR_QA_ASSETS}"
@@ -68,8 +69,9 @@ elif [ "$RUN_UNIT_TESTS" = "true" ] || [ "$RUN_UNIT_TESTS_SEQUENTIAL" = "true" ]
   export DIR_UNIT_TEST_DATA=${DIR_QA_ASSETS}/unit_test_data/
   if [ ! -d "$DIR_UNIT_TEST_DATA" ]; then
     mkdir -p "$DIR_UNIT_TEST_DATA"
+    SCRIPT_ASSETS_COMMIT=$(grep -E '^[0-9a-f]{40}$' "${BASE_ROOT_DIR}/contrib/qa-assets.pin")
     ${CI_RETRY_EXE} curl --location --fail \
-      "https://raw.githubusercontent.com/bitcoin-core/qa-assets/${SCRIPT_ASSETS_COMMIT:-b33d85102d169b54d966ea315ad81a636680aefa}/unit_test_data/script_assets_test.json" \
+      "https://raw.githubusercontent.com/bitcoin-core/qa-assets/${SCRIPT_ASSETS_COMMIT}/unit_test_data/script_assets_test.json" \
       -o "${DIR_UNIT_TEST_DATA}/script_assets_test.json"
   fi
 fi

--- a/contrib/qa-assets.pin
+++ b/contrib/qa-assets.pin
@@ -1,0 +1,5 @@
+# bitcoin-core/qa-assets commit that last touched
+# unit_test_data/script_assets_test.json
+# Bumped by .github/workflows/qa-assets-bump.yml — do not track main.
+# Long-term home: btq-ag/qa-assets (TBD).
+b33d85102d169b54d966ea315ad81a636680aefa

--- a/doc/audit-briefing.md
+++ b/doc/audit-briefing.md
@@ -79,6 +79,8 @@ from a constant that moved sitting next to one that did not.
 | `MAX_OPS_PER_SCRIPT` | 201 | 201 (unchanged) | `script/script.h` |
 | `MAX_STACK_SIZE` | 1,000 | 1,000 (unchanged) | `script/script.h` |
 
+Dilithium reclaims BIP342 OP_SUCCESS bytes `0xbb`–`0xbf` (`IsOpSuccess` in `src/script/script.cpp`). Upstream `script_assets_test` cases are skipped when a GetOp walk of the success or failure executed scripts finds those opcodes, or when the comment starts with `tapscript/inputmaxlimit` / `tapscript/pushmaxlimit` (Bitcoin’s 520-byte element limit; BTQ allows 15000). This is intentional and there are no unexplained corpus divergences. The JSON is fetched from `bitcoin-core/qa-assets` at pin `b33d85102d169b54d966ea315ad81a636680aefa`, not `main`. `btq-ag/qa-assets` is TBD.
+
 ### Mempool policy
 
 | Constant | Bitcoin | BTQ | Defined in |

--- a/doc/audit-briefing.md
+++ b/doc/audit-briefing.md
@@ -79,7 +79,7 @@ from a constant that moved sitting next to one that did not.
 | `MAX_OPS_PER_SCRIPT` | 201 | 201 (unchanged) | `script/script.h` |
 | `MAX_STACK_SIZE` | 1,000 | 1,000 (unchanged) | `script/script.h` |
 
-Dilithium reclaims BIP342 OP_SUCCESS bytes `0xbb`–`0xbf` (`IsOpSuccess` in `src/script/script.cpp`). Upstream `script_assets_test` cases are skipped when a GetOp walk of the success or failure executed scripts finds those opcodes, or when the comment starts with `tapscript/inputmaxlimit` / `tapscript/pushmaxlimit` (Bitcoin’s 520-byte element limit; BTQ allows 15000). This is intentional and there are no unexplained corpus divergences. The JSON is fetched from `bitcoin-core/qa-assets` at pin `b33d85102d169b54d966ea315ad81a636680aefa`, not `main`. `btq-ag/qa-assets` is TBD.
+Dilithium reclaims BIP342 OP_SUCCESS bytes `0xbb`–`0xbf` (`IsOpSuccess` in `src/script/script.cpp`). Upstream `script_assets_test` cases are skipped when a GetOp walk of the success or failure executed scripts finds those opcodes, or when the comment starts with `tapscript/inputmaxlimit` / `tapscript/pushmaxlimit` (Bitcoin’s 520-byte element limit; BTQ allows 15000). This is intentional and there are no unexplained corpus divergences. The JSON is fetched from `bitcoin-core/qa-assets` at the commit in `contrib/qa-assets.pin`, not `main`. `btq-ag/qa-assets` is TBD. Weekly pin bumps are `.github/workflows/qa-assets-bump.yml`.
 
 ### Mempool policy
 

--- a/doc/fuzzing.md
+++ b/doc/fuzzing.md
@@ -82,12 +82,14 @@ $ FUZZ=address_deserialize_v2 src/test/fuzz/fuzz -runs=1 fuzz_seed_corpus/addres
 
 ## Fuzzing corpora
 
-The project's collection of seed corpora is found in the [`btq-core/qa-assets`](https://github.com/btq-core/qa-assets) repo.
-
-To fuzz `process_message` using the [`btq-core/qa-assets`](https://github.com/btq-core/qa-assets) seed corpus:
+BTQ has no qa-assets fork yet (`btq-ag/qa-assets` is TBD). Until then, pin
+[`bitcoin-core/qa-assets`](https://github.com/bitcoin-core/qa-assets) at
+`b33d85102d169b54d966ea315ad81a636680aefa` (last change to
+`script_assets_test.json`). Do not track `main`.
 
 ```sh
-$ git clone https://github.com/btq-core/qa-assets
+$ git clone https://github.com/bitcoin-core/qa-assets
+$ git -C qa-assets checkout --detach b33d85102d169b54d966ea315ad81a636680aefa
 $ FUZZ=process_message src/test/fuzz/fuzz qa-assets/fuzz_seed_corpus/process_message/
 INFO: Seed: 1346407872
 INFO: Loaded 1 modules   (424174 inline 8-bit counters): 424174 [0x55d8a9004ab8, 0x55d8a906c3a6),
@@ -101,7 +103,7 @@ INFO: seed corpus: files: 991 min: 1b max: 1858b total: 288291b rss: 150Mb
 
 ## Run without sanitizers for increased throughput
 
-Fuzzing on a harness compiled with `--with-sanitizers=address,fuzzer,undefined` is good for finding bugs. However, the very slow execution even under libFuzzer will limit the ability to find new coverage. A good approach is to perform occasional long runs without the additional bug-detectors (configure `--with-sanitizers=fuzzer`) and then merge new inputs into a corpus as described in the qa-assets repo (https://github.com/btq-core/qa-assets/blob/main/.github/PULL_REQUEST_TEMPLATE.md).  Patience is useful; even with improved throughput, libFuzzer may need days and 10s of millions of executions to reach deep/hard targets.
+Fuzzing on a harness compiled with `--with-sanitizers=address,fuzzer,undefined` is good for finding bugs. However, the very slow execution even under libFuzzer will limit the ability to find new coverage. A good approach is to perform occasional long runs without the additional bug-detectors (configure `--with-sanitizers=fuzzer`) and then merge new inputs into a corpus as described in the qa-assets repo (https://github.com/bitcoin-core/qa-assets/blob/main/.github/PULL_REQUEST_TEMPLATE.md).  Patience is useful; even with improved throughput, libFuzzer may need days and 10s of millions of executions to reach deep/hard targets.
 
 ## Reproduce a fuzzer crash reported by the CI
 
@@ -117,9 +119,9 @@ Fuzzing on a harness compiled with `--with-sanitizers=address,fuzzer,undefined` 
 
 ## Submit improved coverage
 
-If you find coverage increasing inputs when fuzzing you are highly encouraged to submit them for inclusion in the [`btq-core/qa-assets`](https://github.com/btq-core/qa-assets) repo.
+If you find coverage increasing inputs when fuzzing you are highly encouraged to submit them for inclusion in the [`bitcoin-core/qa-assets`](https://github.com/bitcoin-core/qa-assets) repo.
 
-Every single pull request submitted against the BTQ Core repo is automatically tested against all inputs in the [`btq-core/qa-assets`](https://github.com/btq-core/qa-assets) repo. Contributing new coverage increasing inputs is an easy way to help make BTQ Core more robust.
+Every single pull request submitted against the BTQ Core repo is automatically tested against all inputs in the [`bitcoin-core/qa-assets`](https://github.com/bitcoin-core/qa-assets) repo. Contributing new coverage increasing inputs is an easy way to help make BTQ Core more robust.
 
 ## macOS hints for libFuzzer
 
@@ -324,7 +326,7 @@ be decoded in the same way.
 Fuzzing with Eclipser will likely be much more effective if using an existing corpus:
 
 ```sh
-$ git clone https://github.com/btq-core/qa-assets
+$ git clone https://github.com/bitcoin-core/qa-assets
 $ FUZZ=bech32 dotnet Eclipser/build/Eclipser.dll fuzz -p src/test/fuzz/fuzz -t 36000 -i qa-assets/fuzz_seed_corpus/bech32 outputs --src stdin
 ```
 

--- a/doc/fuzzing.md
+++ b/doc/fuzzing.md
@@ -83,13 +83,12 @@ $ FUZZ=address_deserialize_v2 src/test/fuzz/fuzz -runs=1 fuzz_seed_corpus/addres
 ## Fuzzing corpora
 
 BTQ has no qa-assets fork yet (`btq-ag/qa-assets` is TBD). Until then, pin
-[`bitcoin-core/qa-assets`](https://github.com/bitcoin-core/qa-assets) at
-`b33d85102d169b54d966ea315ad81a636680aefa` (last change to
-`script_assets_test.json`). Do not track `main`.
+[`bitcoin-core/qa-assets`](https://github.com/bitcoin-core/qa-assets) at the
+commit in `contrib/qa-assets.pin`. Do not track `main`.
 
 ```sh
 $ git clone https://github.com/bitcoin-core/qa-assets
-$ git -C qa-assets checkout --detach b33d85102d169b54d966ea315ad81a636680aefa
+$ git -C qa-assets checkout --detach "$(grep -E '^[0-9a-f]{40}$' contrib/qa-assets.pin)"
 $ FUZZ=process_message src/test/fuzz/fuzz qa-assets/fuzz_seed_corpus/process_message/
 INFO: Seed: 1346407872
 INFO: Loaded 1 modules   (424174 inline 8-bit counters): 424174 [0x55d8a9004ab8, 0x55d8a906c3a6),

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -1710,6 +1710,96 @@ static std::vector<unsigned int> AllConsensusFlags()
 /** Precomputed list of all valid combinations of consensus-relevant script validation flags. */
 static const std::vector<unsigned int> ALL_CONSENSUS_FLAGS = AllConsensusFlags();
 
+// Dilithium reclaimed BIP342 OP_SUCCESS 0xbb–0xbf. Skip cases whose success or failure
+// executed scripts contain those opcodes (GetOp walk), plus known size-limit comment prefixes.
+static bool ScriptHasReclaimedDilithiumOpcode(const CScript& script)
+{
+    CScript::const_iterator pc = script.begin();
+    while (pc < script.end()) {
+        opcodetype opcode;
+        if (!script.GetOp(pc, opcode)) break;
+        if (opcode >= 0xbb && opcode <= 0xbf) return true;
+    }
+    return false;
+}
+
+static bool SideHasReclaimedDilithiumOpcode(const UniValue& test, const char* side)
+{
+    if (!test.exists(side)) return false;
+    const UniValue& obj = test[side];
+
+    const CScript scriptSig = ScriptFromHex(obj["scriptSig"].get_str());
+    if (ScriptHasReclaimedDilithiumOpcode(scriptSig)) return true;
+
+    const std::vector<CTxOut> prevouts = TxOutsFromJSON(test["prevouts"]);
+    const size_t idx = test["index"].getInt<int64_t>();
+    CScript scriptPubKey = prevouts[idx].scriptPubKey;
+    if (ScriptHasReclaimedDilithiumOpcode(scriptPubKey)) return true;
+
+    // Inner program for witness checks (redeem script when P2SH-wrapped).
+    CScript program = scriptPubKey;
+    if (scriptPubKey.IsPayToScriptHash()) {
+        CScript::const_iterator pc = scriptSig.begin();
+        std::vector<unsigned char> vData;
+        while (pc < scriptSig.end()) {
+            opcodetype opcode;
+            if (!scriptSig.GetOp(pc, opcode, vData)) break;
+        }
+        CScript redeem_script(vData.begin(), vData.end());
+        if (ScriptHasReclaimedDilithiumOpcode(redeem_script)) return true;
+        program = std::move(redeem_script);
+    }
+
+    std::vector<std::vector<unsigned char>> stack;
+    const UniValue& witness = obj["witness"];
+    if (witness.isArray()) {
+        for (size_t i = 0; i < witness.size(); ++i) {
+            stack.push_back(ParseHex(witness[i].get_str()));
+        }
+    }
+
+    int witversion;
+    std::vector<unsigned char> witprogram;
+    if (program.IsWitnessProgram(witversion, witprogram)) {
+        if (witversion == 1 && witprogram.size() == 32) {
+            // P2TR: strip annex when locating tapscript; key-path has no script to walk.
+            size_t n = stack.size();
+            if (n >= 2 && !stack.back().empty() && stack.back()[0] == ANNEX_TAG) {
+                --n;
+            }
+            if (n >= 2) {
+                const CScript tapscript(stack[n - 2].begin(), stack[n - 2].end());
+                if (ScriptHasReclaimedDilithiumOpcode(tapscript)) return true;
+            }
+        } else if (program.IsPayToWitnessScriptHash() || (witversion == 0 && witprogram.size() == 32)) {
+            // P2WSH: only the witness script (last stack item) is executed as a script.
+            if (!stack.empty()) {
+                const CScript witness_script(stack.back().begin(), stack.back().end());
+                if (ScriptHasReclaimedDilithiumOpcode(witness_script)) return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+static bool IsDilithiumReclaimedOpSuccessCase(const UniValue& test)
+{
+    if (SideHasReclaimedDilithiumOpcode(test, "success")) return true;
+    if (SideHasReclaimedDilithiumOpcode(test, "failure")) return true;
+    // Remainder of the known 11-case taproot set: GetOp does not see 0xbb–0xbf inside the
+    // 520/521-byte pushes. These cases assume Bitcoin's 520-byte element limit (failure is 521);
+    // BTQ allows 15000 so the failure path succeeds.
+    if (test.exists("comment")) {
+        const std::string& comment = test["comment"].get_str();
+        if (comment.rfind("tapscript/inputmaxlimit", 0) == 0 ||
+            comment.rfind("tapscript/pushmaxlimit", 0) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
 static void AssetTest(const UniValue& test)
 {
     BOOST_CHECK(test.isObject());
@@ -1813,6 +1903,14 @@ BOOST_AUTO_TEST_CASE(script_assets_test)
     BOOST_CHECK(tests.size() > 0);
 
     for (size_t i = 0; i < tests.size(); i++) {
+        if (IsDilithiumReclaimedOpSuccessCase(tests[i])) {
+            if (tests[i].exists("comment")) {
+                BOOST_TEST_MESSAGE("Skipping Dilithium-reclaimed OP_SUCCESS / size-limit case: " << tests[i]["comment"].get_str());
+            } else {
+                BOOST_TEST_MESSAGE("Skipping Dilithium-reclaimed OP_SUCCESS / size-limit case");
+            }
+            continue;
+        }
         AssetTest(tests[i]);
     }
     file.close();


### PR DESCRIPTION
## Why

`script_tests/script_assets_test` checks BTQ's script interpreter against Bitcoin Core's shared test data: 2,244 transactions covering legacy script, SegWit v0, Taproot and tapscript, each checked under every combination of consensus flags. BTQ changed the interpreter for Dilithium, so this is the test most likely to catch an accidental difference from Bitcoin's script rules.

It has never run in this repo (#147):

- Locally it skips itself when `DIR_UNIT_TEST_DATA` is unset. The skip is a warning, so `make check` still shows green.
- `ci/test/06_script_b.sh` downloads the data from `github.com/btq-core/qa-assets`, which does not exist. No workflow in `.github/workflows` runs that script anyway.

Run against Bitcoin Core's data, 11 of the 2,244 cases fail. All 11 test rules BTQ changed on purpose:

- BIP342 makes opcodes `0xbb`–`0xbf` `OP_SUCCESS`. BTQ uses them for Dilithium (`IsOpSuccess` in `src/script/script.cpp`).
- Bitcoin limits a stack element to 520 bytes. BTQ allows 15,000, so the cases that expect a 521-byte element to fail now pass.

## What this changes

- `contrib/qa-assets.pin` holds one commit of `bitcoin-core/qa-assets` (`b33d851`, the last commit that changed `script_assets_test.json`). CI downloads the file from that commit, never from `main`, so the test data changes only through a reviewed PR.
- `build-and-address-tests.yml` gets a step that downloads the pinned file and runs `script_assets_test`.
- `src/test/script_tests.cpp` skips the 11 cases above. A case is skipped if one of its executed scripts contains opcode `0xbb`–`0xbf` as an instruction (found with `GetOp`, not a byte search), or if its name starts with `tapscript/inputmaxlimit` or `tapscript/pushmaxlimit`. Every other case must pass.
- `.github/workflows/qa-assets-bump.yml` runs every Monday. If the last upstream commit that changed `script_assets_test.json` differs from the pin, it opens a PR that moves the pin. It never merges, and it skips when a branch for that commit already exists.
- `ci/test/06_script_b.sh`, `doc/fuzzing.md` and `doc/audit-briefing.md` point at `bitcoin-core/qa-assets` at the pinned commit.

qa-assets `main` gets new fuzz inputs every week, but `script_assets_test.json` last changed on 2025-07-23. Watching only that file keeps bump PRs rare.

## Not changed

No node, wallet or consensus code. The diff is CI config, one CI script, the pin file, docs and `src/test/script_tests.cpp`.

## After merge

Add a repo secret `QA_ASSETS_BUMP_TOKEN`: a personal access token with contents and workflow scope. PRs opened with the default `GITHUB_TOKEN` do not start other workflows, so without the secret a bump PR has no CI.

## If the test goes red later

A bump PR fails when Bitcoin adds cases that touch a rule BTQ changed, or when BTQ's interpreter has drifted. Add a skip with the reason, or fix the interpreter. Do not merge a red bump.

## Testing

- CI on this PR: build, `make check` and `script_assets_test` pass. `test each commit` failed because that run used the Sep 10 `ci.yml`, which ran the full functional suite. Those failures are the ones already on master (#104).
- Locally on master + this PR: `script_assets_test` passes with 11 cases skipped. The pin matches the latest upstream commit for the file.

Closes #147. On the issue's fourth item: the skip when the data is missing stays a warning, so `make check` passes without the file. The CI step downloads it with `curl --fail` under `set -e`, so a failed download fails CI instead of skipping the test.

Supersedes #172, which held the first commit of this PR.
