### PR TITLE
validation: keep dbcache warm on prune and periodic flush

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2683,7 +2683,10 @@ bool Chainstate::FlushStateToDisk(
                 return FatalError(m_chainman.GetNotifications(), state, "Disk space is too low!", _("Disk space is too low!"));
             }
             // Flush the chainstate (which may refer to block index entries).
-            if (!CoinsTip().Flush())
+            // Prune and periodic writes Sync() so the dbcache stays warm.
+            // ALWAYS / cache-pressure still Flush() and wipe the cache.
+            const bool empty_cache{(mode == FlushStateMode::ALWAYS) || fCacheLarge || fCacheCritical};
+            if (empty_cache ? !CoinsTip().Flush() : !CoinsTip().Sync())
                 return FatalError(m_chainman.GetNotifications(), state, "Failed to write to coin database");
             m_last_flush = nNow;
             full_flush_completed = true;


### PR DESCRIPTION
## Summary
- Bitcoin Core 28.0 #28280: prune (and periodic) chainstate writes no longer empty `dbcache`.
- `CCoinsViewCache::Sync()` was already in this tree. `FlushStateToDisk` now uses it unless the mode is ALWAYS or the cache is large/critical.
- Fat-block IBD is the reason. Emptying the cache on every prune pass is the expensive part.

## Test plan
- [ ] `src/test/test_btq --run_test=coins_tests`
- [ ] Start a pruned regtest IBD and confirm coins flushes during prune do not drop `gettxoutsetinfo` cache warmth (log: prune writes without a full cache wipe)
- [ ] Crash-recovery: kill during pruned IBD, restart, chainstate still loads