### PR TITLE
wallet: refuse trivial P2MR leaves unless allowed

### DIFF
--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -340,7 +340,8 @@ public:
 
     //! Create and persist a new P2MR destination.
     virtual util::Result<WalletP2MRCreated> createP2MR(const std::vector<WalletP2MRTreeLeaf>& leaves,
-                                                      const std::string& label) = 0;
+                                                      const std::string& label,
+                                                      bool allow_trivial_leaves = false) = 0;
 
     //! Create + persist + fund a P2MR destination atomically.
     virtual util::Result<WalletP2MRFunded> fundP2MR(const std::vector<WalletP2MRTreeLeaf>& leaves,

--- a/src/qt/p2mrcontroller.cpp
+++ b/src/qt/p2mrcontroller.cpp
@@ -80,6 +80,7 @@ CAmount P2MRController::totalBalance(int min_depth)
 
 bool P2MRController::createVault(const std::vector<interfaces::WalletP2MRTreeLeaf>& leaves,
                                  const QString& label,
+                                 bool allow_trivial_leaves,
                                  interfaces::WalletP2MRCreated& out,
                                  QString& error)
 {
@@ -87,7 +88,7 @@ bool P2MRController::createVault(const std::vector<interfaces::WalletP2MRTreeLea
         error = tr("Wallet model unavailable");
         return false;
     }
-    auto res = m_wallet_model->wallet().createP2MR(leaves, label.toStdString());
+    auto res = m_wallet_model->wallet().createP2MR(leaves, label.toStdString(), allow_trivial_leaves);
     if (!res) {
         error = FromBilingual(util::ErrorString(res));
         return false;

--- a/src/qt/p2mrcontroller.h
+++ b/src/qt/p2mrcontroller.h
@@ -75,6 +75,7 @@ public:
     /** Create a new P2MR address. Returns descriptive error on failure. */
     bool createVault(const std::vector<interfaces::WalletP2MRTreeLeaf>& leaves,
                      const QString& label,
+                     bool allow_trivial_leaves,
                      interfaces::WalletP2MRCreated& out,
                      QString& error);
 

--- a/src/qt/p2mrwizards.cpp
+++ b/src/qt/p2mrwizards.cpp
@@ -312,7 +312,8 @@ void P2MRNewVaultDialog::accept()
                 .arg(m_created_address, QString::fromStdString(funded.txid.GetHex())));
     } else {
         interfaces::WalletP2MRCreated created;
-        if (!m_controller->createVault(leaves, label, created, error)) {
+        const bool allow_trivial_leaves = tpl == P2MRController::TreeTemplate::OpTrue;
+        if (!m_controller->createVault(leaves, label, allow_trivial_leaves, created, error)) {
             QMessageBox::critical(this, windowTitle(), error);
             return;
         }

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -306,9 +306,11 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "addnode", 2, "v2transport" },
     // P2MR wallet RPCs
     { "getnewp2mraddress", 0, "tree" },
+    { "getnewp2mraddress", 2, "allow_trivial_leaves" },
     { "sendtop2mr", 0, "tree" },
     { "sendtop2mr", 1, "amount" },
     { "sendtop2mr", 5, "subtractfeefromamount" },
+    { "sendtop2mr", 6, "allow_trivial_leaves" },
     { "createp2mrspend", 2, "amount" },
     { "createp2mrspend", 3, "fee" },
     // Dilithium wallet RPCs

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -612,10 +612,12 @@ public:
     }
     util::Result<interfaces::WalletP2MRCreated> createP2MR(
         const std::vector<interfaces::WalletP2MRTreeLeaf>& leaves,
-        const std::string& label) override
+        const std::string& label,
+        bool allow_trivial_leaves) override
     {
         LOCK(m_wallet->cs_wallet);
-        auto res = CreateP2MR(*m_wallet, FromInterfaceLeaves(leaves), label);
+        auto res = CreateP2MR(*m_wallet, FromInterfaceLeaves(leaves), label,
+                              /*add_to_address_book=*/true, allow_trivial_leaves);
         if (!res) return util::Error{util::ErrorString(res)};
         return ToInterfaceCreated(*res);
     }

--- a/src/wallet/p2mr.cpp
+++ b/src/wallet/p2mr.cpp
@@ -338,6 +338,11 @@ P2MREntry MetadataToEntry(const CTxDestination& dest, const UniValue& meta, cons
 
 } // namespace
 
+bool IsTrivialP2MRLeaf(const P2MRTreeLeaf& leaf)
+{
+    return leaf.script.empty() || IsOpTrueLeaf(leaf);
+}
+
 // --- Tree parsing ----------------------------------------------------------
 
 util::Result<std::vector<P2MRTreeLeaf>> ParseP2MRTreeChecked(const UniValue& tree)
