### PR TITLE
policy: default full replace-by-fee on

### DIFF
--- a/doc/man/btq-qt.1
+++ b/doc/man/btq-qt.1
@@ -674,7 +674,7 @@ this size or less (default: 83)
 \fB\-mempoolfullrbf\fR
 .IP
 Accept transaction replace\-by\-fee without requiring replaceability
-signaling (default: 0)
+signaling (default: 1)
 .HP
 \fB\-minrelaytxfee=\fR<amt>
 .IP

--- a/doc/man/btqd.1
+++ b/doc/man/btqd.1
@@ -674,7 +674,7 @@ this size or less (default: 83)
 \fB\-mempoolfullrbf\fR
 .IP
 Accept transaction replace\-by\-fee without requiring replaceability
-signaling (default: 0)
+signaling (default: 1)
 .HP
 \fB\-minrelaytxfee=\fR<amt>
 .IP

--- a/doc/policy/mempool-replacements.md
+++ b/doc/policy/mempool-replacements.md
@@ -10,13 +10,13 @@ A transaction ("replacement transaction") may replace its directly conflicting t
 their in-mempool descendants (together, "original transactions") if, in addition to passing all
 other consensus and policy rules, each of the following conditions are met:
 
-1. The directly conflicting transactions all signal replaceability explicitly. A transaction is
-   signaling replaceability if any of its inputs have an nSequence number less than (0xffffffff - 1).
+1. The directly conflicting transactions all signal replaceability explicitly, unless
+   `-mempoolfullrbf` is enabled (the default). A transaction is signaling replaceability if any
+   of its inputs have an nSequence number less than (0xffffffff - 1).
 
    *Rationale*: See [BIP125
    explanation](https://github.com/btq/bips/blob/master/bip-0125.mediawiki#motivation).
-   Use the (`-mempoolfullrbf`) configuration option to allow transaction replacement without enforcement of the
-   opt-in signaling rule.
+   `-mempoolfullrbf=0` restores the opt-in signaling rule.
 
 2. The replacement transaction only include an unconfirmed input if that input was included in
    one of the directly conflicting transactions. An unconfirmed input spends an output from a

--- a/share/examples/btq.conf
+++ b/share/examples/btq.conf
@@ -566,7 +566,7 @@
 #datacarriersize=1
 
 # Accept transaction replace-by-fee without requiring replaceability
-# signaling (default: 0)
+# signaling (default: 1)
 #mempoolfullrbf=1
 
 # Fees (in BTQ/kvB) smaller than this are considered zero fee for

--- a/src/kernel/mempool_options.h
+++ b/src/kernel/mempool_options.h
@@ -27,7 +27,7 @@ static_assert(DEFAULT_BLOCKSONLY_MAX_MEMPOOL_SIZE_MB >= 80);
 /** Default for -mempoolexpiry, expiration time for mempool transactions in hours */
 static constexpr unsigned int DEFAULT_MEMPOOL_EXPIRY_HOURS{336};
 /** Default for -mempoolfullrbf, if the transaction replaceability signaling is ignored */
-static constexpr bool DEFAULT_MEMPOOL_FULL_RBF{false};
+static constexpr bool DEFAULT_MEMPOOL_FULL_RBF{true};
 /** Default for -acceptnonstdtxn */
 static constexpr bool DEFAULT_ACCEPT_NON_STD_TXN{false};
 

--- a/src/test/mempool_args_tests.cpp
+++ b/src/test/mempool_args_tests.cpp
@@ -14,6 +14,7 @@
 //! compiled out and unrun on every machine this suite is likely to run on,
 //! which is the same shape of untested guard the cap exists to replace.
 
+#include <kernel/mempool_options.h>
 #include <node/mempool_args.h>
 
 #include <test/util/setup_common.h>
@@ -60,6 +61,13 @@ BOOST_AUTO_TEST_CASE(maxmempool_is_capped_on_32bit)
         BOOST_CHECK_MESSAGE(message.find("32-bit") != std::string::npos,
                             "error does not mention the architecture: " + message);
     }
+}
+
+BOOST_AUTO_TEST_CASE(full_rbf_is_on_when_unset)
+{
+    kernel::MemPoolOptions opts;
+    BOOST_CHECK(DEFAULT_MEMPOOL_FULL_RBF);
+    BOOST_CHECK(opts.full_rbf);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/functional/feature_rbf.py
+++ b/test/functional/feature_rbf.py
@@ -33,9 +33,11 @@ class ReplaceByFeeTest(BTQTestFramework):
                 "-limitancestorsize=101",
                 "-limitdescendantcount=200",
                 "-limitdescendantsize=101",
+                "-mempoolfullrbf=0",
             ],
