### PR TITLE
test: cover header-work filtering through P2P

### DIFF
--- a/.github/workflows/build-and-address-tests.yml
+++ b/.github/workflows/build-and-address-tests.yml
@@ -69,6 +69,9 @@ jobs:
       - name: Unit tests (make check)
         run: make check
 
+      - name: Header-work P2P regression
+        run: python3 test/functional/test_runner.py p2p_headers_sync_with_minchainwork.py --jobs=1
+
       - name: Smoke test - wallet + address generation (regtest)
         # Self-contained smoke test, on purpose NOT using the upstream
         # functional-test framework:

--- a/src/headerssync.cpp
+++ b/src/headerssync.cpp
@@ -9,6 +9,11 @@
 #include <util/check.h>
 #include <util/vector.h>
 
+#include <algorithm>
+
+//! Number of tip-work-equivalent blocks kept as a near-tip relay buffer.
+constexpr uint32_t ANTI_DOS_HEADER_WORK_BUFFER{144};
+
 // The two constants below are computed using the simulation script in
 // contrib/devtools/headerssync-params.py.
 
@@ -22,6 +27,17 @@ constexpr size_t REDOWNLOAD_BUFFER_SIZE{14441}; // 14441/606 = ~23.8 commitments
 // Our memory analysis assumes 48 bytes for a CompressedHeader (so we should
 // re-calculate parameters if we compress further)
 static_assert(sizeof(CompressedHeader) == 48);
+
+arith_uint256 CalculateAntiDoSWorkThreshold(
+    const arith_uint256& tip_chain_work,
+    const arith_uint256& tip_block_work,
+    const arith_uint256& minimum_chain_work)
+{
+    const arith_uint256 buffered_work = std::min<arith_uint256>(
+        tip_block_work * ANTI_DOS_HEADER_WORK_BUFFER,
+        tip_chain_work);
+    return std::max<arith_uint256>(tip_chain_work - buffered_work, minimum_chain_work);
+}
 
 HeadersSyncState::HeadersSyncState(NodeId id, const Consensus::Params& consensus_params,
         const CBlockIndex* chain_start, const arith_uint256& minimum_required_work) :

--- a/src/headerssync.h
+++ b/src/headerssync.h
@@ -52,6 +52,18 @@ struct CompressedHeader {
     };
 };
 
