### PR TITLE
policy: drop default mempool from 2 GB to 300 MB

### DIFF
--- a/src/kernel/mempool_options.h
+++ b/src/kernel/mempool_options.h
@@ -15,8 +15,13 @@
 
 class CBlockPolicyEstimator;
 
-/** Default for -maxmempool, maximum megabytes of mempool memory usage */
-static constexpr unsigned int DEFAULT_MAX_MEMPOOL_SIZE_MB{2000}; // 2 GB
+/** Default for -maxmempool, maximum megabytes of mempool memory usage.
+ *  300 is Bitcoin Core's default and a RAM-safe default for commodity nodes.
+ *  9c97fc7ab raised this to 2 GB so PQ-sized entries would not thrash the
+ *  rolling min-fee. That size is still available with -maxmempool=2000.
+ *  A smaller default does not skip verification (txs are checked before
+ *  TrimToSize); it only shortens retained backlog. */
+static constexpr unsigned int DEFAULT_MAX_MEMPOOL_SIZE_MB{300};
 /** Default for -maxmempool when blocksonly is set.
  *  AppInitMain requires maxmempool >= descendant_size_vbytes * 40. BTQ raised
  *  DEFAULT_DESCENDANT_SIZE_LIMIT_KVB with MAX_BLOCK_WEIGHT, so that floor is

--- a/src/test/mempool_args_tests.cpp
+++ b/src/test/mempool_args_tests.cpp
@@ -14,6 +14,7 @@
 //! compiled out and unrun on every machine this suite is likely to run on,
 //! which is the same shape of untested guard the cap exists to replace.
 
+#include <kernel/mempool_options.h>
 #include <node/mempool_args.h>
 
 #include <test/util/setup_common.h>
@@ -60,6 +61,13 @@ BOOST_AUTO_TEST_CASE(maxmempool_is_capped_on_32bit)
         BOOST_CHECK_MESSAGE(message.find("32-bit") != std::string::npos,
                             "error does not mention the architecture: " + message);
     }
+}
+
+BOOST_AUTO_TEST_CASE(unconfigured_mempool_default_is_300mb)
+{
+    kernel::MemPoolOptions opts;
+    BOOST_CHECK_EQUAL(DEFAULT_MAX_MEMPOOL_SIZE_MB, 300U);
+    BOOST_CHECK_EQUAL(opts.max_size_bytes, DEFAULT_MAX_MEMPOOL_SIZE_MB * 1'000'000);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary
- `DEFAULT_MAX_MEMPOOL_SIZE_MB` was 2000. With PQ-sized witnesses that is an OOM invitation on commodity hardware.
- Default is now 300 MB, same as Bitcoin Core. Operators who want a fat relay set `-maxmempool`.
- Blocksonly floor is unchanged.

Closes E001 from the BTQ-Core final report.

## Test plan
- [ ] Start a node with no `-maxmempool` and check `getmempoolinfo` `maxmempool` is 300000000
- [ ] `-maxmempool=2000` still works for operators who want the old size
- [ ] Blocksonly path still applies its own floor