### PR TITLE
p2p: raise compact-block extra-txn pool to 2000

### DIFF
--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -20,7 +20,10 @@ static constexpr bool DEFAULT_TXRECONCILIATION_ENABLE{false};
 static const uint32_t DEFAULT_MAX_ORPHAN_TRANSACTIONS{100};
 /** Default number of non-mempool transactions to keep around for block reconstruction. Includes
     orphan, replaced, and rejected transactions. */
-static const uint32_t DEFAULT_BLOCK_RECONSTRUCTION_EXTRA_TXN{100};
+// 100 is a Bitcoin-era leftover. An 8 MB Dilithium block is hundreds to
+// low-thousands of txs; keep enough extras that compact-block rebuild
+// does not fall back to a full download. Measure before raising again.
+static const uint32_t DEFAULT_BLOCK_RECONSTRUCTION_EXTRA_TXN{2000};
 static const bool DEFAULT_PEERBLOOMFILTERS = false;
 static const bool DEFAULT_PEERBLOCKFILTERS = false;
 /** Threshold for marking a node to be discouraged, e.g. disconnected and added to the discouragement filter. */


### PR DESCRIPTION
## Summary
- `DEFAULT_BLOCK_RECONSTRUCTION_EXTRA_TXN` 100 → 2000.
- Compact-block reconstruction still uses the same extra pool (orphans, replacements, rejected txs). This only changes how many we keep.
- An 8 MB Dilithium block is hundreds to low-thousands of txs. 100 is how you fall back to a full download.

## Test plan
- [ ] `p2p_compactblocks.py`
- [ ] Mine a near-full Dilithium block on two nodes that already have the mempool. Confirm rebuild without `getblocktxn` for txs already seen.
- [ ] `-blockreconstructionextratxn=100` still starts