+/**
+ * Calculate the minimum chain work required before headers may be stored.
+ *
+ * The 144-block buffer count is header-relay policy inherited from Bitcoin
+ * Core; the resulting work threshold still scales with the current tip's
+ * block work.
+ */
+arith_uint256 CalculateAntiDoSWorkThreshold(
+    const arith_uint256& tip_chain_work,
+    const arith_uint256& tip_block_work,
+    const arith_uint256& minimum_chain_work);
+
 /** HeadersSyncState:
  *
  * We wish to download a peer's headers chain in a DoS-resistant way.

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2464,15 +2464,18 @@ bool PeerManagerImpl::CheckHeadersPoW(const std::vector<CBlockHeader>& headers, 
 
 arith_uint256 PeerManagerImpl::GetAntiDoSWorkThreshold()
 {
-    arith_uint256 near_chaintip_work = 0;
+    arith_uint256 tip_chain_work{0};
+    arith_uint256 tip_block_work{0};
     LOCK(cs_main);
     if (m_chainman.ActiveChain().Tip() != nullptr) {
         const CBlockIndex *tip = m_chainman.ActiveChain().Tip();
-        // Use a 144 block buffer, so that we'll accept headers that fork from
-        // near our tip.
-        near_chaintip_work = tip->nChainWork - std::min<arith_uint256>(144*GetBlockProof(*tip), tip->nChainWork);
+        tip_chain_work = tip->nChainWork;
+        tip_block_work = GetBlockProof(*tip);
     }
-    return std::max(near_chaintip_work, m_chainman.MinimumChainWork());
+    return CalculateAntiDoSWorkThreshold(
+        tip_chain_work,
+        tip_block_work,
+        m_chainman.MinimumChainWork());
 }
 
 /**

--- a/src/test/headers_sync_chainwork_tests.cpp
+++ b/src/test/headers_sync_chainwork_tests.cpp
@@ -57,6 +57,41 @@ void HeadersGeneratorSetup::GenerateHeaders(std::vector<CBlockHeader>& headers,
 
 BOOST_FIXTURE_TEST_SUITE(headers_sync_chainwork_tests, HeadersGeneratorSetup)
 
+BOOST_AUTO_TEST_CASE(anti_dos_work_threshold)
+{
+    struct ThresholdVector {
+        arith_uint256 tip_chain_work;
+        arith_uint256 tip_block_work;
+        arith_uint256 minimum_chain_work;
+        arith_uint256 expected;
+    };
+
+    const std::vector<ThresholdVector> vectors{
+        // No active tip: the configured floor is authoritative.
+        {0, 0, 37, 37},
+        // The near-tip subtraction saturates instead of underflowing.
+        {100, 2, 0, 0},
+        // Constant-work tip, with and without a dominating configured floor.
+        {1000, 2, 0, 712},
+        {1000, 2, 800, 800},
+        // The current tip's work, not an average of recent blocks, sets the buffer.
+        {100000, 500, 0, 28000},
+        {100000, 5, 0, 99280},
+        // A configured floor may be above the local tip's chain work.
+        {1000, 2, 1200, 1200},
+    };
+
+    for (size_t i = 0; i < vectors.size(); ++i) {
+        const auto& test = vectors[i];
+        BOOST_TEST_CONTEXT("threshold vector " << i) {
+            BOOST_CHECK(CalculateAntiDoSWorkThreshold(
+                test.tip_chain_work,
+                test.tip_block_work,
+                test.minimum_chain_work) == test.expected);
+        }
+    }
+}
+
 // In this test, we construct two sets of headers from genesis, one with
 // sufficient proof of work and one without.
 // 1. We deliver the first set of headers and verify that the headers sync state

--- a/test/functional/p2p_headers_sync_with_minchainwork.py
+++ b/test/functional/p2p_headers_sync_with_minchainwork.py
@@ -11,6 +11,8 @@ from test_framework.p2p import (
 )
 
 from test_framework.messages import (
+    CBlockHeader,
+    from_hex,
     msg_headers,
 )
 
@@ -19,7 +21,10 @@ from test_framework.blocktools import (
     create_block,
 )
 
-from test_framework.util import assert_equal
+from test_framework.util import (
+    assert_equal,
+    assert_raises_rpc_error,
+)
 
 NODE1_BLOCKS_REQUIRED = 15
 NODE2_BLOCKS_REQUIRED = 2047
@@ -31,7 +36,7 @@ class RejectLowDifficultyHeadersTest(BTQTestFramework):
         self.setup_clean_chain = True
         self.num_nodes = 4
         # Node0 has no required chainwork; node1 requires 15 blocks on top of the genesis block; node2 requires 2047
-        self.extra_args = [["-minimumchainwork=0x0", "-checkblockindex=0"], ["-minimumchainwork=0x1f", "-checkblockindex=0"], ["-minimumchainwork=0x1000", "-checkblockindex=0"], ["-minimumchainwork=0x1000", "-checkblockindex=0", "-whitelist=noban@127.0.0.1"]]
+        self.extra_args = [["-minimumchainwork=0x0", "-checkblockindex=0"], ["-minimumchainwork=0x20", "-checkblockindex=0"], ["-minimumchainwork=0x1000", "-checkblockindex=0"], ["-minimumchainwork=0x1000", "-checkblockindex=0", "-whitelist=noban@127.0.0.1"]]
 
     def setup_network(self):
         self.setup_nodes()
@@ -52,6 +57,9 @@ class RejectLowDifficultyHeadersTest(BTQTestFramework):
         self.log.info("Generate blocks on the node with no required chainwork, and verify nodes 1 and 2 have no new headers in their headers tree")
         with self.nodes[1].assert_debug_log(expected_msgs=["[net] Ignoring low-work chain (height=14)"]), self.nodes[2].assert_debug_log(expected_msgs=["[net] Ignoring low-work chain (height=14)"]), self.nodes[3].assert_debug_log(expected_msgs=["Synchronizing blockheaders, height: 14"]):
             self.generate(self.nodes[0], NODE1_BLOCKS_REQUIRED-1, sync_fun=self.no_op)
+        # Regtest contributes two units of work per block. Genesis plus 14
+        # blocks is therefore exactly two units below node1's 0x20 floor.
+        assert_equal(int(self.nodes[0].getblockchaininfo()['chainwork'], 16), 0x1e)
 
         # Node3 should always allow headers due to noban permissions
         self.log.info("Check that node3 will sync headers (due to noban permissions)")
@@ -68,12 +76,13 @@ class RejectLowDifficultyHeadersTest(BTQTestFramework):
 
         check_node3_chaintips(2, self.nodes[0].getbestblockhash(), NODE1_BLOCKS_REQUIRED-1)
 
+        genesis_hash = self.nodes[0].getblockhash(0)
         for node in self.nodes[1:3]:
             chaintips = node.getchaintips()
             assert len(chaintips) == 1
             assert {
                 'height': 0,
-                'hash': '0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206',
+                'hash': genesis_hash,
                 'branchlen': 0,
                 'status': 'active',
             } in chaintips
@@ -82,10 +91,14 @@ class RejectLowDifficultyHeadersTest(BTQTestFramework):
         with self.nodes[2].assert_debug_log(expected_msgs=["[net] Ignoring low-work chain (height=15)"]), self.nodes[3].assert_debug_log(expected_msgs=["Synchronizing blockheaders, height: 15"]):
             self.generate(self.nodes[0], NODE1_BLOCKS_REQUIRED - self.nodes[0].getblockcount(), sync_fun=self.no_op)
         self.sync_blocks(self.nodes[0:2]) # node3 will sync headers (noban permissions) but not blocks (due to minchainwork)
+        # Equality with the floor is accepted; the production check rejects
+        # only chains whose total work is strictly lower.
+        assert_equal(int(self.nodes[0].getblockchaininfo()['chainwork'], 16), 0x20)
+        assert_equal(self.nodes[1].getbestblockhash(), self.nodes[0].getbestblockhash())
 
         assert {
             'height': 0,
-            'hash': '0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206',
+            'hash': genesis_hash,
             'branchlen': 0,
             'status': 'active',
         } in self.nodes[2].getchaintips()
@@ -100,6 +113,83 @@ class RejectLowDifficultyHeadersTest(BTQTestFramework):
 
         self.log.info("Verify that node2 and node3 will sync the chain when it gets long enough")
         self.sync_blocks()
+
+    @staticmethod
+    def headers_for_hashes(node, hashes):
+        return [from_hex(CBlockHeader(), node.getblockheader(block_hash, False)) for block_hash in hashes]
+
+    def test_tip_relative_threshold_directionality(self):
+        self.log.info("Test exact tip-relative threshold boundaries and directionality")
+        self.sync_all()
+        self.disconnect_all()
+
+        common_height = self.nodes[0].getblockcount()
+        assert_equal(self.nodes[1].getblockcount(), common_height)
+
+        # Build two valid, isolated constant-work forks from the common tip.
+        # The high branch is 200 blocks longer than the low branch, while the
+        # inherited near-tip work buffer is 144 tip-equivalent blocks.
+        high_hashes = self.generate(self.nodes[0], 450, sync_fun=self.no_op)
+        low_hashes = self.generate(self.nodes[1], 250, sync_fun=self.no_op)
+        assert high_hashes[0] != low_hashes[0]
+
+        high_headers = self.headers_for_hashes(self.nodes[0], high_hashes)
+        low_headers = self.headers_for_hashes(self.nodes[1], low_hashes)
+
+        # The high-work node filters the lower-work fork, but does not
+        # disconnect the peer that announced it.
+        peer_to_high = self.nodes[0].add_p2p_connection(P2PInterface())
+        with self.nodes[0].assert_debug_log(expected_msgs=[f"[net] Ignoring low-work chain (height={common_height + len(low_headers)})"]):
+            peer_to_high.send_and_ping(msg_headers(headers=low_headers))
+        assert peer_to_high.is_connected
+        assert_raises_rpc_error(-5, "Block not found", self.nodes[0].getblockheader, low_hashes[-1])
+
+        # In the opposite direction, the higher-work fork necessarily clears
+        # the lower-work node's threshold and is stored as headers.
+        peer_to_low = self.nodes[1].add_p2p_connection(P2PInterface())
+        peer_to_low.send_and_ping(msg_headers(headers=high_headers))
+        assert peer_to_low.is_connected
+        assert_equal(
+            self.nodes[1].getblockheader(high_hashes[-1])['height'],
+            common_height + len(high_headers),
+        )
+
+        # With two work units per regtest block, a header building on the
+        # ancestor 145 blocks behind the tip has total chainwork exactly equal
+        # to the dynamic threshold. Moving its parent back one more block is
+        # exactly two work units below the threshold.
+        active_tip_height = self.nodes[0].getblockcount()
+        equal_parent_hash = self.nodes[0].getblockhash(active_tip_height - 145)
+        below_parent_hash = self.nodes[0].getblockhash(active_tip_height - 146)
+
+        equal_header = create_block(
+            hashprev=int(equal_parent_hash, 16),
+            tmpl=self.nodes[0].getblocktemplate(NORMAL_GBT_REQUEST_PARAMS),
+        )
+        equal_header.solve()
+        below_header = create_block(
+            hashprev=int(below_parent_hash, 16),
+            tmpl=self.nodes[0].getblocktemplate(NORMAL_GBT_REQUEST_PARAMS),
+        )
+        below_header.solve()
+
+        with self.nodes[0].assert_debug_log(expected_msgs=["[net] Ignoring low-work chain"]):
+            peer_to_high.send_and_ping(msg_headers(headers=[below_header]))
+        assert peer_to_high.is_connected
+        assert_raises_rpc_error(-5, "Block not found", self.nodes[0].getblockheader, below_header.hash)
+
+        peer_to_high.send_and_ping(msg_headers(headers=[equal_header]))
+        assert peer_to_high.is_connected
+        equal_header_info = self.nodes[0].getblockheader(equal_header.hash)
+        tip_chainwork = int(self.nodes[0].getblockheader(high_hashes[-1])['chainwork'], 16)
+        assert_equal(int(equal_header_info['chainwork'], 16), tip_chainwork - 144 * 2)
+
+        # Clear outstanding block requests to the synthetic peers, reconnect
+        # the real nodes, and converge before the remaining reorg tests.
+        self.nodes[0].disconnect_p2ps()
+        self.nodes[1].disconnect_p2ps()
+        self.reconnect_all()
+        self.sync_blocks(timeout=120)
 
     def test_peerinfo_includes_headers_presync_height(self):
         self.log.info("Test that getpeerinfo() includes headers presync height")
@@ -135,6 +225,11 @@ class RejectLowDifficultyHeadersTest(BTQTestFramework):
         self.log.info("Test that a 2000+ block reorg, starting from a point that is more than 2000 blocks before a locator entry, can succeed")
 
         self.sync_all() # Ensure all nodes are synced.
+        # BTQ's future-timestamp window is shorter than Bitcoin's. Re-anchor
+        # mock time at the shared tip before rapidly mining both long forks.
+        tip_time = self.nodes[0].getblockheader(self.nodes[0].getbestblockhash())['time']
+        for node in self.nodes:
+            node.setmocktime(tip_time)
         self.disconnect_all()
 
         # locator(block at height T) will have heights:
@@ -154,6 +249,8 @@ class RejectLowDifficultyHeadersTest(BTQTestFramework):
 
     def run_test(self):
         self.test_chains_sync_when_long_enough()
+
+        self.test_tip_relative_threshold_directionality()
 
         self.test_large_reorgs_can_succeed()
 


### PR DESCRIPTION
## Summary

Draft coverage/refactor PR for the inherited header-work anti-DoS path.

It extracts the existing threshold expression into a production-called helper, verifies its BTQ-specific work vectors, repairs the stale Bitcoin regtest-genesis assertion, and exercises exact acceptance/rejection boundaries through `PeerManager` over P2P.

This is intentionally a behavior-preserving characterization. It does not fix or explain the testnet incident.

Refs #175. #168 is context only.

## Motivation

The previous PR copied a private threshold helper into a unit test and used it to support a mutual-rejection incident claim. Such a test can pass even if production changes, and mutual threshold rejection is impossible when each threshold is bounded by its own chainwork.

The owning inherited functional test also hardcoded Bitcoin regtest genesis, so part of its state assertion was invalid for BTQ.

## Approach

- Extract `CalculateAntiDoSWorkThreshold` into `headerssync` and keep `PeerManagerImpl::GetAntiDoSWorkThreshold` as its production caller under the same `cs_main` scope.
- Preserve the exact inherited expression: `max(W - min(144*p, W), M)`.
- Add unit vectors for subtraction saturation, minimum-chainwork dominance, and variable current-tip work.
- Derive the regtest genesis hash dynamically and move the floor to exact equality at `0x20`.
- Through actual P2P header processing, assert below-threshold absence from the block index, equality acceptance, asymmetric high/low behavior, and peer connection retention.
- Run the targeted functional test in the active lean CI workflow.

Regtest has constant work. Variable tip-work arithmetic is therefore owned by the production-helper unit vectors; the functional test owns network-path behavior.

## Exact behavior checked

- Regtest chainwork `0x1e` is ignored below a `0x20` floor.
- Equality at `0x20` is accepted because production compares `<`, not `<=`.
- A higher-work node filters the lower-work fork; the lower-work node accepts the higher-work fork.
- A header exactly at the dynamic tip-relative threshold is stored; one regtest block-work below is not.
- Low-work filtering does not disconnect the announcing peers.

These outcomes refute mutual low-work filtering as a self-contained stable-split explanation. They do not identify the root cause of #168.

## Testing

Ubuntu 22.04 aarch64, GCC, C++17:

```bash
src/test/test_btq --run_test=headers_sync_chainwork_tests
python3 test/functional/test_runner.py p2p_headers_sync_with_minchainwork.py --jobs=1
python3 -m py_compile test/functional/p2p_headers_sync_with_minchainwork.py
git diff --check e2d19e06b..HEAD
```

Results:

- clean `btqd` and `test_btq` build passed;
- both unit cases passed;
- exact workflow functional command passed;
- four deterministic seed/portseed repeats (101, 202, 303, 404) passed;
- targeted flake8 and mypy passed;
- workflow YAML parsing passed.

Broad repository lint is not claimed green; the wrapper currently reports unrelated baseline type failures.

## Bitcoin 26 differential

Pinned baseline: `44d8b13c81e5276eb610c99f227a4d090cc532f6`.

The same modified functional scenario was run against a clean Bitcoin Core 26.0 worktree with no baseline production file changed, seed/portseed 606. It completed successfully with the same below/equality/directionality/connection outcomes. The threshold production code at the BTQ base is inherited from that baseline.

## Risk and compatibility

**Risk: low, network code touched.** The production edit is an algebraically identical helper extraction with unchanged lock ownership and configured floor. No consensus, wire-format, policy value, wallet, RPC, or configuration behavior changes.

The public scope deliberately excludes mainnet attack fixtures, throughput or memory-amplification reproducers, minimum-chainwork changes, the inherited 144-block buffer choice, and headers-sync parameter recalibration. Any suspected mainnet weakness belongs in the private security process.

No release note is needed for this coverage/refactor.

## Audit-matrix scope

This is a scoped evidence increment for C19. It does not satisfy C19: a replacement BTQ header corpus, invalid LWMA/P2MR relay vectors, calibration review, and independent external review remain missing. It does not satisfy C03 or close #168.

## Review gate

Keep Draft until:

- a network/DoS reviewer traces the production call path and records a Tested ACK;
- a PoW reviewer independently checks the work arithmetic;
- a test-framework reviewer confirms state assertions and cleanup;
- two exact-head public ACKs and relevant green CI are recorded.

Any force-push invalidates prior ACKs until reviewers inspect the range-diff.