-            # second node has default mempool parameters
+            # second node keeps opt-in RBF so the signaling tests stay meaningful
             [
+                "-mempoolfullrbf=0",
             ],
         ]
         self.supports_cli = False
@@ -702,7 +704,7 @@ class ReplaceByFeeTest(BTQTestFramework):
     def test_fullrbf(self):
 
         confirmed_utxo = self.make_utxo(self.nodes[0], int(2 * COIN))
-        self.restart_node(0, extra_args=["-mempoolfullrbf=1"])
+        self.restart_node(0, extra_args=[])
         assert self.nodes[0].getmempoolinfo()["fullrbf"]
 
         # Create an explicitly opt-out transaction

--- a/test/functional/mempool_accept.py
+++ b/test/functional/mempool_accept.py
@@ -50,7 +50,7 @@ class MempoolAcceptanceTest(BTQTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
         self.extra_args = [[
-            '-txindex','-permitbaremultisig=0',
+            '-txindex','-permitbaremultisig=0','-mempoolfullrbf=0',
         ]] * self.num_nodes
         self.supports_cli = False
 

--- a/test/functional/p2p_permissions.py
+++ b/test/functional/p2p_permissions.py
@@ -9,7 +9,9 @@ Test that permissions are correctly calculated and applied
 
 from test_framework.messages import (
     SEQUENCE_FINAL,
+    CTxOut,
 )
+from test_framework.script import CScript, OP_TRUE
 from test_framework.p2p import P2PDataStore
 from test_framework.test_node import ErrorMatch
 from test_framework.test_framework import BTQTestFramework
@@ -111,15 +113,15 @@ class P2PPermissionsTests(BTQTestFramework):
             self.wait_until(lambda: txid in self.nodes[0].getrawmempool())
 
         self.log.debug("Check that node[1] will not send an invalid tx to node[0]")
-        tx.vout[0].nValue += 1
+        tx.vout.append(CTxOut(nValue=0, scriptPubKey=CScript([OP_TRUE])))
         txid = tx.rehash()
-        # Send the transaction twice. The first time, it'll be rejected by ATMP because it conflicts
-        # with a mempool transaction. The second time, it'll be in the m_recent_rejects filter.
+        # Dust is invalid independent of RBF signaling. The first send is
+        # rejected by ATMP; the second hits m_recent_rejects.
         p2p_rebroadcast_wallet.send_txs_and_test(
             [tx],
             self.nodes[1],
             success=False,
-            reject_reason='{} (wtxid={}) from peer=0 was not accepted: txn-mempool-conflict'.format(txid, tx.getwtxid())
+            reject_reason='{} (wtxid={}) from peer=0 was not accepted: dust'.format(txid, tx.getwtxid())
         )
 
         p2p_rebroadcast_wallet.send_txs_and_test(

--- a/test/functional/p2p_permissions.py
+++ b/test/functional/p2p_permissions.py
@@ -11,8 +11,8 @@ from test_framework.messages import (
     SEQUENCE_FINAL,
     CTxOut,
 )
-from test_framework.script import CScript, OP_TRUE
 from test_framework.p2p import P2PDataStore
+from test_framework.script_util import key_to_p2wpkh_script
 from test_framework.test_node import ErrorMatch
 from test_framework.test_framework import BTQTestFramework
 from test_framework.util import (
@@ -113,7 +113,7 @@ class P2PPermissionsTests(BTQTestFramework):
             self.wait_until(lambda: txid in self.nodes[0].getrawmempool())
 
         self.log.debug("Check that node[1] will not send an invalid tx to node[0]")
-        tx.vout.append(CTxOut(nValue=0, scriptPubKey=CScript([OP_TRUE])))
+        tx.vout.append(CTxOut(nValue=0, scriptPubKey=key_to_p2wpkh_script(bytes(33))))
         txid = tx.rehash()
         # Dust is invalid independent of RBF signaling. The first send is
         # rejected by ATMP; the second hits m_recent_rejects.


### PR DESCRIPTION
## Summary
- `DEFAULT_MEMPOOL_FULL_RBF` is now true (Bitcoin Core 28.0 #30493).
- `-mempoolfullrbf=0` still restores BIP125 opt-in signaling.
- `feature_rbf.py` pins `-mempoolfullrbf=0` so the signaling tests stay meaningful. `test_fullrbf` still turns it on.

## Test plan
- [ ] `feature_rbf.py`
- [ ] `getmempoolinfo` shows `"fullrbf": true` on a default node
- [ ] A replacement with `SEQUENCE_FINAL` is accepted at default settings