### PR TITLE
consensus: keep DILITHIUM_SIGOP_COST=50 pending input benches

### DIFF
--- a/src/bench/dilithium_verify.cpp
+++ b/src/bench/dilithium_verify.cpp
@@ -21,20 +21,22 @@
 // Signature verification cost, Dilithium against ECDSA, measured on the same
 // hardware over the same input.
 //
-// This exists because two consensus constants encode a ratio between the two
-// that has never been measured. DILITHIUM_SIGOP_COST (src/script/script.h)
-// charges a Dilithium check 50 sigops, asserting that one Dilithium
-// verification costs about fifty ECDSA verifications. The reasoning recorded
-// when that was chosen cited a figure closer to 10. Both cannot be right, and
-// the constant bounds how many post-quantum signatures a block can carry:
-// MAX_BLOCK_SIGOPS_COST / WITNESS_SCALE_FACTOR legacy sigops, divided by
-// whatever a Dilithium op is charged.
+// This exists because DILITHIUM_SIGOP_COST (src/script/script.h) charges a
+// Dilithium check 50 sigops. 50 is a provisional launch value: over-weight
+// wastes a bit of block space, under-weight is CPU DoS. The primitive pair
+// below overstates the ratio because script/Merkle overhead is shared.
+//
+// Use the input-level pair (P2MRDilithiumInput / P2WPKHECDSAInput). Compute
+// required = ceil(ratio * 1.5). Keep 50 iff required <= 50; otherwise propose
+// `required` with a testnet reset. The bench is one-input VerifyScript, not
+// UTXO lookup or block-level scheduling.
 //
 // Run both and divide the reported ns/op:
 //
 //     ./src/bench/bench_btq -filter='(Dilithium|ECDSA)Verify'
+//     ./src/bench/bench_btq -filter='(P2MRDilithium|P2WPKHECDSA)Input'
 //
-// The ratio is what DILITHIUM_SIGOP_COST should approximate. Verification is
+// The input-level ratio is what DILITHIUM_SIGOP_COST should approximate. Verification is
 // the operation to measure rather than signing, because validation cost is what
 // the sigop budget exists to bound -- every node verifies every signature in
 // every block, while signing happens once on the spending wallet.

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -65,6 +65,16 @@ static constexpr int64_t VALIDATION_WEIGHT_PER_SIGOP_PASSED{50};
 
 // Validation weight per passing Dilithium signature (P2MR tapscript only).
 static constexpr int64_t VALIDATION_WEIGHT_PER_DILITHIUM_SIGOP_PASSED{500};
+// Dilithium is charged 50 sigops against MAX_BLOCK_SIGOPS_COST (80000).
+// 50 is provisional until the input-level ratio is recorded. Measure with
+//   ./src/bench/bench_btq -filter='(P2MRDilithium|P2WPKHECDSA)Input'
+// Compute required = ceil(ratio * 1.5). Keep 50 iff required <= 50; otherwise
+// propose `required` with a testnet reset. Do not lower 50 without a written
+// DoS argument: under-weighting packs more PQ verifies per block.
+//
+// The constant already binds: 80000/50 = 1600 Dilithium inputs per block vs
+// ~1817 by weight at ~4402 WU for a 1-in P2MR input. The bench is one-input
+// VerifyScript (script, P2MR control, sighash, verify), not full block cost.
 static constexpr unsigned int DILITHIUM_SIGOP_COST = 50;
 
 // How much weight budget is added to the witness size (Tapscript only, see BIP 342).


### PR DESCRIPTION
## Summary
- `DILITHIUM_SIGOP_COST` stays 50. Changing it forks live testnet, and 50 already over-weights Dilithium if the real ratio is closer to 10.
- `src/script/script.h` and `src/bench/dilithium_verify.cpp` now say how to decide later: run `./src/bench/bench_btq -filter='(P2MRDilithium|P2WPKHECDSA)Input'` and take `ceil(ratio * 1.5)`.
- Keep 50 if that number is <= 50. Raise only if the input-level ratio is well above 50, and pair a raise with a testnet reset. Do not lower 50 without a written DoS argument.

This documents B001 rather than forking the constant. A real constant change is a companion to #144.

## Test plan
- [ ] Read the new comments in `src/script/script.h` and the bench file
- [ ] On release hardware, run `./src/bench/bench_btq -filter='(P2MRDilithium|P2WPKHECDSA)Input'` and record ns/op
- [ ] If `ceil(ratio * 1.5) > 50`, open a follow-up that raises the constant with a testnet reset