@@ -680,9 +685,18 @@ util::Result<P2MRCreated> ImportDilithiumKeyAsP2MR(CWallet& wallet,
 util::Result<P2MRCreated> CreateP2MR(CWallet& wallet,
                                      const std::vector<P2MRTreeLeaf>& leaves,
                                      const std::string& label,
-                                     bool add_to_address_book)
+                                     bool add_to_address_book,
+                                     bool allow_trivial_leaves)
 {
     AssertLockHeld(wallet.cs_wallet);
+    if (!allow_trivial_leaves) {
+        for (const auto& leaf : leaves) {
+            if (IsTrivialP2MRLeaf(leaf)) {
+                return util::Error{Untranslated(
+                    "P2MR tree contains a trivial anyone-can-spend leaf (empty or OP_TRUE); pass allow_trivial_leaves if this is intentional")};
+            }
+        }
+    }
     auto builder_res = BuildP2MRTreeChecked(leaves);
     if (!builder_res) return util::Error{util::ErrorString(builder_res)};
     P2MRBuilder builder = std::move(*builder_res);
@@ -722,14 +736,15 @@ util::Result<P2MRFunded> FundP2MR(CWallet& wallet,
                                   CAmount amount,
                                   const std::string& label,
                                   bool subtract_fee_from_amount,
-                                  const CCoinControl& coin_control)
+                                  const CCoinControl& coin_control,
+                                  bool allow_trivial_leaves)
 {
     AssertLockHeld(wallet.cs_wallet);
     if (wallet.IsLocked()) {
         return util::Error{_("Wallet is locked")};
     }
 
-    auto created_res = CreateP2MR(wallet, leaves, label);
+    auto created_res = CreateP2MR(wallet, leaves, label, /*add_to_address_book=*/true, allow_trivial_leaves);
     if (!created_res) return util::Error{util::ErrorString(created_res)};
     P2MRCreated created = std::move(*created_res);
 

--- a/src/wallet/p2mr.cpp
+++ b/src/wallet/p2mr.cpp
@@ -338,11 +338,6 @@ P2MREntry MetadataToEntry(const CTxDestination& dest, const UniValue& meta, cons
 
 } // namespace
 
-bool IsTrivialP2MRLeaf(const P2MRTreeLeaf& leaf)
-{
-    return leaf.script.empty() || IsOpTrueLeaf(leaf);
-}
-
 // --- Tree parsing ----------------------------------------------------------
 
 util::Result<std::vector<P2MRTreeLeaf>> ParseP2MRTreeChecked(const UniValue& tree)
@@ -691,9 +686,10 @@ util::Result<P2MRCreated> CreateP2MR(CWallet& wallet,
     AssertLockHeld(wallet.cs_wallet);
     if (!allow_trivial_leaves) {
         for (const auto& leaf : leaves) {
-            if (IsTrivialP2MRLeaf(leaf)) {
+            const CScript script{leaf.script.begin(), leaf.script.end()};
+            if (leaf.leaf_version != TAPROOT_LEAF_TAPSCRIPT || !IsDilithiumLeafSpendable(wallet, script)) {
                 return util::Error{Untranslated(
-                    "P2MR tree contains a trivial anyone-can-spend leaf (empty or OP_TRUE); pass allow_trivial_leaves if this is intentional")};
+                    "P2MR tree contains a leaf the wallet cannot safely spend; pass allow_trivial_leaves if this is intentional")};
             }
         }
     }

--- a/src/wallet/p2mr.h
+++ b/src/wallet/p2mr.h
@@ -136,13 +136,19 @@ std::optional<CKeyID> GetSingleDilithiumKeyIDForP2MR(const CWallet& wallet, cons
 /** Whether any ScriptPubKeyMan in the wallet holds this Dilithium private key. */
 bool WalletHaveDilithiumKey(const CWallet& wallet, const CKeyID& keyid);
 
+/** True if the leaf is empty or a lone OP_TRUE. Those trees are consensus-valid
+ *  anyone-can-spend outputs; the wallet refuses them unless the caller opts in. */
+bool IsTrivialP2MRLeaf(const P2MRTreeLeaf& leaf);
+
 /** Create and persist a new P2MR destination.
  *  Pass add_to_address_book=false for change destinations: an address book
- *  entry is what makes CWallet::IsChange treat an output as a receive. */
+ *  entry is what makes CWallet::IsChange treat an output as a receive.
+ *  Trivial anyone-can-spend leaves are rejected unless allow_trivial_leaves. */
 util::Result<P2MRCreated> CreateP2MR(CWallet& wallet,
                                      const std::vector<P2MRTreeLeaf>& leaves,
                                      const std::string& label,
-                                     bool add_to_address_book = true);
+                                     bool add_to_address_book = true,
+                                     bool allow_trivial_leaves = false);
 
 /**
  * Generate (or reuse) a wallet Dilithium key and create a single-leaf P2MR
@@ -167,7 +173,8 @@ util::Result<P2MRFunded> FundP2MR(CWallet& wallet,
                                   CAmount amount,
                                   const std::string& label,
                                   bool subtract_fee_from_amount,
-                                  const CCoinControl& coin_control);
+                                  const CCoinControl& coin_control,
+                                  bool allow_trivial_leaves = false);
 
 /** Build an unsigned spend of a tracked P2MR UTXO to a destination.
  *  Non-const because change address generation may extend the keypool. */

--- a/src/wallet/p2mr.h
+++ b/src/wallet/p2mr.h
@@ -136,14 +136,11 @@ std::optional<CKeyID> GetSingleDilithiumKeyIDForP2MR(const CWallet& wallet, cons
 /** Whether any ScriptPubKeyMan in the wallet holds this Dilithium private key. */
 bool WalletHaveDilithiumKey(const CWallet& wallet, const CKeyID& keyid);
 
-/** True if the leaf is empty or a lone OP_TRUE. Those trees are consensus-valid
- *  anyone-can-spend outputs; the wallet refuses them unless the caller opts in. */
-bool IsTrivialP2MRLeaf(const P2MRTreeLeaf& leaf);
-
 /** Create and persist a new P2MR destination.
  *  Pass add_to_address_book=false for change destinations: an address book
  *  entry is what makes CWallet::IsChange treat an output as a receive.
- *  Trivial anyone-can-spend leaves are rejected unless allow_trivial_leaves. */
+ *  Leaves the wallet cannot spend through a known Dilithium template are
+ *  rejected unless allow_trivial_leaves is set. */
 util::Result<P2MRCreated> CreateP2MR(CWallet& wallet,
                                      const std::vector<P2MRTreeLeaf>& leaves,
                                      const std::string& label,

--- a/src/wallet/rpc/p2mr.cpp
+++ b/src/wallet/rpc/p2mr.cpp
@@ -42,10 +42,14 @@ RPCHelpMan getnewp2mraddress()
 {
     return RPCHelpMan{
         "getnewp2mraddress",
-        "\nCreate and store a new wallet-managed P2MR destination.\n",
+        "\nCreate and store a new wallet-managed P2MR destination.\n"
+        "The normal Dilithium receive path is getnewdilithiumaddress. This RPC is for custom trees.\n"
+        "A leaf whose script is empty or OP_TRUE (hex 51) is anyone-can-spend. Those trees are\n"
+        "rejected unless allow_trivial_leaves is true (regtest and tests only).\n",
         {
             {"tree", RPCArg::Type::ARR, RPCArg::Optional::NO, "P2MR tree leaves in DFS order", std::vector<RPCArg>{}, RPCArgOptions{}},
             {"label", RPCArg::Type::STR, RPCArg::Default{""}, "Optional label"},
+            {"allow_trivial_leaves", RPCArg::Type::BOOL, RPCArg::Default{false}, "Allow empty or OP_TRUE leaves (anyone-can-spend). Tests only."},
         },
         RPCResult{
             RPCResult::Type::OBJ, "", "",
@@ -55,7 +59,10 @@ RPCHelpMan getnewp2mraddress()
                 {RPCResult::Type::STR_HEX, "scriptPubKey", "P2MR scriptPubKey"},
                 {RPCResult::Type::STR_HEX, "merkle_root", "P2MR merkle root"},
             }},
-        RPCExamples{HelpExampleCli("getnewp2mraddress", "'[{\"depth\":0,\"leaf_version\":192,\"script\":\"51\"}]'")},
+        RPCExamples{
+            HelpExampleCli("getnewdilithiumaddress", "")
+            + HelpExampleCli("getnewp2mraddress", "'[{\"depth\":0,\"leaf_version\":192,\"script\":\"51\"}]' \"\" true")
+        },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
         {
             std::shared_ptr<CWallet> const pwallet = GetWalletForJSONRPCRequest(request);
@@ -63,9 +70,10 @@ RPCHelpMan getnewp2mraddress()
 
             const auto leaves = ParseP2MRTreeFromUniValue(request.params[0]);
             const std::string label = request.params[1].isNull() ? "" : LabelFromValue(request.params[1]);
+            const bool allow_trivial = !request.params[2].isNull() && request.params[2].get_bool();
 
             LOCK(pwallet->cs_wallet);
-            auto created = CreateP2MR(*pwallet, leaves, label);
+            auto created = CreateP2MR(*pwallet, leaves, label, /*add_to_address_book=*/true, allow_trivial);
             if (!created) {
                 throw JSONRPCError(RPC_WALLET_ERROR, util::ErrorString(created).original);
             }
@@ -84,7 +92,9 @@ RPCHelpMan sendtop2mr()
 {
     return RPCHelpMan{
         "sendtop2mr",
-        "\nCreate a wallet-tracked P2MR destination and send funds to it.\n",
+        "\nCreate a wallet-tracked P2MR destination and send funds to it.\n"
+        "Trivial anyone-can-spend leaves (empty or OP_TRUE / hex 51) are rejected unless\n"
+        "allow_trivial_leaves is true. Prefer getnewdilithiumaddress for ordinary receive.\n",
         {
             {"tree", RPCArg::Type::ARR, RPCArg::Optional::NO, "P2MR tree leaves in DFS order", std::vector<RPCArg>{}, RPCArgOptions{}},
             {"amount", RPCArg::Type::AMOUNT, RPCArg::Optional::NO, "Amount to send"},
@@ -92,13 +102,14 @@ RPCHelpMan sendtop2mr()
             {"comment", RPCArg::Type::STR, RPCArg::Default{""}, "Wallet comment"},
             {"comment_to", RPCArg::Type::STR, RPCArg::Default{""}, "Wallet comment-to"},
             {"subtractfeefromamount", RPCArg::Type::BOOL, RPCArg::Default{false}, "Subtract fee from amount"},
+            {"allow_trivial_leaves", RPCArg::Type::BOOL, RPCArg::Default{false}, "Allow empty or OP_TRUE leaves (anyone-can-spend). Tests only."},
         },
         RPCResult{RPCResult::Type::OBJ, "", "", {
             {RPCResult::Type::STR_HEX, "txid", "Funding transaction id"},
             {RPCResult::Type::STR, "address", "P2MR destination"},
             {RPCResult::Type::STR, "p2mr_id", "Stored metadata id"},
         }},
-        RPCExamples{HelpExampleCli("sendtop2mr", "'[{\"depth\":0,\"leaf_version\":192,\"script\":\"51\"}]' 1.0")},
+        RPCExamples{HelpExampleCli("sendtop2mr", "'[{\"depth\":0,\"leaf_version\":192,\"script\":\"51\"}]' 1.0 \"\" \"\" \"\" false true")},
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
         {
             std::shared_ptr<CWallet> const pwallet = GetWalletForJSONRPCRequest(request);
@@ -108,14 +119,19 @@ RPCHelpMan sendtop2mr()
             const CAmount amount = AmountFromValue(request.params[1]);
             const std::string label = request.params[2].isNull() ? "" : LabelFromValue(request.params[2]);
             const bool subtract_fee = request.params[5].isNull() ? false : request.params[5].get_bool();
+            const bool allow_trivial = !request.params[6].isNull() && request.params[6].get_bool();
 
             LOCK(pwallet->cs_wallet);
             EnsureWalletIsUnlocked(*pwallet);
 
             CCoinControl coin_control;
-            auto funded = FundP2MR(*pwallet, leaves, amount, label, subtract_fee, coin_control);
+            auto funded = FundP2MR(*pwallet, leaves, amount, label, subtract_fee, coin_control, allow_trivial);
             if (!funded) {
-                throw JSONRPCError(RPC_WALLET_INSUFFICIENT_FUNDS, util::ErrorString(funded).original);
+                const std::string msg = util::ErrorString(funded).original;
+                if (msg.find("trivial anyone-can-spend") != std::string::npos) {
+                    throw JSONRPCError(RPC_WALLET_ERROR, msg);
+                }
+                throw JSONRPCError(RPC_WALLET_INSUFFICIENT_FUNDS, msg);
             }
 
             UniValue out(UniValue::VOBJ);

--- a/src/wallet/rpc/p2mr.cpp
+++ b/src/wallet/rpc/p2mr.cpp
@@ -44,12 +44,12 @@ RPCHelpMan getnewp2mraddress()
         "getnewp2mraddress",
         "\nCreate and store a new wallet-managed P2MR destination.\n"
         "The normal Dilithium receive path is getnewdilithiumaddress. This RPC is for custom trees.\n"
-        "A leaf whose script is empty or OP_TRUE (hex 51) is anyone-can-spend. Those trees are\n"
-        "rejected unless allow_trivial_leaves is true (regtest and tests only).\n",
+        "Leaves are rejected unless the wallet recognises them as spendable Dilithium scripts or\n"
+        "allow_trivial_leaves is true (regtest and tests only).\n",
         {
             {"tree", RPCArg::Type::ARR, RPCArg::Optional::NO, "P2MR tree leaves in DFS order", std::vector<RPCArg>{}, RPCArgOptions{}},
             {"label", RPCArg::Type::STR, RPCArg::Default{""}, "Optional label"},
-            {"allow_trivial_leaves", RPCArg::Type::BOOL, RPCArg::Default{false}, "Allow empty or OP_TRUE leaves (anyone-can-spend). Tests only."},
+            {"allow_trivial_leaves", RPCArg::Type::BOOL, RPCArg::Default{false}, "Allow leaves outside known wallet-spendable Dilithium templates. Tests only."},
         },
         RPCResult{
             RPCResult::Type::OBJ, "", "",
@@ -93,7 +93,7 @@ RPCHelpMan sendtop2mr()
     return RPCHelpMan{
         "sendtop2mr",
         "\nCreate a wallet-tracked P2MR destination and send funds to it.\n"
-        "Trivial anyone-can-spend leaves (empty or OP_TRUE / hex 51) are rejected unless\n"
+        "Leaves outside known wallet-spendable Dilithium templates are rejected unless\n"
         "allow_trivial_leaves is true. Prefer getnewdilithiumaddress for ordinary receive.\n",
         {
             {"tree", RPCArg::Type::ARR, RPCArg::Optional::NO, "P2MR tree leaves in DFS order", std::vector<RPCArg>{}, RPCArgOptions{}},
@@ -102,7 +102,7 @@ RPCHelpMan sendtop2mr()
             {"comment", RPCArg::Type::STR, RPCArg::Default{""}, "Wallet comment"},
             {"comment_to", RPCArg::Type::STR, RPCArg::Default{""}, "Wallet comment-to"},
             {"subtractfeefromamount", RPCArg::Type::BOOL, RPCArg::Default{false}, "Subtract fee from amount"},
-            {"allow_trivial_leaves", RPCArg::Type::BOOL, RPCArg::Default{false}, "Allow empty or OP_TRUE leaves (anyone-can-spend). Tests only."},
+            {"allow_trivial_leaves", RPCArg::Type::BOOL, RPCArg::Default{false}, "Allow leaves outside known wallet-spendable Dilithium templates. Tests only."},
         },
         RPCResult{RPCResult::Type::OBJ, "", "", {
             {RPCResult::Type::STR_HEX, "txid", "Funding transaction id"},
@@ -128,7 +128,7 @@ RPCHelpMan sendtop2mr()
             auto funded = FundP2MR(*pwallet, leaves, amount, label, subtract_fee, coin_control, allow_trivial);
             if (!funded) {
                 const std::string msg = util::ErrorString(funded).original;
-                if (msg.find("trivial anyone-can-spend") != std::string::npos) {
+                if (msg.find("cannot safely spend") != std::string::npos) {
                     throw JSONRPCError(RPC_WALLET_ERROR, msg);
                 }
                 throw JSONRPCError(RPC_WALLET_INSUFFICIENT_FUNDS, msg);

--- a/src/wallet/test/p2mr_tests.cpp
+++ b/src/wallet/test/p2mr_tests.cpp
@@ -14,6 +14,7 @@
 #include <script/sign.h>
 #include <script/signingprovider.h>
 #include <univalue.h>
+#include <util/result.h>
 #include <util/strencodings.h>
 #include <util/vector.h>
 #include <validation.h>
@@ -198,15 +199,29 @@ BOOST_AUTO_TEST_CASE(reject_typeerror_on_script_int)
     BOOST_CHECK(!parsed);
 }
 
+BOOST_FIXTURE_TEST_CASE(create_rejects_trivial_leaves_by_default, BasicTestingSetup)
+{
+    auto wallet = MakeP2MRTestWallet(*m_node.chain);
+    LOCK(wallet->cs_wallet);
+    const auto leaves = MakeOpTrueTree();
+
+    auto rejected = CreateP2MR(*wallet, leaves, "unsafe");
+    BOOST_CHECK(!rejected);
+    BOOST_CHECK(util::ErrorString(rejected).original.find("trivial anyone-can-spend") != std::string::npos);
+
+    auto allowed = CreateP2MR(*wallet, leaves, "unsafe", /*add_to_address_book=*/true, /*allow_trivial_leaves=*/true);
+    BOOST_REQUIRE(allowed);
+}
+
 BOOST_FIXTURE_TEST_CASE(create_is_idempotent_for_identical_tree, BasicTestingSetup)
 {
     auto wallet = MakeP2MRTestWallet(*m_node.chain);
     LOCK(wallet->cs_wallet);
     const auto leaves = MakeOpTrueTree();
 
-    auto first = CreateP2MR(*wallet, leaves, "first");
+    auto first = CreateP2MR(*wallet, leaves, "first", /*add_to_address_book=*/true, /*allow_trivial_leaves=*/true);
     BOOST_REQUIRE(first);
-    auto second = CreateP2MR(*wallet, leaves, "second");
+    auto second = CreateP2MR(*wallet, leaves, "second", /*add_to_address_book=*/true, /*allow_trivial_leaves=*/true);
     BOOST_REQUIRE(second);
 
     BOOST_CHECK_EQUAL(second->id, first->id);
@@ -227,7 +242,7 @@ BOOST_FIXTURE_TEST_CASE(wallet_is_mine_recognizes_valid_p2mr_metadata, BasicTest
 
     BOOST_CHECK_EQUAL(wallet->IsMine(tracked_script), ISMINE_NO);
 
-    auto created = CreateP2MR(*wallet, leaves, "tracked");
+    auto created = CreateP2MR(*wallet, leaves, "tracked", /*add_to_address_book=*/true, /*allow_trivial_leaves=*/true);
     BOOST_REQUIRE(created);
     BOOST_CHECK_EQUAL(HexStr(created->script_pub_key), HexStr(tracked_script));
     BOOST_CHECK_EQUAL(wallet->IsMine(created->script_pub_key), ISMINE_SPENDABLE);
@@ -282,7 +297,7 @@ BOOST_FIXTURE_TEST_CASE(tracked_balance_deduplicates_legacy_duplicate_metadata, 
     LOCK(wallet->cs_wallet);
     const auto leaves = MakeOpTrueTree();
 
-    auto created = CreateP2MR(*wallet, leaves, "original");
+    auto created = CreateP2MR(*wallet, leaves, "original", /*add_to_address_book=*/true, /*allow_trivial_leaves=*/true);
     BOOST_REQUIRE(created);
 
     UniValue duplicate_meta(UniValue::VOBJ);
@@ -326,7 +341,7 @@ BOOST_FIXTURE_TEST_CASE(create_p2mr_spend_aggregates_inputs_and_reports_effectiv
     LOCK(wallet->cs_wallet);
     const auto leaves = MakeOpTrueTree();
 
-    auto created = CreateP2MR(*wallet, leaves, "aggregate");
+    auto created = CreateP2MR(*wallet, leaves, "aggregate", /*add_to_address_book=*/true, /*allow_trivial_leaves=*/true);
     BOOST_REQUIRE(created);
 
     const CBlockIndex* tip = WITH_LOCK(Assert(m_node.chainman)->GetMutex(), return m_node.chainman->ActiveChain().Tip());

--- a/src/wallet/test/p2mr_tests.cpp
+++ b/src/wallet/test/p2mr_tests.cpp
@@ -199,17 +199,25 @@ BOOST_AUTO_TEST_CASE(reject_typeerror_on_script_int)
     BOOST_CHECK(!parsed);
 }
 
-BOOST_FIXTURE_TEST_CASE(create_rejects_trivial_leaves_by_default, BasicTestingSetup)
+BOOST_FIXTURE_TEST_CASE(create_allows_only_wallet_spendable_dilithium_leaves_by_default, BasicTestingSetup)
 {
     auto wallet = MakeP2MRTestWallet(*m_node.chain);
     LOCK(wallet->cs_wallet);
-    const auto leaves = MakeOpTrueTree();
+    const std::vector<std::vector<P2MRTreeLeaf>> rejected_trees{
+        {{0, TAPROOT_LEAF_TAPSCRIPT, {}}},
+        {{0, TAPROOT_LEAF_TAPSCRIPT, {OP_TRUE}}},
+        {{0, TAPROOT_LEAF_TAPSCRIPT, {OP_2}}},
+        {{0, TAPROOT_LEAF_TAPSCRIPT, {OP_DROP, OP_TRUE}}},
+        {{0, TAPROOT_LEAF_TAPSCRIPT, {0x50}}}, // OP_SUCCESS80
+        {{0, 0xc2, {OP_TRUE}}},
+    };
+    for (const auto& leaves : rejected_trees) {
+        auto rejected = CreateP2MR(*wallet, leaves, "unsafe");
+        BOOST_CHECK(!rejected);
+        BOOST_CHECK(util::ErrorString(rejected).original.find("cannot safely spend") != std::string::npos);
+    }
 
-    auto rejected = CreateP2MR(*wallet, leaves, "unsafe");
-    BOOST_CHECK(!rejected);
-    BOOST_CHECK(util::ErrorString(rejected).original.find("trivial anyone-can-spend") != std::string::npos);
-
-    auto allowed = CreateP2MR(*wallet, leaves, "unsafe", /*add_to_address_book=*/true, /*allow_trivial_leaves=*/true);
+    auto allowed = CreateP2MR(*wallet, rejected_trees[3], "unsafe", /*add_to_address_book=*/true, /*allow_trivial_leaves=*/true);
     BOOST_REQUIRE(allowed);
 }
 
@@ -279,7 +287,7 @@ BOOST_FIXTURE_TEST_CASE(wallet_is_mine_tracks_unowned_p2mr_metadata_as_watchonly
     const auto leaves = MakeXOnlyChecksigTree(XOnlyPubKey{external_key.GetPubKey()});
 
     LOCK(wallet->cs_wallet);
-    auto created = CreateP2MR(*wallet, leaves, "external");
+    auto created = CreateP2MR(*wallet, leaves, "external", /*add_to_address_book=*/true, /*allow_trivial_leaves=*/true);
     BOOST_REQUIRE(created);
 
     BOOST_CHECK(IsTrackedP2MRScript(*wallet, created->script_pub_key));
@@ -727,7 +735,7 @@ BOOST_FIXTURE_TEST_CASE(build_signing_provider_exports_descriptor_xonly_p2mr_lea
     FlatSigningProvider provider;
     {
         LOCK(wallet.cs_wallet);
-        auto created_res = CreateP2MR(wallet, leaves, "descriptor-xonly");
+        auto created_res = CreateP2MR(wallet, leaves, "descriptor-xonly", /*add_to_address_book=*/true, /*allow_trivial_leaves=*/true);
         BOOST_REQUIRE(created_res);
         created = std::move(*created_res);
         BOOST_CHECK_EQUAL(wallet.IsMine(created.script_pub_key), ISMINE_SPENDABLE);

--- a/test/functional/feature_p2mr_rpc.py
+++ b/test/functional/feature_p2mr_rpc.py
@@ -36,11 +36,15 @@ class P2MRRPCTest(BTQTestFramework):
             "script": "51",  # OP_TRUE
         }]
 
+        self.log.info("Refuse OP_TRUE trees unless allow_trivial_leaves is set")
+        assert_raises_rpc_error(-4, "trivial anyone-can-spend", wallet.getnewp2mraddress, tree, "rpc-p2mr")
+        assert_raises_rpc_error(-4, "trivial anyone-can-spend", wallet.sendtop2mr, tree, Decimal("1.0"), "rpc-p2mr-fund")
+
         self.log.info("Create, persist, and list a P2MR address")
-        created = wallet.getnewp2mraddress(tree, "rpc-p2mr")
+        created = wallet.getnewp2mraddress(tree, "rpc-p2mr", True)
         assert created["address"]
         assert created["p2mr_id"]
-        duplicate = wallet.getnewp2mraddress(tree, "rpc-p2mr-duplicate")
+        duplicate = wallet.getnewp2mraddress(tree, "rpc-p2mr-duplicate", True)
         assert_equal(duplicate["address"], created["address"])
         assert_equal(duplicate["p2mr_id"], created["p2mr_id"])
         listed = wallet.listp2mr()
@@ -50,7 +54,7 @@ class P2MRRPCTest(BTQTestFramework):
         assert_raises_rpc_error(-8, "unknown p2mr_id", wallet.getp2mrinfo, "does-not-exist")
 
         self.log.info("Fund through convenience RPC")
-        funded = wallet.sendtop2mr(tree, Decimal("1.0"), "rpc-p2mr-fund")
+        funded = wallet.sendtop2mr(tree, Decimal("1.0"), "rpc-p2mr-fund", allow_trivial_leaves=True)
         assert funded["txid"]
         assert_equal(funded["p2mr_id"], created["p2mr_id"])
         self.generate(node, 1)

--- a/test/functional/feature_p2mr_rpc.py
+++ b/test/functional/feature_p2mr_rpc.py
@@ -36,9 +36,18 @@ class P2MRRPCTest(BTQTestFramework):
             "script": "51",  # OP_TRUE
         }]
 
-        self.log.info("Refuse OP_TRUE trees unless allow_trivial_leaves is set")
-        assert_raises_rpc_error(-4, "trivial anyone-can-spend", wallet.getnewp2mraddress, tree, "rpc-p2mr")
-        assert_raises_rpc_error(-4, "trivial anyone-can-spend", wallet.sendtop2mr, tree, Decimal("1.0"), "rpc-p2mr-fund")
+        self.log.info("Refuse leaves outside known Dilithium templates unless explicitly allowed")
+        rejected_trees = [
+            [{"depth": 0, "leaf_version": LEAF_VERSION_TAPSCRIPT, "script": ""}],
+            tree,
+            [{"depth": 0, "leaf_version": LEAF_VERSION_TAPSCRIPT, "script": "52"}],  # OP_2
+            [{"depth": 0, "leaf_version": LEAF_VERSION_TAPSCRIPT, "script": "7551"}],  # OP_DROP OP_TRUE
+            [{"depth": 0, "leaf_version": LEAF_VERSION_TAPSCRIPT, "script": "50"}],  # OP_SUCCESS80
+            [{"depth": 0, "leaf_version": 0xc2, "script": "51"}],
+        ]
+        for rejected_tree in rejected_trees:
+            assert_raises_rpc_error(-4, "cannot safely spend", wallet.getnewp2mraddress, rejected_tree, "rpc-p2mr")
+            assert_raises_rpc_error(-4, "cannot safely spend", wallet.sendtop2mr, rejected_tree, Decimal("1.0"), "rpc-p2mr-fund")
 
         self.log.info("Create, persist, and list a P2MR address")
         created = wallet.getnewp2mraddress(tree, "rpc-p2mr", True)
@@ -103,7 +112,8 @@ class P2MRRPCTest(BTQTestFramework):
             "leaf_version": LEAF_VERSION_TAPSCRIPT,
             "script": "7551",  # OP_DROP OP_TRUE
         }]
-        needs_stack = wallet.sendtop2mr(needs_stack_tree, Decimal("0.1"), "rpc-p2mr-needs-stack")
+        assert_raises_rpc_error(-4, "cannot safely spend", wallet.sendtop2mr, needs_stack_tree, Decimal("0.1"), "rpc-p2mr-needs-stack")
+        needs_stack = wallet.sendtop2mr(needs_stack_tree, Decimal("0.1"), "rpc-p2mr-needs-stack", allow_trivial_leaves=True)
         self.generate(node, 1)
         needs_stack_spend = wallet.createp2mrspend(needs_stack["p2mr_id"], destination, Decimal("0.05"))
         incomplete = wallet.signp2mrtransaction(needs_stack_spend["hex"], needs_stack["p2mr_id"])

--- a/test/functional/wallet_bip360_send_paths.py
+++ b/test/functional/wallet_bip360_send_paths.py
@@ -112,7 +112,7 @@ class WalletBip360SendPathsTest(BTQTestFramework):
             "script": "51",
         }]
 
-        created = receiver.getnewp2mraddress(tree, "plain-wallet-send")
+        created = receiver.getnewp2mraddress(tree, "plain-wallet-send", True)
         assert created["address"].startswith("qcrt1z")
         assert created["scriptPubKey"].startswith("5220")
         assert_equal(receiver.getp2mrinfo(created["p2mr_id"])["address"], created["address"])
@@ -133,8 +133,8 @@ class WalletBip360SendPathsTest(BTQTestFramework):
         self.generate(node, 1)
         assert_equal(receiver.gettransaction(spent_txid, True)["confirmations"], 1)
 
-        funded_p2mr = wallet.sendtop2mr(tree, Decimal("0.25"), "sender-owned-p2mr")
-        duplicate = wallet.getnewp2mraddress(tree, "sender-owned-p2mr-duplicate")
+        funded_p2mr = wallet.sendtop2mr(tree, Decimal("0.25"), "sender-owned-p2mr", allow_trivial_leaves=True)
+        duplicate = wallet.getnewp2mraddress(tree, "sender-owned-p2mr-duplicate", True)
         assert_equal(funded_p2mr["address"], duplicate["address"])
         assert_equal(funded_p2mr["p2mr_id"], duplicate["p2mr_id"])
 


### PR DESCRIPTION
## Summary
- `CreateP2MR` / `FundP2MR` reject empty and OP_TRUE leaves by default. `script: "51"` is consensus-valid and anyone-can-spend; RPC help used to teach that tree.
- Tests and explicit anyone-can-spend callers pass `allow_trivial_leaves`. `getnewp2mraddress` (param 2) and `sendtop2mr` (param 6) expose the same flag.
- `sendtop2mr` maps that reject to `RPC_WALLET_ERROR` (-4), not insufficient funds.

Closes the C001 / E003 items from the BTQ-Core final report.

## Test plan
- [ ] `src/test/test_btq -t p2mr_tests` (or the wallet unit binary that holds `create_rejects_trivial_leaves_by_default`)
- [ ] `test/functional/feature_p2mr_rpc.py --descriptors`
- [ ] `test/functional/wallet_bip360_send_paths.py`
- [ ] Default `sendtop2mr` with `script: "51"` returns -4
- [ ] Same call with `allow_trivial_leaves=true` still funds